### PR TITLE
fix: always upgrade stable binary when newer version runs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -251,6 +251,25 @@ if $IS_MACOS; then
 fi
 
 echo "  $(green '✓') Binary installed to ${INSTALL_DIR}/${BINARY_NAME}"
+
+# ── Restart service if already installed (upgrade path) ──
+
+SERVICE_EXISTS=false
+if $IS_MACOS && [ -f "$HOME/Library/LaunchAgents/com.wolfpack.server.plist" ]; then
+  SERVICE_EXISTS=true
+elif $IS_LINUX && [ -f "$HOME/.config/systemd/user/wolfpack.service" ]; then
+  SERVICE_EXISTS=true
+fi
+
+if $SERVICE_EXISTS && [ -f "$HOME/.wolfpack/config.json" ]; then
+  echo "  Restarting service with new binary..."
+  if "${INSTALL_DIR}/${BINARY_NAME}" service install 2>/dev/null; then
+    echo "  $(green '✓') Service upgraded"
+  else
+    echo "  $(dim 'Service restart failed — run: wolfpack service install')"
+  fi
+fi
+
 echo ""
 
 # ── Add to PATH ──

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wolfpack-bridge",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "type": "module",
   "description": "Mobile command center for tmux-based AI agent sessions",
   "bin": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,7 @@ import {
   serviceStatus,
   isServiceInstalled,
   isServiceRunning,
+  updateStableBinary,
   uninstall,
 } from "./service.js";
 import { setup } from "./setup.js";
@@ -59,13 +60,19 @@ async function start() {
     return;
   }
 
-  // CLI invocation — ensure service is running
+  // CLI invocation — ensure service is running the current version
   const url = remoteUrl(config);
+  const binaryUpdated = updateStableBinary();
   const wasRunning = isServiceRunning();
   try {
-    const action = planServiceEnsureAction(wasRunning, isServiceInstalled());
-    if (action === "start") serviceStart();
-    else if (action === "install") serviceInstall();
+    if (binaryUpdated && wasRunning) {
+      // new binary on disk but old version still in memory — reinstall
+      serviceInstall();
+    } else {
+      const action = planServiceEnsureAction(wasRunning, isServiceInstalled());
+      if (action === "start") serviceStart();
+      else if (action === "install") serviceInstall();
+    }
   } catch (e) {
     print(red(`  Service startup failed: ${e}`));
     print(dim("  Run 'wolfpack service install' to retry."));

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -7,7 +7,9 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  readFileSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -62,6 +64,36 @@ function programArgs(): string[] {
     } catch {}
   }
   return [exe];
+}
+
+/**
+ * Copies the currently-running binary to ~/.wolfpack/bin/wolfpack if it
+ * differs from what's already there.  Returns true when the stable binary
+ * was actually replaced (i.e. an upgrade happened).
+ */
+export function updateStableBinary(): boolean {
+  const exe = process.execPath;
+  if (exe.endsWith("/bun") || exe.endsWith("/bun.exe")) return false;
+
+  const stableBin = join(WOLFPACK_DIR, "bin", "wolfpack");
+  if (exe === stableBin) return false;
+  if (!existsSync(exe)) return false;
+
+  try {
+    if (existsSync(stableBin)) {
+      const a = statSync(exe).size;
+      const b = statSync(stableBin).size;
+      if (a === b && readFileSync(exe).equals(readFileSync(stableBin))) {
+        return false;
+      }
+    }
+    mkdirSync(join(WOLFPACK_DIR, "bin"), { recursive: true });
+    copyFileSync(exe, stableBin);
+    chmodSync(stableBin, 0o755);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function renderPlist(config: Config | null, args: string[], logPath: string): string {


### PR DESCRIPTION
## Summary
- CLI now auto-copies itself to `~/.wolfpack/bin/wolfpack` when the running binary differs from the installed one, then restarts the service
- `install.sh` restarts an existing service after upgrading the binary
- Eliminates the manual `cp + codesign + launchctl kickstart` dance on upgrades

## Test plan
- [ ] Run `wolfpack` from a new binary — verify it copies itself to `~/.wolfpack/bin/wolfpack` and restarts the service
- [ ] Run `wolfpack` when binary is already current — verify no restart
- [ ] Run `install.sh` upgrade path — verify service gets restarted
- [ ] Run via `bun` in dev — verify `updateStableBinary` is a no-op