### PR TITLE
fix: restore Tailscale binding and fix CORS for raw IP access

### DIFF
--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -105,6 +105,7 @@ export function renderPlist(config: Config | null, args: string[], logPath: stri
   const env: Record<string, string> = { WOLFPACK_SERVICE: "1" };
   if (config?.devDir) env.WOLFPACK_DEV_DIR = config.devDir;
   if (config?.port) env.WOLFPACK_PORT = String(config.port);
+  if (config?.tailscaleHostname) env.WOLFPACK_HOST = "0.0.0.0";
 
   const envEntries = Object.entries(env)
     .map(([k, v]) => `      <key>${xmlEsc(k)}</key>\n      <string>${xmlEsc(v)}</string>`)
@@ -156,6 +157,7 @@ export function renderSystemdUnit(config: Config | null, args: string[]): string
   ];
   if (config?.devDir) envLines.push(`Environment="WOLFPACK_DEV_DIR=${systemdEsc(config.devDir)}"`);
   if (config?.port) envLines.push(`Environment="WOLFPACK_PORT=${config.port}"`);
+  if (config?.tailscaleHostname) envLines.push(`Environment="WOLFPACK_HOST=0.0.0.0"`);
 
   const quotedArgs = args.map(a => `"${systemdEsc(a)}"`).join(" ");
   return `[Unit]

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -34,6 +34,7 @@ const log = createLogger("server");
 
 const PORT =
   Number(process.env.WOLFPACK_PORT) || Number(process.argv[2]) || 18790;
+const HOST = process.env.WOLFPACK_HOST || "127.0.0.1";
 const VERSION: string = pkg.version;
 
 // inherit user's full PATH from login shell — launchd PATH is minimal
@@ -57,6 +58,23 @@ const ALLOWED_ORIGINS = new Set<string>([
   `http://localhost:${PORT}`,
   `http://127.0.0.1:${PORT}`,
 ]);
+
+// Add local Tailscale IP to allowed origins so the raw 100.x.x.x address works
+{
+  const tsBins = [
+    "/usr/local/bin/tailscale",
+    "/usr/bin/tailscale",
+    "/opt/homebrew/bin/tailscale",
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+  ];
+  const tsBin = tsBins.find(p => { try { execFileSync("test", ["-x", p]); return true; } catch { return false; } });
+  if (tsBin) {
+    try {
+      const ip = execFileSync(tsBin, ["ip", "-4"], { encoding: "utf-8" }).trim();
+      if (ip) ALLOWED_ORIGINS.add(`http://${ip}:${PORT}`);
+    } catch { /* Tailscale not connected or unavailable */ }
+  }
+}
 
 // Extract tailnet suffix from config
 const TAILNET_SUFFIX = (() => {
@@ -206,7 +224,7 @@ export function createServerInstance(): { server: ReturnType<typeof createServer
 // Module-level singleton for production
 const { server, wss } = createServerInstance();
 
-export function startServer(port = PORT, host = "127.0.0.1"): void {
+export function startServer(port = PORT, host = HOST): void {
   cleanupOrphanPtySessions();
 
   server.on("error", (err: NodeJS.ErrnoException) => {


### PR DESCRIPTION
## Problem

Two regressions introduced by the refactor in #43:

**1. Server binds to `127.0.0.1` instead of `0.0.0.0`**
`renderPlist()` and `renderSystemdUnit()` no longer inject `WOLFPACK_HOST=0.0.0.0` when `tailscaleHostname` is configured. The server binds to loopback only — Tailscale access gets connection refused.

**2. Raw Tailscale IP rejected by CORS**
`ALLOWED_ORIGINS` only permits `localhost`, `127.0.0.1`, and `https://*.tailnet`. Requests from `http://100.x.x.x:<port>` (the raw Tailscale IP over HTTP) are blocked with `403 origin not allowed`, breaking session creation and login.

## Fix

**`src/server/index.ts`**
- Read `WOLFPACK_HOST` env var (default: `127.0.0.1`) and use it as the bind address
- At startup, run `tailscale ip -4` to detect the local Tailscale IP and add `http://<ip>:<port>` to `ALLOWED_ORIGINS`

**`src/cli/service.ts`**
- Re-add `WOLFPACK_HOST=0.0.0.0` to the generated launchd plist and systemd unit when `tailscaleHostname` is present in config

The secure default (`127.0.0.1`) is unchanged for users without Tailscale.

## Testing

```bash
# Ensure tailscaleHostname is set in ~/.wolfpack/config.json, then:
wolfpack service install
lsof -i :18790          # should show *:18790, not localhost:18790
curl http://<tailscale-ip>:18790/         # should return 200
curl -H "Origin: http://evil.com" http://<tailscale-ip>:18790/api/info  # should return 403
```