### PR TITLE
fix: handle npm 403 already-published error + tmux mouse mode

### DIFF
--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -47,7 +47,7 @@ for (const pkg of PLATFORM_PACKAGES) {
     execSync(`npm publish ${publishArgs}`, { cwd: pkgDir, stdio: "inherit" });
   } catch (e: any) {
     const stderr = e.stderr?.toString() || "";
-    if (stderr.includes("EPUBLISHCONFLICT") || stderr.includes("cannot publish over")) {
+    if (stderr.includes("EPUBLISHCONFLICT") || stderr.includes("cannot publish over") || stderr.includes("previously published versions")) {
       console.log(`  already published, skipping`);
     } else {
       console.error(`  failed to publish ${pkg}`);


### PR DESCRIPTION
## Summary
- Fixes publish script crash when platform packages are already published at a version (npm returns 403, not the expected error string)
- Includes tmux mouse mode fix

## Root cause
`publish.ts` catch block checked for `"cannot publish over"` but npm's actual error is `"You cannot publish over the previously published versions"` — mismatch caused `process.exit(1)` instead of skipping already-published packages.