### PR TITLE
fix: guard against duplicate tmux sessions + legacy launchd upgrade

### DIFF
--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -180,7 +180,13 @@ const LAUNCHD_TARGET = `${LAUNCHD_DOMAIN}/${PLIST_LABEL}`;
 function launchdBootout() {
   try {
     execSync(`launchctl bootout ${LAUNCHD_TARGET} 2>/dev/null`);
-  } catch {}
+  } catch {
+    // fallback: pre-1.4 versions used deprecated `launchctl load`, which
+    // `bootout` can't always remove — try the legacy unload path
+    try {
+      execSync(`launchctl unload "${PLIST_PATH}" 2>/dev/null`);
+    } catch {}
+  }
 }
 
 function launchdBootstrap() {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -285,7 +285,14 @@ export const routes: Record<
     }
     if (!validateProjectDir(res, projectDir)) return;
     const finalName = customName || await uniqueSessionName(folderName);
-    await tmuxNewSession(finalName, projectDir, cmd, loadSettings);
+    try {
+      await tmuxNewSession(finalName, projectDir, cmd, loadSettings);
+    } catch (e: any) {
+      if (e.code === "DUPLICATE_SESSION") {
+        return json(res, { error: "session name already exists" }, 409);
+      }
+      throw e;
+    }
     json(res, { ok: true, session: finalName });
   },
 

--- a/src/server/tmux.ts
+++ b/src/server/tmux.ts
@@ -227,6 +227,17 @@ export async function tmuxNewSession(
   cmd: string | undefined,
   loadSettings: () => { agentCmd: string },
 ): Promise<void> {
+  // Guard: if a tmux session with this name already exists, bail with a clear error
+  try {
+    await exec(TMUX, ["has-session", "-t", name], { timeout: 2000 });
+    const err = new Error(`duplicate session: ${name}`);
+    (err as any).code = "DUPLICATE_SESSION";
+    throw err;
+  } catch (e: any) {
+    // has-session exits non-zero when session doesn't exist — that's the happy path
+    if (e.code === "DUPLICATE_SESSION") throw e;
+  }
+
   const agentCmd = cmd || loadSettings().agentCmd || "claude";
   if (agentCmd === "shell") {
     await exec(TMUX, ["new-session", "-d", "-s", name, "-c", cwd, SHELL]);

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -205,7 +205,14 @@ const routes: Record<
       }
     }
     const finalName = customName || await uniqueSessionName(folderName);
-    await tmuxNewSession(finalName, `/tmp/dev/${folderName}`, cmd);
+    try {
+      await tmuxNewSession(finalName, `/tmp/dev/${folderName}`, cmd);
+    } catch (e: any) {
+      if (e.code === "DUPLICATE_SESSION") {
+        return json(res, { error: "session name already exists" }, 409);
+      }
+      throw e;
+    }
     json(res, { ok: true, session: finalName });
   },
 
@@ -607,6 +614,16 @@ describe("POST /api/create", () => {
     expect(res.status).toBe(409);
     const data = await res.json();
     expect(data.error).toBe("session name already taken");
+  });
+
+  test("returns 409 when tmux reports duplicate session (race condition)", async () => {
+    const err = new Error("duplicate session: my-app");
+    (err as any).code = "DUPLICATE_SESSION";
+    tmuxNewSession.mockRejectedValueOnce(err);
+    const res = await post("/api/create", { project: "my-app" });
+    expect(res.status).toBe(409);
+    const data = await res.json();
+    expect(data.error).toBe("session name already exists");
   });
 });
 


### PR DESCRIPTION
## Summary
- `tmuxNewSession` now checks `tmux has-session` before creating — returns `DUPLICATE_SESSION` error instead of letting tmux fail with an opaque exit code 1
- `POST /api/create` catches duplicate and returns 409 instead of 500
- `launchdBootout` falls back to deprecated `launchctl unload` for users upgrading from pre-1.4 (which used `launchctl load`) — fixes bootstrap error 125

## Context
User upgrading from v1.2 → v1.5.7 hit two issues:
1. `launchctl bootstrap` failed (error 125) because old service was loaded via deprecated `load` and `bootout` couldn't remove it
2. Creating sessions with names matching existing tmux sessions returned 500 instead of 409

## Test plan
- [x] `bun test` — 729 pass, 0 fail
- [x] New regression test: mock `tmuxNewSession` throwing `DUPLICATE_SESSION` → verify 409 response