### PR TITLE
feat: custom session naming in agent picker

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -277,6 +277,65 @@
         .card-preview { -webkit-line-clamp: 1; }
         .dot { width: 7px; height: 7px; }
       }
+
+      /* ── Session name field ── */
+      .session-name-block {
+        padding: 10px 6px 14px;
+        border-bottom: 1px solid #1a1a1a;
+        margin-bottom: 6px;
+      }
+      .session-name-label {
+        font-size: 9px;
+        color: #555;
+        text-transform: uppercase;
+        letter-spacing: 2.5px;
+        margin-bottom: 6px;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .session-name-label::before {
+        content: '>';
+        color: #00ff41;
+        text-shadow: 0 0 6px rgba(0,255,65,0.4);
+        font-size: 10px;
+      }
+      .session-name-input {
+        width: 100%;
+        background: #0e0e0e;
+        border: 1px solid #222;
+        border-radius: 4px;
+        padding: 9px 10px;
+        color: #00ff41;
+        font-family: 'JetBrains Mono', 'Fira Code', monospace;
+        font-size: 13px;
+        letter-spacing: 0.8px;
+        outline: none;
+        caret-color: #00ff41;
+        text-shadow: 0 0 4px rgba(0,255,65,0.15);
+        transition: border-color 0.2s, box-shadow 0.2s;
+      }
+      .session-name-input::placeholder { color: #2a2a2a; }
+      .session-name-input:focus {
+        border-color: rgba(0,255,65,0.4);
+        box-shadow: 0 0 8px rgba(0,255,65,0.08), inset 0 0 12px rgba(0,255,65,0.03);
+      }
+      .session-name-input.invalid {
+        border-color: rgba(255,60,60,0.5);
+        box-shadow: 0 0 8px rgba(255,60,60,0.08);
+        color: #ff4444;
+        text-shadow: 0 0 4px rgba(255,60,60,0.15);
+      }
+      .session-name-error {
+        font-size: 9px;
+        color: #ff4444;
+        letter-spacing: 1px;
+        margin-top: 4px;
+        text-transform: uppercase;
+        display: none;
+      }
+      .session-name-error.visible { display: block; }
+
       .new-btn {
         background: #1a1a1a;
         border: 1px solid rgba(0, 255, 65, 0.4);
@@ -2159,6 +2218,17 @@
           border-radius: 8px !important;
         }
 
+        /* ── Session name field in agent view ── */
+        .session-name-input {
+          padding: 12px 12px !important;
+          font-size: 14px !important;
+          border-radius: 8px !important;
+        }
+        .session-name-label {
+          font-size: 10px !important;
+          margin-bottom: 8px !important;
+        }
+
         /* ── Custom cmd input in agent view ── */
         #custom-cmd-input {
           padding: 10px 12px !important;
@@ -2325,6 +2395,13 @@
     <!-- Agent picker view -->
     <div id="agent-view" class="view">
       <button class="picker-cancel-btn" onclick="showView('projects')">← Back</button>
+      <div class="session-name-block">
+        <div class="session-name-label">session name</div>
+        <input type="text" class="session-name-input" id="session-name-input"
+          spellcheck="false" autocomplete="off" autocapitalize="off"
+          placeholder="session name...">
+        <div class="session-name-error" id="session-name-error"></div>
+      </div>
       <div id="agent-list" class="list"></div>
       <div style="padding:6px;display:flex;gap:6px">
         <input id="custom-cmd-input" type="text" placeholder="custom command…"
@@ -3969,8 +4046,17 @@
         showView("agent");
         const el = document.getElementById("agent-list");
         el.innerHTML = '<div class="empty">Loading...</div>';
+        const nameInput = document.getElementById("session-name-input");
+        const nameError = document.getElementById("session-name-error");
+        nameInput.value = "";
+        nameInput.classList.remove("invalid");
+        nameError.classList.remove("visible");
         try {
-          const data = await api("/settings", undefined, projectMachine);
+          const [data, nameData] = await Promise.all([
+            api("/settings", undefined, projectMachine),
+            api("/next-session-name?project=" + encodeURIComponent(selectedProject), undefined, projectMachine),
+          ]);
+          nameInput.value = nameData.name || selectedProject;
           const presets = Object.entries(data.presets || {});
           const customCmds = data.settings?.customCmds || [];
           let html = presets.map(([label, cmd]) => `
@@ -3991,6 +4077,24 @@
           el.innerHTML = '<div class="empty">Failed to load agents</div>';
         }
       }
+
+      // Session name input validation
+      (function() {
+        const input = document.getElementById("session-name-input");
+        const error = document.getElementById("session-name-error");
+        input.addEventListener("input", () => {
+          const val = input.value.trim();
+          if (val && !/^[a-zA-Z0-9_-]+$/.test(val)) {
+            input.classList.add("invalid");
+            error.textContent = "letters, numbers, hyphens, underscores only";
+            error.classList.add("visible");
+          } else {
+            input.classList.remove("invalid");
+            error.classList.remove("visible");
+          }
+        });
+        input.addEventListener("focus", () => input.select());
+      })();
 
       async function addCustomCmd() {
         const input = document.getElementById("custom-cmd-input");
@@ -4024,12 +4128,15 @@
       }
 
       async function createSessionWithAgent(cmd) {
+        const nameInput = document.getElementById("session-name-input");
+        const sessionName = (nameInput.value || "").trim();
+        if (sessionName && !/^[a-zA-Z0-9_-]+$/.test(sessionName)) return;
         const machine = projectMachine;
-        showTerminalLoading(selectedProject);
+        showTerminalLoading(sessionName || selectedProject);
         try {
           const body = isNewProject
-            ? { newProject: selectedProject, cmd }
-            : { project: selectedProject, cmd };
+            ? { newProject: selectedProject, cmd, sessionName: sessionName || undefined }
+            : { project: selectedProject, cmd, sessionName: sessionName || undefined };
           const data = await api("/create", {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -22,6 +22,7 @@ import { promisify } from "node:util";
 import {
   CMD_REGEX,
   isValidProjectName,
+  isValidSessionName,
   clampCols,
   clampRows,
 } from "../validation.js";
@@ -220,20 +221,41 @@ export const routes: Record<
     json(res, { projects });
   },
 
+  "GET /api/next-session-name": async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const project = url.searchParams.get("project");
+    if (!project || !isValidProjectName(project)) {
+      return json(res, { error: "invalid project" }, 400);
+    }
+    const name = await uniqueSessionName(project);
+    json(res, { name });
+  },
+
   "POST /api/create": async (req, res) => {
     const body = await parseBody<{
       project?: string;
       newProject?: string;
       cmd?: string;
+      sessionName?: string;
     }>(req, res);
     if (!body) return;
-    const { project, newProject, cmd } = body;
+    const { project, newProject, cmd, sessionName } = body;
     const folderName = newProject?.trim() || project?.trim();
     if (!folderName || !isValidProjectName(folderName)) {
       return json(res, { error: "invalid project name" }, 400);
     }
     if (cmd && cmd !== "shell" && !CMD_REGEX.test(cmd)) {
       return json(res, { error: "invalid characters in command" }, 400);
+    }
+    const customName = sessionName?.trim();
+    if (customName) {
+      if (!isValidSessionName(customName)) {
+        return json(res, { error: "invalid session name (letters, numbers, hyphens, underscores only)" }, 400);
+      }
+      const existing = await tmuxList();
+      if (existing.includes(customName)) {
+        return json(res, { error: "session name already taken" }, 409);
+      }
     }
     const projectDir = join(DEV_DIR, folderName);
     if (newProject) {
@@ -245,9 +267,9 @@ export const routes: Record<
     } catch {
       return json(res, { error: "project directory not found" }, 404);
     }
-    const sessionName = await uniqueSessionName(folderName);
-    await tmuxNewSession(sessionName, projectDir, cmd, loadSettings);
-    json(res, { ok: true, session: sessionName });
+    const finalName = customName || await uniqueSessionName(folderName);
+    await tmuxNewSession(finalName, projectDir, cmd, loadSettings);
+    json(res, { ok: true, session: finalName });
   },
 
   "GET /api/settings": async (_req, res) => {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -25,6 +25,10 @@ export function isValidProjectName(name: string): boolean {
   return /^[a-zA-Z0-9._-]+$/.test(name) && name !== "." && name !== "..";
 }
 
+export function isValidSessionName(name: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(name) && name.length > 0 && name.length <= 100;
+}
+
 export function isValidPlanFile(name: string): boolean {
   return PLAN_FILE_REGEX.test(name) && name !== ".." && name !== ".";
 }

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -63,6 +63,10 @@ function isValidProjectName(name: string): boolean {
   return /^[a-zA-Z0-9._-]+$/.test(name) && name !== "." && name !== "..";
 }
 
+function isValidSessionName(name: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(name) && name.length > 0 && name.length <= 100;
+}
+
 const ALLOWED_KEYS = [
   "Enter", "Tab", "Escape", "Up", "Down", "Left", "Right",
   "BTab", "y", "n", "C-c", "C-d", "C-z",
@@ -167,21 +171,42 @@ const routes: Record<
     json(res, { ok: true });
   },
 
+  "GET /api/next-session-name": async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const project = url.searchParams.get("project");
+    if (!project || !isValidProjectName(project)) {
+      return json(res, { error: "invalid project" }, 400);
+    }
+    const name = await uniqueSessionName(project);
+    json(res, { name });
+  },
+
   "POST /api/create": async (req, res) => {
     const body = await parseBody<{
       project?: string;
       newProject?: string;
       cmd?: string;
+      sessionName?: string;
     }>(req, res);
     if (!body) return;
-    const { project, newProject, cmd } = body;
+    const { project, newProject, cmd, sessionName } = body;
     const folderName = newProject?.trim() || project?.trim();
     if (!folderName || !isValidProjectName(folderName)) {
       return json(res, { error: "invalid project name" }, 400);
     }
-    const sessionName = await uniqueSessionName(folderName);
-    await tmuxNewSession(sessionName, `/tmp/dev/${folderName}`, cmd);
-    json(res, { ok: true, session: sessionName });
+    const customName = sessionName?.trim();
+    if (customName) {
+      if (!isValidSessionName(customName)) {
+        return json(res, { error: "invalid session name (letters, numbers, hyphens, underscores only)" }, 400);
+      }
+      const existing = await tmuxList();
+      if (existing.includes(customName)) {
+        return json(res, { error: "session name already taken" }, 409);
+      }
+    }
+    const finalName = customName || await uniqueSessionName(folderName);
+    await tmuxNewSession(finalName, `/tmp/dev/${folderName}`, cmd);
+    json(res, { ok: true, session: finalName });
   },
 
   "POST /api/key": async (req, res) => {
@@ -546,6 +571,68 @@ describe("POST /api/create", () => {
       "/tmp/dev/my-app",
       "claude",
     );
+  });
+
+  test("uses custom sessionName when provided", async () => {
+    tmuxNewSession.mockClear();
+    const res = await post("/api/create", {
+      project: "my-app",
+      sessionName: "auth-refactor",
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.session).toBe("auth-refactor");
+    expect(tmuxNewSession).toHaveBeenCalledWith(
+      "auth-refactor",
+      "/tmp/dev/my-app",
+      undefined,
+    );
+  });
+
+  test("rejects invalid session name characters", async () => {
+    const res = await post("/api/create", {
+      project: "my-app",
+      sessionName: "foo.bar",
+    });
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("invalid session name");
+  });
+
+  test("rejects taken session name with 409", async () => {
+    const res = await post("/api/create", {
+      project: "my-app",
+      sessionName: "wolf-1",
+    });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error).toBe("session name already taken");
+  });
+});
+
+describe("GET /api/next-session-name", () => {
+  test("returns project name when not taken", async () => {
+    const res = await fetch(`${base}/api/next-session-name?project=my-app`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.name).toBe("my-app");
+  });
+
+  test("returns suffixed name when taken", async () => {
+    const res = await fetch(`${base}/api/next-session-name?project=wolf-1`);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.name).toBe("wolf-1-2");
+  });
+
+  test("rejects invalid project name", async () => {
+    const res = await fetch(`${base}/api/next-session-name?project=../etc`);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects missing project param", async () => {
+    const res = await fetch(`${base}/api/next-session-name`);
+    expect(res.status).toBe(400);
   });
 });
 

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -19,6 +19,63 @@ function isValidPlanFile(name: string): boolean {
 /** Mirrors serve.ts BRANCH_REGEX (inline in ralph start handler) */
 const BRANCH_REGEX = /^[a-zA-Z0-9._\-/]+$/;
 
+/** Mirrors validation.ts isValidSessionName() — no dots or colons (tmux restriction) */
+function isValidSessionName(name: string): boolean {
+  return /^[a-zA-Z0-9_-]+$/.test(name) && name.length > 0 && name.length <= 100;
+}
+
+// ── isValidSessionName tests ──
+
+describe("isValidSessionName", () => {
+  test("accepts simple name", () => {
+    expect(isValidSessionName("my-session")).toBe(true);
+  });
+
+  test("accepts underscores", () => {
+    expect(isValidSessionName("my_session")).toBe(true);
+  });
+
+  test("accepts numbers", () => {
+    expect(isValidSessionName("wolfpack-2")).toBe(true);
+  });
+
+  test("accepts uppercase", () => {
+    expect(isValidSessionName("MySession")).toBe(true);
+  });
+
+  test("rejects dots (tmux restriction)", () => {
+    expect(isValidSessionName("foo.bar")).toBe(false);
+  });
+
+  test("rejects colons (tmux restriction)", () => {
+    expect(isValidSessionName("foo:bar")).toBe(false);
+  });
+
+  test("rejects spaces", () => {
+    expect(isValidSessionName("my session")).toBe(false);
+  });
+
+  test("rejects empty string", () => {
+    expect(isValidSessionName("")).toBe(false);
+  });
+
+  test("rejects slashes", () => {
+    expect(isValidSessionName("foo/bar")).toBe(false);
+  });
+
+  test("rejects shell injection", () => {
+    expect(isValidSessionName("foo;rm -rf /")).toBe(false);
+  });
+
+  test("rejects names over 100 chars", () => {
+    expect(isValidSessionName("a".repeat(101))).toBe(false);
+  });
+
+  test("accepts names at 100 chars", () => {
+    expect(isValidSessionName("a".repeat(100))).toBe(true);
+  });
+});
+
 // ── isValidProjectName tests ──
 
 describe("isValidProjectName", () => {


### PR DESCRIPTION
- GET /api/next-session-name?project=X returns suggested name
- POST /api/create accepts optional sessionName param (409 on conflict)
- Agent picker shows editable session name field pre-filled from API
- isValidSessionName: letters, numbers, hyphens, underscores (no dots/colons per tmux)
- 20 new tests covering validation, endpoint, and conflict handling