### PR TITLE
Desktop terminal WS reconnect + task granularity

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -777,22 +777,6 @@
         user-select: text;
         -webkit-user-select: text;
       }
-      .dt-cursor {
-        position: relative;
-      }
-      .dt-cursor::after {
-        content: '\00a0';
-        position: absolute;
-        left: 0;
-        top: 0;
-        background: #e0e0e0;
-        color: #0a0a0a;
-        pointer-events: none;
-        animation: dt-blink 1s step-end infinite;
-      }
-      @keyframes dt-blink {
-        50% { opacity: 0; }
-      }
     </style>
     <script src="/ansi_up.min.js"></script>
   </head>
@@ -1768,7 +1752,7 @@
 
       let desktopReconnectTimer = null;
       let desktopReconnectDelay = 1000;
-      let desktopLastCursor = null;
+
 
       function connectDesktopWs(pre, ansi) {
         if (desktopReconnectTimer) { clearTimeout(desktopReconnectTimer); desktopReconnectTimer = null; }
@@ -1792,12 +1776,11 @@
             const msg = JSON.parse(ev.data);
             if (msg.type === "output") {
               desktopRawAnsi = msg.data;
-              desktopLastCursor = msg.cursor || null;
               const wasAtBottom = pre.scrollHeight - pre.scrollTop - pre.clientHeight < 40;
               if (searchActive && searchTerm) {
                 applySearchHighlights();
               } else {
-                renderDesktopOutput(pre, ansi, msg.data, msg.cursor);
+                pre.innerHTML = ansi.ansi_to_html(msg.data);
               }
               if (wasAtBottom) pre.scrollTop = pre.scrollHeight;
             }
@@ -1824,49 +1807,6 @@
           }
         }, desktopReconnectDelay);
         desktopReconnectDelay = Math.min(desktopReconnectDelay * 2, 5000);
-      }
-
-      function renderDesktopOutput(pre, ansi, data, cursor) {
-        let html = ansi.ansi_to_html(data);
-        if (cursor && typeof cursor.x === "number" && typeof cursor.y === "number") {
-          html = injectCursor(html, cursor.x, cursor.y);
-        }
-        pre.innerHTML = html;
-      }
-
-      function injectCursor(html, cx, cy) {
-        const lines = html.split("\n");
-        if (cy < 0 || cy >= lines.length) return html;
-        const line = lines[cy];
-        // Walk the line counting only visible text chars (skip HTML tags)
-        let textPos = 0;
-        let insertIdx = -1;
-        let inTag = false;
-        for (let i = 0; i < line.length; i++) {
-          if (line[i] === "<") { inTag = true; continue; }
-          if (line[i] === ">") { inTag = false; continue; }
-          if (inTag) continue;
-          // Handle HTML entities as single chars
-          if (line[i] === "&") {
-            const semi = line.indexOf(";", i);
-            if (semi !== -1 && semi - i < 10) {
-              if (textPos === cx) { insertIdx = i; break; }
-              textPos++;
-              i = semi;
-              continue;
-            }
-          }
-          if (textPos === cx) { insertIdx = i; break; }
-          textPos++;
-        }
-        const cursorSpan = '<span class="dt-cursor"></span>';
-        if (insertIdx === -1) {
-          // cursor beyond line end — append
-          lines[cy] = line + cursorSpan;
-        } else {
-          lines[cy] = line.slice(0, insertIdx) + cursorSpan + line.slice(insertIdx);
-        }
-        return lines.join("\n");
       }
 
       function initDesktopTerminal() {

--- a/ralph-macchio.ts
+++ b/ralph-macchio.ts
@@ -230,7 +230,7 @@ OUTPUT (always include):
 RULES:
 - ONLY work on ONE task per iteration.
 - If a task has sub-tasks, complete one sub-task.
-- If you decide the task needs breakdown, output a <subtasks> block with one task per line, and DO NOT modify any files or make a commit in that iteration.
+- If you decide the task needs breakdown, output a <subtasks> block with one task per line, and DO NOT modify any files or make a commit in that iteration. Follow the Task Granularity rules from the context above.
 - Be thorough but focused.
 
 BEGIN.`;

--- a/serve.ts
+++ b/serve.ts
@@ -1098,14 +1098,13 @@ function handleTerminalWs(ws: WebSocket, session: string): void {
     try {
       const pane = await capturePaneAnsi(session);
       const msg: Record<string, unknown> = { type: "output", data: pane };
-      // Query cursor position (best-effort — some sessions may not report it)
-      // cursor_y is relative to visible pane, so offset by scrollback lines
+      // Query cursor position — only for plain shells (TUI programs draw their own)
       let cursorKey = "";
       try {
-        const { stdout } = await exec(TMUX, ["display-message", "-t", session, "-p", "#{cursor_x},#{cursor_y},#{pane_height},#{alternate_on}"]);
-        const parts = stdout.trim().split(",");
-        if (parts.length === 4 && parts[3] !== "1") {
-          // Skip cursor when alternate screen is active (TUI programs manage their own)
+        const SHELLS = new Set(["bash", "zsh", "sh", "fish", "dash", "ksh", "tcsh", "csh"]);
+        const { stdout } = await exec(TMUX, ["display-message", "-t", session, "-p", "#{cursor_x}|#{cursor_y}|#{pane_height}|#{pane_current_command}"]);
+        const parts = stdout.trim().split("|");
+        if (parts.length >= 4 && SHELLS.has(parts[3])) {
           const x = Number(parts[0]);
           const rawY = Number(parts[1]);
           const paneHeight = Number(parts[2]);

--- a/serve.ts
+++ b/serve.ts
@@ -1102,9 +1102,10 @@ function handleTerminalWs(ws: WebSocket, session: string): void {
       // cursor_y is relative to visible pane, so offset by scrollback lines
       let cursorKey = "";
       try {
-        const { stdout } = await exec(TMUX, ["display-message", "-t", session, "-p", "#{cursor_x},#{cursor_y},#{pane_height}"]);
+        const { stdout } = await exec(TMUX, ["display-message", "-t", session, "-p", "#{cursor_x},#{cursor_y},#{pane_height},#{alternate_on}"]);
         const parts = stdout.trim().split(",");
-        if (parts.length === 3) {
+        if (parts.length === 4 && parts[3] !== "1") {
+          // Skip cursor when alternate screen is active (TUI programs manage their own)
           const x = Number(parts[0]);
           const rawY = Number(parts[1]);
           const paneHeight = Number(parts[2]);

--- a/serve.ts
+++ b/serve.ts
@@ -1086,7 +1086,6 @@ async function capturePaneAnsi(session: string): Promise<string> {
 
 function handleTerminalWs(ws: WebSocket, session: string): void {
   let prev = "";
-  let prevCursor = "";
   let alive = true;
   let sized = false;
   let pollTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1097,30 +1096,9 @@ function handleTerminalWs(ws: WebSocket, session: string): void {
     updating = true;
     try {
       const pane = await capturePaneAnsi(session);
-      const msg: Record<string, unknown> = { type: "output", data: pane };
-      // Query cursor position — only for plain shells (TUI programs draw their own)
-      let cursorKey = "";
-      try {
-        const SHELLS = new Set(["bash", "zsh", "sh", "fish", "dash", "ksh", "tcsh", "csh"]);
-        const { stdout } = await exec(TMUX, ["display-message", "-t", session, "-p", "#{cursor_x}|#{cursor_y}|#{pane_height}|#{pane_current_command}"]);
-        const parts = stdout.trim().split("|");
-        if (parts.length >= 4 && SHELLS.has(parts[3])) {
-          const x = Number(parts[0]);
-          const rawY = Number(parts[1]);
-          const paneHeight = Number(parts[2]);
-          if (Number.isFinite(x) && Number.isFinite(rawY) && Number.isFinite(paneHeight)) {
-            const totalLines = pane.split("\n").length;
-            const y = totalLines - paneHeight + rawY;
-            msg.cursor = { x, y };
-            cursorKey = `${x},${y}`;
-          }
-        }
-      } catch {}
-      // Send if pane content or cursor position changed
-      if (pane !== prev || cursorKey !== prevCursor) {
+      if (pane !== prev) {
         prev = pane;
-        prevCursor = cursorKey;
-        ws.send(JSON.stringify(msg));
+        ws.send(JSON.stringify({ type: "output", data: pane }));
       }
     } catch {}
     updating = false;

--- a/wolfpack-context.ts
+++ b/wolfpack-context.ts
@@ -19,6 +19,10 @@ Task sections MUST use this exact header format:
 
 Do NOT use other header styles like \`## Phase 1:\`, \`## Step 1 -\`, \`### Task: Foo\`, etc. The automated task extractor only recognizes the \`## N. Title\` pattern.
 
+### Task Granularity (CRITICAL)
+
+Each task should be a meaningful deliverable — a unit of work a senior dev would recognize, NOT individual lines of code, imports, or type fields. Aim for 3-5 tasks per feature/phase. If a task can be described in fewer than 10 words of code, it's too granular — combine it with related work. Bad: "Add agent_pubkey field to interface". Good: "Add per-agent policy scoping to types and evaluation logic". When breaking tasks into subtasks, the same rule applies: 3-5 subtasks max, each a coherent unit touching multiple lines/files. Never produce line-by-line checkbox plans.
+
 ### Progress File
 
 Append-only log file (default: progress.txt). Each iteration appends what was done. Never overwrite previous entries.


### PR DESCRIPTION
## Summary
- **WS reconnect**: desktop terminal now auto-reconnects on tab switch / connection drop (exponential backoff 1s→5s, immediate on visibilitychange)
- **Cursor reverted**: attempted cursor rendering via tmux cursor_x/cursor_y — unreliable for TUI programs (claude CLI parks cursor at bottom-left). All cursor code removed.
- **Task granularity**: added guidance to wolfpack context so ralph-spawned agents produce 3-5 tasks per feature instead of 50+ line-by-line checkboxes. ralph buildPrompt references context instead of duplicating.

## Test plan
- [ ] `bun test` passes (410/410)
- [ ] Open desktop terminal, switch tabs for 30s, switch back → terminal resumes
- [ ] Run ralph on a plan — verify subtask breakdowns stay at 3-5 items