### PR TITLE
feat: add srt sandbox wrapping for ralph agent workers

### DIFF
--- a/sandbox-test.txt
+++ b/sandbox-test.txt
@@ -1,0 +1,1 @@
+hello from sandbox test

--- a/src/ralph-macchio.ts
+++ b/src/ralph-macchio.ts
@@ -18,7 +18,7 @@ import { writeFileSync, appendFileSync, readFileSync, existsSync, unlinkSync, co
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { RALPH_AGENT_CONTEXT, TASK_HEADER, countTasksInContent, validatePlanFormat } from "./wolfpack-context.js";
-import { expandBudget, resolveCleanupDiffBase } from "./validation.js";
+import { expandBudget, resolveCleanupDiffBase, buildSrtSettings } from "./validation.js";
 import { buildAuditFixPrompt } from "./ralph-skill-audit.js";
 import { buildCleanupPrompt } from "./ralph-skill-cleanup.js";
 import { createWorktree, cleanupAllExceptFinal, removeWorktree, listWorktrees, slugifyTaskName } from "./worktree.js";
@@ -37,6 +37,7 @@ const { values: args } = parseArgs({
     worktree: { type: "string", default: "false" },
     "worktree-branch": { type: "string" },
     "worktree-base": { type: "string" },
+    sandbox: { type: "string", default: "true" },
   },
 });
 
@@ -50,6 +51,7 @@ const AUDIT_FIX_ENABLED = args["audit-fix"] === "true";
 const WORKTREE_MODE = (args.worktree === "plan" || args.worktree === "task") ? args.worktree : "false" as const;
 const WORKTREE_BRANCH = args["worktree-branch"] || undefined;
 const WORKTREE_BASE = args["worktree-base"] || undefined;
+const SANDBOX_ENABLED = args.sandbox !== "false";
 const PROJECT_DIR = process.cwd();
 
 /**
@@ -115,6 +117,28 @@ function resolveBin(name: string): string {
     // `where` on windows can return multiple lines, take the first
     return result.split("\n")[0].trim();
   } catch { return name; }
+}
+
+// ── Sandbox (srt) support ──
+
+const SRT_BIN = SANDBOX_ENABLED ? resolveBin("srt") : "";
+const SRT_AVAILABLE = SANDBOX_ENABLED && SRT_BIN !== "srt"; // resolveBin returns the bare name if not found
+
+/** Path to the per-run srt settings file (cleaned up on exit). */
+const SRT_SETTINGS_PATH = join(PROJECT_DIR, ".ralph-srt-settings.json");
+
+/** Write srt settings file and return the path. */
+function writeSrtSettings(allowedWriteDir: string): string {
+  const settings = buildSrtSettings(allowedWriteDir);
+  writeFileSync(SRT_SETTINGS_PATH, JSON.stringify(settings, null, 2));
+  return SRT_SETTINGS_PATH;
+}
+
+/** Remove the srt settings file. */
+function cleanupSrtSettings(): void {
+  try { unlinkSync(SRT_SETTINGS_PATH); } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") console.warn("failed to clean up srt settings:", errMsg(e));
+  }
 }
 
 interface AgentConfig {
@@ -367,9 +391,16 @@ appendFileSync(LOG_FILE, `progress: ${PROGRESS_FILE}\n`);
 appendFileSync(LOG_FILE, `phase_cleanup: ${CLEANUP_ENABLED ? "on" : "off"}\n`);
 appendFileSync(LOG_FILE, `phase_audit_fix: ${AUDIT_FIX_ENABLED ? "on" : "off"}\n`);
 appendFileSync(LOG_FILE, `worktree: ${WORKTREE_MODE}\n`);
+appendFileSync(LOG_FILE, `sandbox: ${SRT_AVAILABLE ? "srt" : SANDBOX_ENABLED ? "srt-not-found" : "off"}\n`);
 appendFileSync(LOG_FILE, `pid: ${process.pid}\n`);
 appendFileSync(LOG_FILE, `bin: ${agent.bin}\n`);
 appendFileSync(LOG_FILE, `started: ${new Date().toString()}\n\n`);
+
+if (SANDBOX_ENABLED && !SRT_AVAILABLE) {
+  const msg = "⚠️  sandbox requested but srt not found — install with: npm i -g @anthropic-ai/sandbox-runtime";
+  appendFileSync(LOG_FILE, `${msg}\n\n`);
+  console.warn(msg);
+}
 
 // capture starting commit for summary diff
 let START_COMMIT = "";
@@ -456,7 +487,20 @@ let activeChild: ReturnType<typeof nodeSpawn> | null = null;
 function runIteration(prompt: string): Promise<{ exitCode: number; output: string }> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
-    const child = nodeSpawn(agent.bin, agent.args(prompt), {
+
+    // Wrap with srt sandbox if available
+    let spawnBin: string;
+    let spawnArgs: string[];
+    if (SRT_AVAILABLE) {
+      writeSrtSettings(workingDir);
+      spawnBin = SRT_BIN;
+      spawnArgs = ["--settings", SRT_SETTINGS_PATH, agent.bin, ...agent.args(prompt)];
+    } else {
+      spawnBin = agent.bin;
+      spawnArgs = agent.args(prompt);
+    }
+
+    const child = nodeSpawn(spawnBin, spawnArgs, {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -491,8 +535,8 @@ function runIteration(prompt: string): Promise<{ exitCode: number; output: strin
   });
 }
 
-// last-resort lock cleanup on any exit (covers unhandled exceptions, SIGINT, etc.)
-process.on("exit", removeLock);
+// last-resort lock + srt settings cleanup on any exit (covers unhandled exceptions, SIGINT, etc.)
+process.on("exit", () => { removeLock(); cleanupSrtSettings(); });
 
 // clean up child process, worktrees, and lock on SIGTERM
 process.on("SIGTERM", () => {
@@ -514,6 +558,7 @@ process.on("SIGTERM", () => {
   syncPlanToProject();
   appendFileSync(LOG_FILE, `finished: ${new Date().toString()}\n`);
   removeLock();
+  cleanupSrtSettings();
   setTimeout(() => process.exit(0), 3500);
 });
 

--- a/src/ralph-macchio.ts
+++ b/src/ralph-macchio.ts
@@ -18,7 +18,7 @@ import { writeFileSync, appendFileSync, readFileSync, existsSync, unlinkSync, co
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { RALPH_AGENT_CONTEXT, TASK_HEADER, countTasksInContent, validatePlanFormat } from "./wolfpack-context.js";
-import { expandBudget, resolveCleanupDiffBase, buildSrtSettings } from "./validation.js";
+import { expandBudget, resolveCleanupDiffBase, buildSrtSettings, shellEscape } from "./validation.js";
 import { buildAuditFixPrompt } from "./ralph-skill-audit.js";
 import { buildCleanupPrompt } from "./ralph-skill-cleanup.js";
 import { createWorktree, cleanupAllExceptFinal, removeWorktree, listWorktrees, slugifyTaskName } from "./worktree.js";
@@ -493,8 +493,14 @@ function runIteration(prompt: string): Promise<{ exitCode: number; output: strin
     let spawnArgs: string[];
     if (SRT_AVAILABLE) {
       writeSrtSettings(workingDir);
+      // srt joins positional args with spaces then runs via `bash -c`, so args
+      // containing shell metacharacters (e.g. parentheses in --allowedTools)
+      // must be passed through `-c` with proper quoting.
+      const innerCmd = [agent.bin, ...agent.args(prompt)]
+        .map(a => shellEscape(a))
+        .join(" ");
       spawnBin = SRT_BIN;
-      spawnArgs = ["--settings", SRT_SETTINGS_PATH, agent.bin, ...agent.args(prompt)];
+      spawnArgs = ["--settings", SRT_SETTINGS_PATH, "-c", innerCmd];
     } else {
       spawnBin = agent.bin;
       spawnArgs = agent.args(prompt);

--- a/src/server/ralph.ts
+++ b/src/server/ralph.ts
@@ -36,6 +36,7 @@ export interface RalphStatus {
   tasksTotal: number;
   worktreeMode: string;
   worktreeBranch: string;
+  sandbox: string;
 }
 
 export function listDevProjects(): string[] {
@@ -105,6 +106,7 @@ export function parseRalphLog(projectDir: string): RalphStatus | null {
     tasksTotal: 0,
     worktreeMode: "false",
     worktreeBranch: "",
+    sandbox: "",
   };
 
   try {
@@ -125,6 +127,8 @@ export function parseRalphLog(projectDir: string): RalphStatus | null {
       if (auditFixMatch) status.auditFixEnabled = auditFixMatch[1] === "on";
       const wtMatch = line.match(/^worktree:\s*(.+)/);
       if (wtMatch) status.worktreeMode = wtMatch[1].trim();
+      const sandboxMatch = line.match(/^sandbox:\s*(.+)/);
+      if (sandboxMatch) status.sandbox = sandboxMatch[1].trim();
       const startMatch = line.match(/^started:\s*(.+)/);
       if (startMatch) status.started = startMatch[1].trim();
       const pidMatch = line.match(/^pid:\s*(\d+)/);
@@ -180,7 +184,7 @@ export function parseRalphLog(projectDir: string): RalphStatus | null {
         !l.startsWith("progress:") && !l.startsWith("started:") &&
         !l.startsWith("finished:") && !l.startsWith("pid:") &&
         !l.startsWith("agent:") && !l.startsWith("phase_cleanup:") &&
-        !l.startsWith("phase_audit_fix:") && !l.startsWith("🥋"),
+        !l.startsWith("phase_audit_fix:") && !l.startsWith("sandbox:") && !l.startsWith("🥋"),
     );
     status.lastOutput = meaningful.slice(-5).join("\n");
 

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -594,9 +594,10 @@ export const routes: Record<
       worktree?: false | "plan" | "task";
       worktreeBranch?: string;
       worktreeBase?: string;
+      sandbox?: boolean;
     }>(req, res);
     if (!body) return;
-    const { project, iterations, planFile, agent, newBranch, sourceBranch, format, cleanup, auditFix, worktree, worktreeBranch, worktreeBase } = body;
+    const { project, iterations, planFile, agent, newBranch, sourceBranch, format, cleanup, auditFix, worktree, worktreeBranch, worktreeBase, sandbox } = body;
     const projectDir = resolveProjectDir(res, project);
     if (!projectDir) return;
     const existing = parseRalphLog(projectDir);
@@ -745,6 +746,7 @@ export const routes: Record<
       "--worktree", worktreeMode,
       ...(worktreeBranch ? ["--worktree-branch", worktreeBranch] : []),
       ...(worktreeBase ? ["--worktree-base", worktreeBase] : []),
+      "--sandbox", String(sandbox !== false),
     ];
     const child = spawn(RALPH_BIN_ARGS[0], workerArgs, {
       cwd: projectDir,

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -2,6 +2,7 @@
  * Shared pure validation functions.
  * Extracted from serve.ts and cli.ts for testability — zero side effects.
  */
+import { resolve } from "node:path";
 
 // ── Classic terminal WS allowed keys ──
 
@@ -81,4 +82,45 @@ export function xmlEsc(s: string): string {
 
 export function systemdEsc(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "");
+}
+
+// ── Sandbox (srt) settings ──
+
+export interface SrtSettings {
+  network: {
+    allowedDomains: string[];
+    allowLocalBinding: boolean;
+  };
+  filesystem: {
+    denyRead: string[];
+    allowWrite: string[];
+    denyWrite: string[];
+  };
+}
+
+/** Build srt settings scoped to the given working directory. */
+export function buildSrtSettings(allowedWriteDir: string): SrtSettings {
+  const absDir = resolve(allowedWriteDir);
+  return {
+    network: {
+      allowedDomains: [
+        "github.com", "*.github.com",
+        "npmjs.org", "*.npmjs.org", "registry.npmjs.org",
+        "yarnpkg.com", "*.yarnpkg.com",
+        "crates.io", "*.crates.io", "static.crates.io",
+        "pypi.org", "*.pypi.org", "files.pythonhosted.org",
+        "proxy.golang.org", "sum.golang.org",
+        "bun.sh", "*.bun.sh",
+        "api.anthropic.com",
+        "api.openai.com",
+        "generativelanguage.googleapis.com",
+      ],
+      allowLocalBinding: false,
+    },
+    filesystem: {
+      denyRead: ["~/.ssh", "~/.gnupg", "~/.aws/credentials"],
+      allowWrite: [absDir, "/tmp"],
+      denyWrite: [".env", ".env.*", "*.pem", "*.key"],
+    },
+  };
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -2,7 +2,10 @@
  * Shared pure validation functions.
  * Extracted from serve.ts and cli.ts for testability — zero side effects.
  */
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
 
 // ── Classic terminal WS allowed keys ──
 
@@ -89,6 +92,7 @@ export function systemdEsc(s: string): string {
 export interface SrtSettings {
   network: {
     allowedDomains: string[];
+    deniedDomains: string[];
     allowLocalBinding: boolean;
   };
   filesystem: {
@@ -96,12 +100,28 @@ export interface SrtSettings {
     allowWrite: string[];
     denyWrite: string[];
   };
+  ripgrep?: {
+    command: string;
+  };
+}
+
+/** Resolve a real binary path for rg (shell functions/aliases don't work in child processes). */
+function resolveRipgrepBin(): { command: string; argv0?: string } | undefined {
+  // Prefer a real rg binary on PATH
+  try {
+    const rgPath = execFileSync("which", ["rg"], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    if (rgPath && !rgPath.includes("not found")) return { command: rgPath };
+  } catch { /* not on PATH */ }
+  // Fallback: claude bundles rg as a multicall binary (ARGV0=rg)
+  const claudeBin = join(homedir(), ".local/bin/claude");
+  try { statSync(claudeBin); return { command: claudeBin, argv0: "rg" }; } catch { /* nope */ }
+  return undefined;
 }
 
 /** Build srt settings scoped to the given working directory. */
 export function buildSrtSettings(allowedWriteDir: string): SrtSettings {
   const absDir = resolve(allowedWriteDir);
-  return {
+  const settings: SrtSettings = {
     network: {
       allowedDomains: [
         "github.com", "*.github.com",
@@ -115,6 +135,7 @@ export function buildSrtSettings(allowedWriteDir: string): SrtSettings {
         "api.openai.com",
         "generativelanguage.googleapis.com",
       ],
+      deniedDomains: [],
       allowLocalBinding: false,
     },
     filesystem: {
@@ -123,4 +144,7 @@ export function buildSrtSettings(allowedWriteDir: string): SrtSettings {
       denyWrite: [".env", ".env.*", "*.pem", "*.key"],
     },
   };
+  const rg = resolveRipgrepBin();
+  if (rg) settings.ripgrep = rg;
+  return settings;
 }

--- a/tests/unit/ralph-sandbox.test.ts
+++ b/tests/unit/ralph-sandbox.test.ts
@@ -54,10 +54,13 @@ describe("buildSrtSettings", () => {
 
   test("settings structure matches srt schema", () => {
     const settings = buildSrtSettings("/tmp/test");
-    // verify top-level keys
-    expect(Object.keys(settings).sort()).toEqual(["filesystem", "network"]);
+    // verify top-level keys (ripgrep is optional)
+    const keys = Object.keys(settings).sort();
+    expect(keys).toContain("filesystem");
+    expect(keys).toContain("network");
     // verify network keys
     expect(settings.network).toHaveProperty("allowedDomains");
+    expect(settings.network).toHaveProperty("deniedDomains");
     expect(settings.network).toHaveProperty("allowLocalBinding");
     // verify filesystem keys
     expect(settings.filesystem).toHaveProperty("denyRead");

--- a/tests/unit/ralph-sandbox.test.ts
+++ b/tests/unit/ralph-sandbox.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { resolve } from "node:path";
+import { writeFileSync, mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildSrtSettings } from "../../src/validation.js";
+import { parseRalphLog } from "../../src/server/ralph.js";
+
+describe("buildSrtSettings", () => {
+  test("allowWrite contains the resolved working directory", () => {
+    const settings = buildSrtSettings("/tmp/my-project");
+    expect(settings.filesystem.allowWrite).toContain("/tmp/my-project");
+  });
+
+  test("allowWrite always includes /tmp for package manager caches", () => {
+    const settings = buildSrtSettings("/home/user/project");
+    expect(settings.filesystem.allowWrite).toContain("/tmp");
+  });
+
+  test("resolves relative paths to absolute", () => {
+    const settings = buildSrtSettings("./relative-dir");
+    const expected = resolve("./relative-dir");
+    expect(settings.filesystem.allowWrite[0]).toBe(expected);
+  });
+
+  test("denyRead blocks sensitive directories", () => {
+    const settings = buildSrtSettings("/tmp/test");
+    expect(settings.filesystem.denyRead).toContain("~/.ssh");
+    expect(settings.filesystem.denyRead).toContain("~/.gnupg");
+    expect(settings.filesystem.denyRead).toContain("~/.aws/credentials");
+  });
+
+  test("denyWrite blocks env and key files", () => {
+    const settings = buildSrtSettings("/tmp/test");
+    expect(settings.filesystem.denyWrite).toContain(".env");
+    expect(settings.filesystem.denyWrite).toContain(".env.*");
+    expect(settings.filesystem.denyWrite).toContain("*.pem");
+    expect(settings.filesystem.denyWrite).toContain("*.key");
+  });
+
+  test("network allows common package registries", () => {
+    const settings = buildSrtSettings("/tmp/test");
+    const domains = settings.network.allowedDomains;
+    expect(domains).toContain("github.com");
+    expect(domains).toContain("registry.npmjs.org");
+    expect(domains).toContain("bun.sh");
+    expect(domains).toContain("api.anthropic.com");
+  });
+
+  test("network disallows local binding", () => {
+    const settings = buildSrtSettings("/tmp/test");
+    expect(settings.network.allowLocalBinding).toBe(false);
+  });
+
+  test("settings structure matches srt schema", () => {
+    const settings = buildSrtSettings("/tmp/test");
+    // verify top-level keys
+    expect(Object.keys(settings).sort()).toEqual(["filesystem", "network"]);
+    // verify network keys
+    expect(settings.network).toHaveProperty("allowedDomains");
+    expect(settings.network).toHaveProperty("allowLocalBinding");
+    // verify filesystem keys
+    expect(settings.filesystem).toHaveProperty("denyRead");
+    expect(settings.filesystem).toHaveProperty("allowWrite");
+    expect(settings.filesystem).toHaveProperty("denyWrite");
+  });
+
+  test("serializes to valid JSON", () => {
+    const settings = buildSrtSettings("/tmp/test");
+    const json = JSON.stringify(settings, null, 2);
+    const parsed = JSON.parse(json);
+    expect(parsed).toEqual(settings);
+  });
+});
+
+describe("parseRalphLog sandbox field", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ralph-sandbox-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("parses sandbox: srt from log header", () => {
+    writeFileSync(
+      join(tmpDir, ".ralph.log"),
+      [
+        "🥋 ralph — 5 iterations",
+        "agent: claude",
+        "plan: PLAN.md",
+        "progress: progress.txt",
+        "phase_cleanup: on",
+        "phase_audit_fix: off",
+        "worktree: false",
+        "sandbox: srt",
+        "pid: 99999",
+        "bin: /usr/local/bin/claude",
+        "started: Mon Mar 25 2026 10:00:00 GMT-0700",
+        "",
+      ].join("\n"),
+    );
+    const status = parseRalphLog(tmpDir);
+    expect(status).not.toBeNull();
+    expect(status!.sandbox).toBe("srt");
+  });
+
+  test("parses sandbox: srt-not-found from log header", () => {
+    writeFileSync(
+      join(tmpDir, ".ralph.log"),
+      [
+        "🥋 ralph — 3 iterations",
+        "agent: codex",
+        "plan: PLAN.md",
+        "progress: progress.txt",
+        "phase_cleanup: on",
+        "phase_audit_fix: off",
+        "worktree: false",
+        "sandbox: srt-not-found",
+        "pid: 99999",
+        "bin: /usr/local/bin/codex",
+        "started: Mon Mar 25 2026 10:00:00 GMT-0700",
+        "",
+      ].join("\n"),
+    );
+    const status = parseRalphLog(tmpDir);
+    expect(status).not.toBeNull();
+    expect(status!.sandbox).toBe("srt-not-found");
+  });
+
+  test("sandbox is empty string when not present in log", () => {
+    writeFileSync(
+      join(tmpDir, ".ralph.log"),
+      [
+        "🥋 ralph — 5 iterations",
+        "agent: claude",
+        "plan: PLAN.md",
+        "pid: 99999",
+        "started: Mon Mar 25 2026 10:00:00 GMT-0700",
+        "",
+      ].join("\n"),
+    );
+    const status = parseRalphLog(tmpDir);
+    expect(status).not.toBeNull();
+    expect(status!.sandbox).toBe("");
+  });
+
+  test("sandbox line excluded from lastOutput", () => {
+    writeFileSync(
+      join(tmpDir, ".ralph.log"),
+      [
+        "🥋 ralph — 1 iterations",
+        "agent: claude",
+        "sandbox: srt",
+        "pid: 99999",
+        "started: Mon Mar 25 2026 10:00:00 GMT-0700",
+        "some actual output here",
+        "",
+      ].join("\n"),
+    );
+    const status = parseRalphLog(tmpDir);
+    expect(status).not.toBeNull();
+    expect(status!.lastOutput).not.toContain("sandbox:");
+  });
+});


### PR DESCRIPTION
## Summary
- Wraps ralph agent spawning with `@anthropic-ai/sandbox-runtime` (srt) for **kernel-level filesystem isolation** — agents can only write under their project directory, enforced by macOS Seatbelt / Linux bubblewrap
- Graceful degradation: warns if srt not installed, runs unsandboxed (current behavior)
- Network allowlist for package registries + AI provider APIs; denyRead on `~/.ssh`, `~/.gnupg`, `~/.aws/credentials`; denyWrite on `.env*`, `*.pem`, `*.key`
- Sandbox status exposed in ralph log + API response

Closes #63

## Test plan
- [x] 13 unit tests for `buildSrtSettings()` and log parsing (800/800 unit tests pass)
- [x] Install srt (`npm i -g @anthropic-ai/sandbox-runtime`) and verify ralph run is sandboxed
- [x] Verify graceful degradation when srt is not installed
- [x] Test with `--sandbox false` to confirm opt-out works