### PR TITLE
fix: apply iOS safe-area-inset-top to header for PWA home screen

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -98,7 +98,7 @@ body::after {
   color: var(--text-primary);
 }
 header {
-  padding: 3px 8px;
+  padding: max(3px, env(safe-area-inset-top)) 8px 3px;
   background: var(--bg-header-gradient);
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -2404,7 +2404,6 @@ body.mobile-no-ghost-focus #desktop-terminal-container textarea {
   }
   .header-center .wolfpack-icon { display: none; }
   #terminal-view {
-    padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
   }
 }


### PR DESCRIPTION
## Problem

When wolfpack is added to the iOS home screen as a PWA, it runs with `apple-mobile-web-app-status-bar-style: black-translucent` and `viewport-fit=cover`. This causes the status bar (clock, battery, signal) to overlay the app's content — the Back and Settings buttons in the header are hidden behind it and cannot be tapped.

There was a `padding-top: env(safe-area-inset-top)` applied to `#terminal-view` inside the mobile media query, which appears to have been an attempt at this fix but applied to the wrong element — it adds dead space at the top of the terminal without actually fixing the header overlap.

## Fix

**`public/styles.css`** — one line change:

```diff
-  padding: 3px 8px;
+  padding: max(3px, env(safe-area-inset-top)) 8px 3px;
```

Applied to `header`. The `max()` ensures at least 3px padding on devices without a notch/Dynamic Island.

Also removed the misplaced `padding-top: env(safe-area-inset-top)` from `#terminal-view` in the mobile media query, since the header now handles the top safe area correctly.

## Testing

1. Open wolfpack on iOS Safari and add to home screen
2. Launch from the home screen icon
3. Verify the Back and Settings buttons are fully visible and tappable below the status bar