### PR TITLE
ci: add --locked to all cargo invocations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,14 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      # `--locked` ensures release builds use the exact dependency versions
+      # in Cargo.lock; if the lockfile is stale CI fails loudly instead of
+      # picking up a newer dep at tag-push time.
       - name: Build broker (darwin-arm64)
-        run: cargo build --release --manifest-path broker/Cargo.toml --target aarch64-apple-darwin --bin wolfpack-broker
+        run: cargo build --release --locked --manifest-path broker/Cargo.toml --target aarch64-apple-darwin --bin wolfpack-broker
 
       - name: Build broker (darwin-x64)
-        run: cargo build --release --manifest-path broker/Cargo.toml --target x86_64-apple-darwin --bin wolfpack-broker
+        run: cargo build --release --locked --manifest-path broker/Cargo.toml --target x86_64-apple-darwin --bin wolfpack-broker
 
       - name: Stage broker binaries
         run: |
@@ -74,11 +77,13 @@ jobs:
         # something doesn't surprise us at tag-push time.
         run: cargo install cross --version 0.2.5 --locked
 
+      # `--locked` for the same reason as the darwin job above. cross is
+      # a thin wrapper around cargo, so it passes the flag through.
       - name: Build broker (linux-x64)
-        run: cross build --release --manifest-path broker/Cargo.toml --target x86_64-unknown-linux-gnu --bin wolfpack-broker
+        run: cross build --release --locked --manifest-path broker/Cargo.toml --target x86_64-unknown-linux-gnu --bin wolfpack-broker
 
       - name: Build broker (linux-arm64)
-        run: cross build --release --manifest-path broker/Cargo.toml --target aarch64-unknown-linux-gnu --bin wolfpack-broker
+        run: cross build --release --locked --manifest-path broker/Cargo.toml --target aarch64-unknown-linux-gnu --bin wolfpack-broker
 
       - name: Stage broker binaries
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,17 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      # `--locked` makes cargo refuse to build when Cargo.lock would need
+      # updating, catching a stale lockfile (forgotten `cargo update`,
+      # hand-edited Cargo.toml without lock refresh, etc.) instead of
+      # silently drifting at build time. CI is the only place we enforce
+      # this; `bun run scripts/build.ts` in dev mode stays unlocked so
+      # local rebuilds Just Work.
       - name: Build wolfpack-broker (required by integration + e2e tests)
-        run: cargo build --release --manifest-path broker/Cargo.toml --bin wolfpack-broker
+        run: cargo build --release --locked --manifest-path broker/Cargo.toml --bin wolfpack-broker
 
       - name: Run broker tests
-        run: cargo test --manifest-path broker/Cargo.toml --all
+        run: cargo test --locked --manifest-path broker/Cargo.toml --all
 
       - name: Audit dependencies
         run: |


### PR DESCRIPTION
## what

Adds `--locked` to every `cargo` / `cross` invocation in CI:

- `test.yml`: `cargo build` + `cargo test` (PR/push gate)
- `release.yml`: 4 broker builds (darwin x2 native + linux x2 via `cross`)

`cross` is a thin cargo wrapper so it passes `--locked` through unchanged.

## why

`--locked` makes cargo refuse to build when `Cargo.lock` would need updating. Catches stale lockfiles (forgotten `cargo update`, hand-edited `Cargo.toml` without lock refresh, accidental dep drift) at build time with a clear error, instead of silently picking up newer dependency versions in CI/release artifacts.

This was item #12 in the PR #123 review cleanup plan — last remaining cleanup task.

## what's NOT changed

Local dev (`bun run scripts/build.ts`) stays unlocked so contributors can rebuild after editing `Cargo.toml` without having to manually refresh the lockfile in the same step. The CI gate is sufficient.

## verification

- locally: `cargo build --release --locked --manifest-path broker/Cargo.toml` accepts current lock cleanly; full `cargo test --locked` suite green (161 tests)
- CI: this PR validates the `test.yml` path. `release.yml` cross-compile path is tag-triggered only — already validated end-to-end in the previous `v0.0.0-broker-test1` dry-run on PR #123