### PR TITLE
Fix session switcher showing wrong session in header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1127,6 +1127,8 @@
           if (data.session) {
             currentSession = data.session;
             currentMachine = machine;
+            // Refresh session list so switcher has the new session
+            await loadSessions();
             loadSessionSwitcher();
             resizePane();
             startPolling();
@@ -1291,6 +1293,8 @@
           }
         }
         sel.innerHTML = opts;
+        // Set value programmatically — webkit ignores selected attr via innerHTML
+        sel.value = currentMachine ? currentMachine + "|" + currentSession : currentSession;
       }
 
       function switchSession(val) {


### PR DESCRIPTION
Refresh session list after creating new session so the switcher dropdown has the new entry. Set select value programmatically since webkit ignores the selected attr set via innerHTML.