### PR TITLE
fix: prevent curl|bash stdin leak during tmux auto-install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ else
   echo "  $(dim '○') tmux not found — installing..."
   if $IS_MACOS; then
     if command -v brew &>/dev/null; then
-      brew install --quiet tmux || {
+      brew install --quiet tmux </dev/null || {
         echo "  $(red '✗') Failed to install tmux via brew."
         echo "  Install manually: $(bold 'brew install tmux')"
         exit 1
@@ -100,7 +100,7 @@ else
     fi
   elif $IS_LINUX; then
     if command -v apt &>/dev/null; then
-      sudo apt update -qq && sudo apt install -y -qq tmux || {
+      sudo apt update -qq </dev/null && sudo apt install -y -qq tmux </dev/null || {
         echo "  $(red '✗') Failed to install tmux via apt."
         echo "  Install manually: $(bold 'sudo apt install tmux')"
         exit 1


### PR DESCRIPTION
## Summary
- under \`curl ... | bash\`, \`brew install\` / \`apt install\` inherit stdin from the pipe and consume the rest of install.sh
- observable as: raw shell-source lines echoed mid-install, then the binary-download step is skipped (\`wolfpack\` ends up not installed even though tmux does)
- redirect those calls from \`/dev/null\` so they stop draining the pipe

## Test plan
- [x] uninstall tmux + wolfpack, then \`cat install.sh | bash\` locally
- [x] tmux auto-installs without leaking script source
- [x] wolfpack binary downloads and lands at \`~/.wolfpack/bin/wolfpack\`
- [x] \`which wolfpack\` + \`which tmux\` both resolve after