### PR TITLE
fix: kill stale mobile WS on foreground resume

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6412,8 +6412,16 @@
                 connectDesktopWs();
               }
             } else {
-              // Mobile: resume WS stream
-              startPolling(false);
+              // Mobile: kill stale WS and reconnect fresh.
+              // After backgrounding, the OS suspends the tab and the TCP connection
+              // dies silently — but the WS object may still report readyState=OPEN,
+              // blocking reconnection for 30-60s until the browser detects the dead socket.
+              if (state.mobileWs) {
+                const ws = state.mobileWs;
+                state.mobileWs = null;
+                try { ws.close(1000, "resume foreground"); } catch {}
+              }
+              startPolling(true);
             }
           }
         } else {


### PR DESCRIPTION
## Summary
- When backgrounding the mobile browser, the OS kills the TCP connection but the WS object still reports `readyState=OPEN`
- The `visibilitychange` handler called `startPolling(false)` which hit the early-exit guard in `connectMobileTerminalWs()`, leaving the terminal stale for 30-60s until the browser detected the dead socket
- Now explicitly closes the stale WS and calls `startPolling(true)` with a fresh reconnect budget for immediate reconnection

## Test plan
- [ ] Open wolfpack on mobile, navigate to a terminal session
- [ ] Background the browser for 30+ seconds (let the OS suspend the tab)
- [ ] Reopen the browser — terminal should refresh immediately instead of showing stale content
- [ ] Verify reconnect count increments in debug panel