### PR TITLE
fix: show tailscale serve hint on all platforms

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -376,9 +376,7 @@ async function setup() {
             "  Failed to configure tailscale serve. You can do it manually later.",
           ),
         );
-        if (IS_LINUX) {
-          print(dim(`  Try: sudo tailscale serve --bg ${port}`));
-        }
+        print(dim(`  Try: ${sudoPrefix}tailscale serve --bg ${port}`));
       }
     }
   }


### PR DESCRIPTION
## Summary
- Shows the manual `tailscale serve --bg <port>` hint on macOS too, not just Linux
- Previously the error message said "do it manually later" without telling macOS users what command to run

## Test plan
- [ ] Trigger the error path on macOS (e.g. tailscale serve fails) and verify hint prints