### PR TITLE
chore: bump version to 1.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wolfpack-bridge",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "type": "module",
   "description": "Mobile command center for tmux-based AI agent sessions",
   "bin": {
@@ -15,10 +15,10 @@
     "postinstall": "node bin/install.cjs"
   },
   "optionalDependencies": {
-    "wolfpack-bridge-darwin-arm64": "1.4.4",
-    "wolfpack-bridge-darwin-x64": "1.4.4",
-    "wolfpack-bridge-linux-arm64": "1.4.4",
-    "wolfpack-bridge-linux-x64": "1.4.4"
+    "wolfpack-bridge-darwin-arm64": "1.4.5",
+    "wolfpack-bridge-darwin-x64": "1.4.5",
+    "wolfpack-bridge-linux-arm64": "1.4.5",
+    "wolfpack-bridge-linux-x64": "1.4.5"
   },
   "keywords": [
     "tmux",


### PR DESCRIPTION
Bump version to 1.4.5 across package.json and optionalDependencies. Tag after merge.