### PR TITLE
Fix tailscale discovery on macOS App Store version

### DIFF
--- a/serve.ts
+++ b/serve.ts
@@ -519,7 +519,12 @@ const routes: Record<
     if (!tsBin) return json(res, { peers: [], error: "tailscale not found" });
 
     try {
-      const { stdout } = await exec(tsBin, ["status", "--json"], { maxBuffer: 10 * 1024 * 1024 });
+      // Use login shell so macOS Tailscale GUI CLI gets the Aqua session context
+      // (direct execFile fails from launchd services — no Mach bootstrap namespace)
+      const { stdout } = await exec(
+        "/bin/sh", ["-l", "-c", `"${tsBin}" status --json`],
+        { maxBuffer: 10 * 1024 * 1024 },
+      );
       const status = JSON.parse(stdout);
       const self = status.Self?.DNSName?.replace(/\.$/, "");
       const peers: { hostname: string; url: string }[] = [];


### PR DESCRIPTION
The macOS App Store Tailscale CLI uses Mach IPC to communicate with its system extension. When wolfpack runs as a launchd service, the process inherits a different Mach bootstrap namespace that lacks the Tailscale GUI's service endpoint, causing `tailscale status --json` to fail with "The Tailscale GUI failed to start".

Wrapping the call in a login shell (`/bin/sh -l -c`) re-establishes the Aqua session context. Harmless on systems using the homebrew CLI.