### PR TITLE
ci: add npm publish to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,9 @@ jobs:
             dist/wolfpack-darwin-x64
             dist/wolfpack-darwin-arm64
             dist/checksums-sha256.txt
+
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Publish to npm
+        run: bun run scripts/publish.ts


### PR DESCRIPTION
## Summary
- Adds npm auth + `bun run scripts/publish.ts` steps after the GitHub Release step in the release workflow
- `scripts/publish.ts` already handles publishing all 4 platform packages + the main `wolfpack-bridge` package

## Prerequisite
- `NPM_TOKEN` must be added as a GitHub repo secret

## Test plan
- [ ] Add `NPM_TOKEN` secret to repo settings
- [ ] Push a tag → verify workflow runs npm publish after release creation
- [ ] `bunx wolfpack-bridge` resolves to new version