### PR TITLE
fix: sort sessions by name, hide dotfolders in project picker

### DIFF
--- a/src/server/ralph.ts
+++ b/src/server/ralph.ts
@@ -42,6 +42,7 @@ export function listDevProjects(): string[] {
   try {
     return readdirSync(DEV_DIR)
       .filter((f) => {
+        if (f.startsWith(".")) return false;
         try {
           return statSync(join(DEV_DIR, f)).isDirectory();
         } catch { /* race: entry removed between readdir and stat */

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -179,11 +179,6 @@ const SETTINGS_PATH = join(homedir(), ".wolfpack", "bridge-settings.json");
 /** Previous pane content per session — used for content-diff triage. */
 const prevPaneContent = new Map<string, string>();
 
-const TRIAGE_PRIORITY: Record<TriageStatus, number> = {
-  "needs-input": 0,
-  "running": 1,
-  "idle": 2,
-};
 
 const AGENT_PRESETS: Record<string, string> = {
   shell: "shell",
@@ -296,7 +291,7 @@ export const routes: Record<
         return { name, lastLine, triage };
       }),
     );
-    results.sort((a, b) => TRIAGE_PRIORITY[a.triage] - TRIAGE_PRIORITY[b.triage]);
+    results.sort((a, b) => a.name.localeCompare(b.name));
     json(res, { sessions: results });
   },
 


### PR DESCRIPTION
## Summary
- Sessions sorted alphabetically by name instead of by triage priority — eliminates disorienting reordering when session states change
- Hidden folders (dotfiles) filtered out of the ~/Dev project picker list

## Test plan
- [ ] Verify sessions appear in stable alphabetical order regardless of triage state
- [ ] Verify hidden folders (e.g. `.git`, `.cache`) don't appear in project picker