### PR TITLE
docs+chore: README accuracy pass + comment dev-process cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
              :+**++++++*++*+=-:: .. ...... ..   .:..::
 ```
 
-Mobile & desktop command center for AI coding agents. Control agent sessions (Claude, Codex, Gemini, or any custom command) across multiple machines from your phone or browser. Two session backends: **pty** (lightweight, no dependencies) or **tmux** (persistent, survives restarts). Secured by [Tailscale](https://tailscale.com/) — zero-config encrypted access, no ports to open.
+Mobile & desktop command center for AI coding agents. Control agent sessions (Claude, Codex, Gemini, or any custom command) across multiple machines from your phone or browser. Sessions live in a dedicated Rust PTY broker daemon, so they survive wolfpack server restarts and redeploys. Secured by [Tailscale](https://tailscale.com/) — zero-config encrypted access, no ports to open.
 
 Install on your phone's home screen for a native app experience — scan the QR code after setup and tap **"Add to Home Screen"**.
 
@@ -53,32 +53,30 @@ Install on your phone's home screen for a native app experience — scan the QR 
   <img src="docs/mobile-sessions.png" width="250" alt="Mobile — session list with multi-machine support" />
 </p>
 <p align="center">
-  <kbd>Classic</kbd>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<kbd>Ghostty (WASM)</kbd>
-</p>
-<p align="center">
-  <img src="docs/mobile-terminal.png" width="300" alt="Mobile — classic terminal mode" />
-  <img src="docs/mobile-ghostty.png" width="300" alt="Mobile — ghostty WASM terminal mode" />
+  <img src="docs/mobile-ghostty.png" width="300" alt="Mobile — ghostty-web terminal" />
 </p>
 
 ## Architecture
 
 ```
-┌─────────────┐      ┌───────────┐      ┌──────────────────────────────────┐
-│   Phone /   │      │ Tailscale │      │          Your Machine            │
-│   Browser   │◄────►│  (HTTPS)  │◄────►│                                  │
-│   (PWA)     │      │  mesh VPN │      │  ┌──────────┐ ┌──────┐ ┌─────┐  │
-└─────────────┘      └───────────┘      │  │ wolfpack │ │pty or│ │Agent│  │
-                                        │  │  server  │◄│ tmux │◄│(any)│  │
-                                        │  │ HTTP/WS  │ │      │ │     │  │
-                                        │  └──────────┘ └──────┘ └─────┘  │
-                                        └──────────────────────────────────┘
+┌─────────────┐    ┌───────────┐    ┌──────────────────────────────────────────┐
+│   Phone /   │    │ Tailscale │    │              Your Machine                │
+│   Browser   │◄──►│  (HTTPS)  │◄──►│                                          │
+│   (PWA)     │    │  mesh VPN │    │  ┌──────────┐  unix   ┌──────────────┐  │
+└─────────────┘    └───────────┘    │  │ wolfpack │ socket  │  wolfpack-   │  │
+                                    │  │  server  │◄───────►│   broker     │  │
+                                    │  │ (Bun)    │         │  (Rust, PTY) │  │
+                                    │  │ HTTP/WS  │         │  owns agents │  │
+                                    │  └──────────┘         └──────────────┘  │
+                                    └──────────────────────────────────────────┘
 ```
 
 **Components:**
-- **PWA** — single-file vanilla JS app (~90KB), no framework. Mobile-optimized touch UI + desktop ANSI terminal
-- **Server** — Bun HTTP + WebSocket. Serves embedded assets, manages sessions via pty (default) or tmux backend
-- **Ralph** — detached subprocess that iterates through a markdown plan file, invoking agents per-task
-- **Agents** — Claude, Codex, Gemini, or any shell command. Agent-agnostic by design
+- **PWA** — vanilla JS, no framework. ghostty-web (WASM) renders the terminal on both mobile and desktop. Settings + multi-machine list persist in localStorage.
+- **Server** — Bun HTTP + WebSocket. Serves embedded assets, exposes `/api/*` and the `/ws/pty` binary stream. Pure broker client — owns no PTYs.
+- **Broker** — `wolfpack-broker`, a Rust daemon. Owns every PTY, keeps per-session output rings, and survives wolfpack server restarts. One Unix-domain socket per host (`$XDG_RUNTIME_DIR/wolfpack-broker.sock`, fallback `~/.wolfpack/broker.sock`). Wire format documented in [docs/broker-protocol.md](docs/broker-protocol.md).
+- **Ralph** — detached subprocess that iterates through a markdown plan file, invoking agents per-task. See [docs/ralph-macchio.md](docs/ralph-macchio.md).
+- **Agents** — Claude, Codex, Gemini, or any shell command. Agent-agnostic by design.
 
 ## Quick Install
 
@@ -100,94 +98,76 @@ curl -fsSL https://raw.githubusercontent.com/almogdepaz/wolfpack/main/install.sh
 
 This will download the pre-built binary for your platform, run the setup wizard, and optionally install as a login service.
 
-Supported platforms: macOS (Apple Silicon, Intel), Linux (x64, arm64).
+Supported platforms: macOS (Apple Silicon, Intel), Linux (x64, arm64). Each platform package ships both `wolfpack` (the Bun binary) and `wolfpack-broker` (the Rust daemon).
 
 ### Prerequisites
 
 - **Tailscale** *(optional)* — install from [tailscale.com/download](https://tailscale.com/download), sign in, and make sure both your computer and phone are on the same tailnet. Required for remote access.
-- **tmux** *(optional)* — only needed if you choose the tmux backend. The default **pty** backend has no external dependencies.
 
-### Session Backends
+No other runtime dependencies. The broker is bundled.
 
-Wolfpack supports two backends for managing terminal sessions. You choose during setup and can switch at runtime from Settings.
+### Session Persistence
 
-| | **PTY** (default) | **tmux** |
-|---|---|---|
-| **Dependencies** | None | Requires tmux installed |
-| **Session persistence** | In-memory — sessions lost on server crash/restart | tmux server is a separate process — sessions survive wolfpack restarts, deploys, and crashes |
-| **Terminal streaming** | Direct binary WebSocket (`/ws/pty`) — low latency | Capture-pane polling (`/ws/terminal`) |
-| **Desktop terminal** | ghostty-web with full scrollback | ghostty-web with full scrollback |
-| **Best for** | Quick setup, no-dependency environments | Long-running agent sessions where persistence matters |
+The `wolfpack-broker` daemon owns every PTY and runs independently of the wolfpack server. If the server crashes, gets redeployed, or restarts (e.g. `launchctl kickstart`), agent sessions keep running. When the server comes back up, it reconnects to the existing broker over the Unix socket and re-attaches to live sessions automatically.
 
-**Why tmux is more robust:** tmux runs as an independent server process. Your agent sessions live inside tmux, not inside wolfpack. If wolfpack crashes, gets redeployed, or restarts (e.g. `launchctl kickstart`), tmux sessions keep running untouched. When wolfpack comes back up, it reconnects to the existing tmux sessions automatically. With the PTY backend, a wolfpack restart kills all running sessions — any in-progress agent work is lost.
-
-**Why PTY is the default:** zero dependencies, simpler setup, and lower latency terminal streaming. For most users running short agent tasks, the convenience outweighs the persistence tradeoff.
-
-Both backends can run simultaneously — the backend router tracks which backend owns each session. You can have tmux sessions and PTY sessions active at the same time.
-
-### tmux History
-
-Wolfpack can only hydrate history that tmux still retains. Desktop terminal sessions prefill the latest 5,000 lines on connect, so if you want deeper scrollback, raise tmux's history limit:
-
-```tmux
-set -g history-limit 50000
-```
-
-Reload tmux or restart your sessions after changing it.
+The broker is started by `wolfpack service install` (alongside the server) and is checked by `wolfpack doctor`.
 
 ## Usage
 
 ```bash
 wolfpack                    # Start the server (runs setup on first launch)
 wolfpack setup              # Re-run the setup wizard
-wolfpack service install    # Auto-start on login (launchd / systemd)
+wolfpack ls                 # List active broker sessions
+wolfpack kill <session>     # Kill a session by name
+wolfpack doctor             # Diagnose broker socket, binaries, JWT, Tailscale
+wolfpack migrate-plan FILE  # Convert old-format plan headers to ## N. Title
+wolfpack service install    # Auto-start on login (launchd / systemd) — installs broker too
 wolfpack service stop       # Stop the background service
 wolfpack service start      # Start the background service
 wolfpack service status     # Check if running
 wolfpack service uninstall  # Remove the launch agent
-wolfpack uninstall          # Remove everything (service, config, global command)
+wolfpack uninstall --yes    # Remove everything (service, config, ~/.wolfpack, global command)
 ```
 
 ### Setup Wizard
 
 On first run, `wolfpack` walks you through:
 
-1. Checking prerequisites (tmux, Tailscale — both optional)
-2. Choosing a session backend (pty or tmux, default: pty)
-3. Setting your projects directory (default: `~/Dev`)
-4. Choosing a port (default: `18790`)
-5. Enabling Tailscale HTTPS access
-6. Optionally installing as a login service
-7. Displaying a QR code to scan with your phone
+1. Checking prerequisites (Tailscale — optional)
+2. Setting your projects directory (default: `~/Dev`)
+3. Choosing a port (default: `18790`)
+4. Detecting/configuring Tailscale HTTPS access
+5. Optionally installing as a login service (which also installs the broker)
+6. Displaying a QR code to scan with your phone
+7. Printing JWT setup instructions
 
 ## Features
 
 ### Session Management
-- Create, view, and kill agent sessions (pty or tmux backend)
-- Agent picker — Claude, Codex, Gemini, or custom commands per session
+- Create, view, and kill agent sessions — all owned by the broker daemon
+- Agent picker — Claude, Codex, Gemini, or custom commands per session (configurable in Settings → Agents)
 - Session triage — running, idle, and needs-input states with color-coded indicators
 - Live terminal output preview on session cards
 
 ### Desktop
-- **Multi-terminal grid** — view 2-6 sessions side-by-side in a CSS grid layout. Click `+` on any sidebar card to add it to the grid, `×` to remove. Focused cell highlighted with green glow.
+- **Multi-terminal grid** — view multiple sessions side-by-side in a CSS grid layout. Click `+` on any sidebar card to add it to the grid, `×` to remove. Focused cell highlighted.
 - **Collapsible sidebar** — pin or auto-hide. Shows all sessions across machines with status badges, output preview, and grid/kill buttons.
-- **xterm.js PTY** — full terminal emulator with direct PTY connection (not capture-pane polling)
+- **ghostty-web terminal** — full WASM terminal emulator with direct binary `/ws/pty` connection. Per-instance isolation lets each grid cell run its own emulator.
 - **Keyboard shortcuts:**
   - `Cmd/Ctrl + ArrowUp/Down` — cycle between sessions
   - `Cmd/Ctrl + ArrowLeft/Right` — navigate grid cells
   - `Cmd/Ctrl + T` — new session (project picker)
-  - `Cmd/Ctrl + K` — clear terminal
+  - `Cmd/Ctrl + K` — clear focused terminal
 
 ### Mobile
-- **Two terminal modes** — choose in Settings:
-  - **Classic** (default) — lightweight capture-pane polling. No WASM, works on all devices. Best for quick monitoring and input.
-  - **Ghostty (WASM)** — full terminal emulator via [ghostty-web](https://github.com/ghostty-org/ghostty). Richer output (colors, cursor, scrollback) but heavier on battery. Keyboard is suppressed by default — tap the keyboard button to open it.
-- **Keyboard accessory** — quick-action bar with Enter, Esc, arrow keys, Ctrl combos, and git status
-- **Touch scrolling** — momentum physics, long-press to select text and copy
-- **Haptic feedback** — vibration on key actions (toggleable)
-- **PWA** — install as a standalone app on your phone's home screen
+- **ghostty-web terminal** — same WASM emulator as desktop, with the on-screen keyboard suppressed until you tap the keyboard button (prevents accidental focus steals).
+- **Keyboard accessory** — quick-action bar with Enter, Esc, arrow keys, a `git` shortcut, and copy/keyboard buttons.
+- **Quick commands** — user-defined command chips, configurable in Settings.
+- **Touch scrolling** — momentum physics, long-press to select text and copy.
+- **Haptic feedback** — vibration on key actions (toggleable).
+- **PWA** — install as a standalone app on your phone's home screen.
 
-All settings (terminal mode, font size, haptics, etc.) persist in localStorage across sessions.
+All settings (font size, haptics, enter-sends, snapshot TTL, etc.) persist in localStorage across sessions.
 
 ### Multi-Machine
 - One phone connects to multiple Wolfpack servers
@@ -197,7 +177,6 @@ All settings (terminal mode, font size, haptics, etc.) persist in localStorage a
 
 ### Other
 - **Notifications** — browser notifications + vibration when sessions need attention
-- **Search** — find text in terminal output with match navigation
 - **Reconnect handling** — auto-recovers on connection drop with status indicator
 - **Auto-resize** — terminal resizes to match your screen/grid cell
 
@@ -205,7 +184,7 @@ All settings (terminal mode, font size, haptics, etc.) persist in localStorage a
 
 1. Install [Tailscale](https://tailscale.com/download) on both your computer and phone
 2. Sign in to the same Tailscale account on both devices
-3. Run `wolfpack setup` and say **y** to "Enable Tailscale HTTPS access?"
+3. Run `wolfpack setup` — it auto-detects your Tailscale hostname and runs `tailscale serve` to expose the port over HTTPS
 4. Scan the QR code with your phone
 5. Tap **"Add to Home Screen"** for the native app experience
 
@@ -215,7 +194,7 @@ Tailscale's encrypted mesh network handles auth and routing — no ports to open
 
 **Always use the Tailscale hostname** (e.g. `https://mybox.tail1234.ts.net`) — not raw IPs. The QR code from setup already points to the correct URL. Raw IP access (LAN or Tailscale `100.x.x.x`) bypasses Tailscale's DNS-based routing and may not be protected by CORS.
 
-**JWT authentication** adds a second layer of protection. Without it, anyone who can reach the server port has full access to your tmux sessions. To enable:
+**JWT authentication** adds a second layer of protection. Without it, anyone who can reach the server port has full access to your sessions. To enable:
 
 1. Generate a secret (minimum 32 characters):
    ```bash
@@ -242,61 +221,69 @@ Autonomous task runner. Write a markdown plan file, pick an agent, set iteration
 
 ## Config
 
-Stored in `~/.wolfpack/config.json`:
+Stored in `~/.wolfpack/config.json` (mode 0600):
 
 ```json
 {
   "devDir": "/Users/you/Dev",
   "port": 18790,
-  "backend": "pty",
   "tailscaleHostname": "your-machine.tailnet-name.ts.net"
 }
 ```
 
-Agent command and settings stored in `~/.wolfpack/bridge-settings.json`.
+Agent list and per-server settings stored in `~/.wolfpack/bridge-settings.json`.
+
+The broker socket lives at `$XDG_RUNTIME_DIR/wolfpack-broker.sock` (or `~/.wolfpack/broker.sock`) and is owned by the user (filesystem permissions are the auth boundary).
 
 ## Contributing
 
 ### Dev Setup
 
-Requires [Bun](https://bun.sh/) (v1.2+).
+Requires [Bun](https://bun.sh/) (v1.2+) and a [Rust toolchain](https://rustup.rs/) (for building the broker).
 
 ```bash
 git clone https://github.com/almogdepaz/wolfpack.git
 cd wolfpack
 bun install
-bun run scripts/gen-assets.ts   # generate embedded assets (required once)
-bun run cli.ts                  # start the server locally
+bun run scripts/gen-assets.ts          # generate embedded assets (required once)
+cargo build --release --manifest-path broker/Cargo.toml  # build the broker
+bun run src/cli/index.ts                # start the server locally
 ```
+
+For an end-to-end local install (build + service install + restart), use `scripts/deploy-local.sh`.
 
 ### Testing
 
 ```bash
-bun test                             # all tests
-bun test tests/unit/                 # unit tests only
-bun test tests/unit/plan-parsing.test.ts  # single file
+bun test                                 # all bun tests
+bun test tests/unit/                     # unit tests only
+bun test tests/unit/plan-parsing.test.ts # single file
+bunx playwright test                     # e2e (uses test-server harness)
 ```
 
-Tests use Bun's built-in runner. Three categories:
-- `tests/unit/` — plan parsing, ralph log parsing, escaping, validation, grid logic
+Test layout:
+- `tests/unit/` — pure-logic tests (plan parsing, ralph log parsing, escaping, validation, grid logic, broker codec, etc.)
+- `tests/integration/` — API routes, broker backend, ralph loop endpoints, WS dispatch
 - `tests/snapshot/` — launchd plist and systemd unit generation
-- `tests/integration/` — API routes, ralph loop endpoints
+- `tests/e2e/` — Playwright end-to-end (`test:e2e` / `test:e2e:headed` scripts)
+
+The Rust broker has its own tests under `broker/tests/` (`cargo test` from `broker/`).
 
 ### Asset Pipeline
 
 Frontend files live in `public/`. The server doesn't serve from disk — everything is embedded:
 
-1. Edit files in `public/` (HTML, PNG, manifest, etc.)
-2. Run `bun run scripts/gen-assets.ts` — embeds them into `public-assets.ts` (binary→base64, text→string)
-3. **Do NOT edit `public-assets.ts` manually** — it's auto-generated
+1. Edit files in `public/` (HTML, TS, CSS, manifest, etc.)
+2. Run `bun run scripts/gen-assets.ts` — bundles `public/app.ts` and ghostty-web, then embeds every file from `public/` into `src/public-assets.ts` (binary→base64, text→string)
+3. **Do NOT edit `src/public-assets.ts` manually** — it's auto-generated
 
 ### Building Binaries
 
 ```bash
-bun run scripts/build.ts    # assets + 4 platform binaries in dist/
+bun run scripts/build.ts    # assets + broker + 4 platform binaries + npm pkg dirs in dist/
 ```
 
-Compiles for: linux-x64, linux-arm64, darwin-x64, darwin-arm64.
+Compiles `wolfpack` for: linux-x64, linux-arm64, darwin-x64, darwin-arm64. The script also stages `wolfpack-broker` per platform — in CI it expects pre-built broker binaries under `dist/broker/<target>/`; locally it falls back to a host-arch-only `cargo build --release`.
 
 ### PR Conventions
 

--- a/public/app-grid.ts
+++ b/public/app-grid.ts
@@ -475,11 +475,10 @@ export function addToGrid(session, machine) {
     console.warn("[grid] WebAssembly unavailable — cannot open grid terminal");
     return;
   }
-  // HIGH finding from edc-context/reports/issues.md: without per-Terminal WASM
-  // isolation, all grid cells share one WebAssembly.Memory. Concurrent
-  // fit()/write() across cells produce out-of-bounds memory accesses that
-  // crash every terminal in the tab. Refuse to enter grid mode in that
-  // state and surface a visible warning.
+  // Without per-Terminal WASM isolation, all grid cells share one
+  // WebAssembly.Memory. Concurrent fit()/write() across cells produce
+  // out-of-bounds memory accesses that crash every terminal in the tab.
+  // Refuse to enter grid mode in that state and surface a visible warning.
   if (typeof (window as any).createIsolatedGhostty !== "function") {
     console.error("[grid] createIsolatedGhostty unavailable — grid mode disabled to prevent WASM OOB crash. Reload to pick up a newer ghostty-web bundle.");
     if (typeof window !== "undefined" && typeof (window as any).alert === "function") {

--- a/public/app-state.ts
+++ b/public/app-state.ts
@@ -310,7 +310,7 @@ export const state = {
   // is a self-fulfilling prophecy: a peer that was slow yesterday gets the
   // 1.5s failing-timeout today, fails again because legit cold fetches
   // sometimes take longer than that, and never recovers. Per-tab in-memory
-  // is the right scope. (issues.md L5 left open by design.)
+  // is the right scope.
   peerHealth: {} as Record<string, { failures: number }>,
 };
 

--- a/public/app.ts
+++ b/public/app.ts
@@ -79,11 +79,11 @@ const wpMetrics = {
 // reconstruct the WS frame timing, prefill vs replay byte distribution,
 // _writeTermData call shape, and rAF cadence during the hydration window.
 //
-// PURE DIAGNOSTIC. Gated behind `localStorage.wolfpackDebug = "1"`
-// (issues.md L3) — previously this was always-on and exposed per-session
-// attach metadata to any JS in the page context (XSS, extension,
-// bookmarklet). When disabled, all helpers are no-ops and `__wfTrace` /
-// `__wf_dumpTrace` / `__wf_clearTrace` are NOT installed on `window`.
+// PURE DIAGNOSTIC. Gated behind `localStorage.wolfpackDebug = "1"` so it
+// doesn't expose per-session attach metadata to any JS in the page context
+// (XSS, extension, bookmarklet). When disabled, all helpers are no-ops and
+// `__wfTrace` / `__wf_dumpTrace` / `__wf_clearTrace` are NOT installed on
+// `window`.
 //
 // Read with `window.__wf_dumpTrace()` or `window.__wf_dumpTrace("sess")`
 // after enabling: `localStorage.wolfpackDebug = "1"; location.reload()`.
@@ -472,11 +472,11 @@ async function createTerminalInstance({ fontSize, scrollback, cursorBlink = true
   // See scripts/bundle-ghostty.ts for context. Falls back to shared singleton if
   // createIsolatedGhostty isn't available (e.g. older bundle).
   //
-  // edc-context/reports/issues.md HIGH finding: when isolation is unavailable
-  // AND grid mode is in use, concurrent fit()/write() across cells can OOB
-  // on the shared WebAssembly.Memory. addToGrid() now refuses to enter grid
-  // mode in that state, so any path reaching here without isolation is a
-  // single-cell terminal where shared singleton is safe.
+  // When isolation is unavailable AND grid mode is in use, concurrent
+  // fit()/write() across cells can OOB on the shared WebAssembly.Memory.
+  // addToGrid() refuses to enter grid mode in that state, so any path
+  // reaching here without isolation is a single-cell terminal where the
+  // shared singleton is safe.
   let isolatedGhostty = null;
   if (typeof (window as any).createIsolatedGhostty === "function") {
     try { isolatedGhostty = await (window as any).createIsolatedGhostty(); }
@@ -1837,9 +1837,9 @@ function flushGridSnapshots() {
 
 /**
  * Validate a peer URL before any code uses it for `fetch` / WS construction.
- * (issues.md M12) An XSS payload could write attacker-controlled URLs into
- * localStorage; without this guard those URLs would receive every API call
- * and the bearer JWT in the next page session.
+ * An XSS payload could write attacker-controlled URLs into localStorage;
+ * without this guard those URLs would receive every API call and the
+ * bearer JWT in the next page session.
  *
  * Accept only http(s) URLs whose hostname looks tailnet-shaped
  * (`*.ts.net`), is a literal IP, or is localhost. Port is NOT pinned —
@@ -3069,7 +3069,7 @@ function sendMsg() {
     // duplicate Enter on any command that took >800ms to produce output
     // (slow grep, network request, interactive prompt waiting for input),
     // potentially triggering an unintended second command or corrupting
-    // TUI confirm prompts (issues.md M11). The send-success branch trusts
+    // TUI confirm prompts. The send-success branch trusts
     // _sendTerminalInput's return: if the WS layer reports success, the
     // bytes are queued; broker drops surface as reconnects, not silent
     // input loss. enterRetryTimer is still cleared on output dispatch in

--- a/src/broker/client.ts
+++ b/src/broker/client.ts
@@ -279,9 +279,9 @@ export class BrokerClient {
     if (opts.sinceSeq !== undefined) {
       // Take max(prev, sinceSeq): never lower the floor below what we've
       // already observed via OUTPUT_BINARY frames. A caller passing a stale
-      // sinceSeq would otherwise force redundant replay on reconnect (LOW-1
-      // in review-tasks/report-broker.md). The broker handles redundancy
-      // gracefully but the duplicate bytes are wasted work.
+      // sinceSeq would otherwise force redundant replay on reconnect.
+      // The broker handles redundancy gracefully but the duplicate bytes
+      // are wasted work.
       const prev = this.activeSubscriptionSeq.get(sessionId);
       const next = prev !== undefined && prev > opts.sinceSeq ? prev : opts.sinceSeq;
       this.activeSubscriptionSeq.set(sessionId, next);
@@ -529,8 +529,8 @@ export class BrokerClient {
     this.currentReconnectDelay = base;
     // ±20% jitter to avoid thundering-herd reconnect spikes when many
     // wolfpack server instances restart simultaneously and target the same
-    // broker (issues.md M3). Base value still drives exponential growth
-    // for predictable testing; jitter is applied only at scheduling time.
+    // broker. Base value still drives exponential growth for predictable
+    // testing; jitter is applied only at scheduling time.
     const jitter = base * 0.2 * (Math.random() * 2 - 1);
     const delay = Math.max(0, Math.round(base + jitter));
     this.reconnectTimer = setTimeout(() => {

--- a/src/broker/codec.ts
+++ b/src/broker/codec.ts
@@ -135,7 +135,7 @@ export function uuidFromBytes(buf: Uint8Array, off = 0): string {
 // ---------------------------------------------------------------------------
 
 const TEXT_ENCODER = new TextEncoder();
-// fatal:true (issues.md L9) — reject malformed UTF-8 in JSON control
+// fatal:true — reject malformed UTF-8 in JSON control
 // frames instead of replacing bytes with U+FFFD. Silent replacement
 // could parse-as-clean a corrupted field (mojibake in session names
 // etc.), misrouting events. The TypeError is caught by `decodeJson`
@@ -311,10 +311,10 @@ export class FrameParser {
   /**
    * Ensure chunks[0] holds at least `n` bytes (or the remainder of the buffer if smaller).
    *
-   * Allocation characteristic (known LOW tradeoff in edc-context/reports/issues.md):
-   * when data spans multiple chunks, coalesce() allocates a new Uint8Array and
-   * copies bytes. Under high-throughput + fragmented input this increases GC
-   * pressure, but keeps parser logic simple/obvious for current scale.
+   * Allocation tradeoff: when data spans multiple chunks, coalesce()
+   * allocates a new Uint8Array and copies bytes. Under high-throughput +
+   * fragmented input this increases GC pressure, but keeps parser logic
+   * simple/obvious for current scale.
    */
   private coalesce(n: number): void {
     if (this.chunks.length === 0) return;

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -82,7 +82,7 @@ export function saveConfig(c: Config) {
   mkdirSync(WOLFPACK_DIR, { recursive: true, mode: 0o700 });
   // 0600 — config holds Tailscale hostname and port; on shared machines
   // a default-umask 0644 would leak the network address to other local
-  // users. (issues.md M8)
+  // users.
   writeFileSync(CONFIG_PATH, JSON.stringify(c, null, 2), { mode: 0o600 });
 }
 

--- a/src/cli/sessions.ts
+++ b/src/cli/sessions.ts
@@ -19,7 +19,7 @@ function baseUrl(): string {
 }
 
 /** Track a one-shot warning so a too-short JWT secret is surfaced once
- *  per CLI invocation rather than spammed on every API call. (issues.md M1) */
+ *  per CLI invocation rather than spammed on every API call. */
 let _warnedShortSecret = false;
 
 /** Mint a short-lived HS256 JWT if WOLFPACK_JWT_SECRET is set. Matches the

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -95,9 +95,9 @@ export async function setup() {
   print("");
 
   // Detect non-interactive shells (CI, piped stdin, redirected stdout)
-  // and announce up-front (issues.md L8). Without this, every prompt
-  // silently no-ops via the hasTTY=false flip in `ask()`, leaving
-  // operators wondering why setup "just finished" with nothing changed.
+  // and announce up-front. Without this, every prompt silently no-ops via
+  // the hasTTY=false flip in `ask()`, leaving operators wondering why
+  // setup "just finished" with nothing changed.
   // process.stdin.isTTY is undefined when not a TTY — treat any non-true
   // value as non-interactive.
   const interactive = Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);

--- a/src/ralph-macchio.ts
+++ b/src/ralph-macchio.ts
@@ -127,9 +127,8 @@ const SRT_AVAILABLE = SANDBOX_ENABLED && SRT_BIN !== "srt"; // resolveBin return
 /**
  * Path to this worker's srt settings file (cleaned up on exit).
  *
- * MEDIUM finding from edc-context/reports/issues.md: fixed filename caused
- * concurrent ralph workers on the same project to overwrite each other's
- * sandbox config. Include pid so each worker owns its own file.
+ * Filename includes pid so concurrent ralph workers on the same project
+ * don't overwrite each other's sandbox config.
  */
 const SRT_SETTINGS_PATH = join(PROJECT_DIR, `.ralph-srt-settings-${process.pid}.json`);
 
@@ -554,11 +553,10 @@ process.on("exit", () => { removeLock(); cleanupSrtSettings(); });
 /**
  * Graceful shutdown shared by SIGTERM and SIGINT.
  *
- * Resolves HIGH finding from edc-context/reports/issues.md: previously only
- * SIGTERM was handled, so Ctrl+C (SIGINT) from a terminal or `kill -INT`
- * left `.ralph.lock` and any in-progress git worktrees behind. The next
- * `POST /api/ralph/start` would hit the stale lock and reject with 409
- * until manually cleaned up.
+ * Both signals must be handled — with only SIGTERM, Ctrl+C from a
+ * terminal or `kill -INT` would leave `.ralph.lock` and in-progress git
+ * worktrees behind, and the next `POST /api/ralph/start` would hit the
+ * stale lock and reject with 409 until manually cleaned up.
  *
  * Both signals share the same teardown:
  *   1. set `stopping` so the iterate loop can short-circuit

--- a/src/server/backend.ts
+++ b/src/server/backend.ts
@@ -44,7 +44,7 @@ export interface SessionBackend {
  *    `subscribe` response (ring overrun during the lag window).
  *    Subscribers should force a re-snapshot — in practice the WS layer
  *    closes the viewer with 1011 so the client reconnects and re-prefills
- *    instead of sitting on out-of-sync output (issues.md M7 / L14).
+ *    instead of sitting on out-of-sync output.
  */
 export type SessionLifecycleEvent =
   | { kind: "exited"; exitCode?: number; signal?: number }
@@ -69,9 +69,9 @@ export interface PtyBackendMethods {
        * unwound its local refcount but the WS layer's reference to the
        * (now dead) callback is still in `entry.unsubscribe`, leaving the
        * viewer connected with no data stream forever. The callback is
-       * REQUIRED so callers can't silently regress the dead-viewer fix
-       * (LOW-2 in review-tasks/report-server.md); pass `() => {}` for
-       * fire-and-forget probe paths that don't care about teardown.
+       * REQUIRED so callers can't silently regress the dead-viewer fix;
+       * pass `() => {}` for fire-and-forget probe paths that don't care
+       * about teardown.
        */
       onSubscribeError: (err: unknown) => void;
     },
@@ -142,7 +142,7 @@ export class BackendRouter implements SessionBackend {
       // and replay would skip bytes), fan it out to that session's
       // lifecycle subscribers as a `replay_truncated` event. The WS layer
       // turns it into a 1011 close so the client reconnects with a fresh
-      // snapshot — closing the issues.md M7/L14 stale-prefill gap.
+      // snapshot — closing the stale-prefill gap.
       onReplayTruncated: (sessionId: string) => {
         this.broker?.handleReplayTruncated(sessionId);
       },

--- a/src/server/broker-backend.ts
+++ b/src/server/broker-backend.ts
@@ -374,8 +374,7 @@ export class BrokerBackend implements SessionBackend, PtyBackendMethods {
       // Fire-and-forget subscribe RPC. On failure, unwind the local subscriber
       // state so the refcount doesn't leak and the output sub is cleaned up.
       // ALSO notify the caller via opts.onSubscribeError so the WS layer can
-      // tear down the viewer (otherwise it sits idle forever — see HIGH
-      // finding in edc-context/reports/issues.md).
+      // tear down the viewer (otherwise it sits idle forever).
       this.client.subscribe(id, { sinceSeq: opts.sinceSeq }).catch((e: unknown) => {
         log.warn("subscribe rpc failed; unwinding", { name, id, error: errMsg(e) });
         try { unsubData(); } catch { /* ignore */ }
@@ -517,7 +516,7 @@ export class BrokerBackend implements SessionBackend, PtyBackendMethods {
    * given session id. Wired by `BackendRouter` via
    * `BrokerClient.onReplayTruncated`. The WS layer translates this into a
    * 1011 close so the client reconnects with a fresh snapshot, closing
-   * the issues.md M7 / L14 stale-prefill window.
+   * the stale-prefill window.
    */
   handleReplayTruncated(id: string): void {
     const subs = this.lifecycleSubs.get(id);

--- a/src/server/http.ts
+++ b/src/server/http.ts
@@ -169,7 +169,7 @@ export function serveFile(res: ServerResponse, filename: string): void {
   // (without it the scope is restricted to the directory containing the
   // SW script). Previously a dedicated `GET /sw.js` route set this; now
   // that the file is served by the generic asset handler we set the
-  // header here for the single SW path. (issues.md L2)
+  // header here for the single SW path.
   if (filename === "sw.js") {
     headers["Service-Worker-Allowed"] = "/";
   }

--- a/src/server/push.ts
+++ b/src/server/push.ts
@@ -122,7 +122,7 @@ function saveSubscriptions(subs: PushSubscription[]): void {
   // fsync the containing directory so the rename is durable across an
   // ungraceful shutdown on non-CoW filesystems (ext4 without
   // data=ordered would otherwise be free to reorder the dir-entry write
-  // and silently revert the subscription file). issues.md M9.
+  // and silently revert the subscription file).
   try {
     const dirFd = openSync(dirname(SUBS_PATH), "r");
     try { fsyncSync(dirFd); } finally { closeSync(dirFd); }

--- a/src/server/ralph.ts
+++ b/src/server/ralph.ts
@@ -173,12 +173,12 @@ export function parseRalphLog(projectDir: string): RalphStatus | null {
       status.finished = finishedMatch[1].trim();
     }
 
-    // detect active: PID-reuse-safe liveness via `ps -o command=` filter
-    // (issues.md H6). `kill(pid, 0)` alone would report "active" for any
-    // unrelated process the kernel happened to assign the recycled PID to
-    // after the ralph worker reaped — leaving the UI showing a dead loop
-    // as live and the cancel button as a no-op (the cancel endpoint
-    // applies the same filter and would refuse to kill).
+    // detect active: PID-reuse-safe liveness via `ps -o command=` filter.
+    // `kill(pid, 0)` alone would report "active" for any unrelated process
+    // the kernel happened to assign the recycled PID to after the ralph
+    // worker reaped — leaving the UI showing a dead loop as live and the
+    // cancel button as a no-op (the cancel endpoint applies the same filter
+    // and would refuse to kill).
     if (status.pid > 1 && isRalphProcessAlive(status.pid)) {
       status.active = true;
       status.completed = false;

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -422,12 +422,12 @@ export const routes: Record<
     // fallback rules. `effective.cmds` is what the picker should render;
     // `effective.agentCmd` is the pre-selected default.
     //
-    // (issues.md L13) If the stored `settings.agentCmd` points to a
-    // disabled command, the runtime already resolves correctly via
-    // effectiveAgentCmd(). Normalize the raw field in the response so a
-    // future settings-UI consumer that reads `settings.agentCmd` directly
-    // doesn't surface a stale/disabled selection. We don't mutate the
-    // on-disk settings — just the returned view.
+    // If the stored `settings.agentCmd` points to a disabled command, the
+    // runtime already resolves correctly via effectiveAgentCmd(). Normalize
+    // the raw field in the response so a future settings-UI consumer that
+    // reads `settings.agentCmd` directly doesn't surface a stale/disabled
+    // selection. We don't mutate the on-disk settings — just the returned
+    // view.
     const enabled = new Set((settings.cmds ?? []).filter((c) => c.enabled).map((c) => c.cmd));
     const view = settings.agentCmd && !enabled.has(settings.agentCmd)
       ? { ...settings, agentCmd: "" }
@@ -925,9 +925,9 @@ export const routes: Record<
     if (!status?.active || !status.pid || status.pid <= 1) {
       return json(res, { error: "no active ralph loop found" }, 404);
     }
-    // Reuse the same filter parseRalphLog now applies (issues.md H6) so
-    // the cancel and the active-detection paths agree. ps -o command=
-    // confirms it's actually a ralph worker, not a reused PID slot.
+    // Reuse the same PID-reuse-safe filter parseRalphLog applies so the
+    // cancel and active-detection paths agree. ps -o command= confirms
+    // it's actually a ralph worker, not a reused PID slot.
     if (!isRalphProcessAlive(status.pid)) {
       return json(res, { error: "PID does not belong to a ralph process or process not found" }, 404);
     }

--- a/src/server/websocket.ts
+++ b/src/server/websocket.ts
@@ -1,8 +1,10 @@
 /**
- * WebSocket handlers — PTY (ghostty-web WASM) + classic terminal (text polling).
+ * WebSocket handler for `/ws/pty` — binary PTY stream backed by the broker.
  *
- * Backend-agnostic: works with both TmuxBackend (spawns `tmux attach-session`)
- * and PtyBackend (pipes WS directly to session terminal I/O).
+ * Forwards broker output bytes to the viewer and viewer input back to
+ * the broker. Handles takeover (a new viewer displaces the old one with
+ * close code 4002), prefill replay from snapshot, and replay-truncated
+ * resets when the broker's per-session ring overflows.
  */
 import type { WebSocket } from "ws";
 import {
@@ -167,17 +169,15 @@ export function __getTestState(): {
   return { activePtySessions, ptySpawnAttempts, sendPrefillChunked, PREFILL_CHUNK_SIZE };
 }
 
-// ── Classic terminal WS handler (text polling for mobile) ──
-
 export function teardownPty(session: string): void {
   const entry = activePtySessions.get(session);
   if (!entry) return;
   entry.alive = false;
   // Tear down sub/proc state BEFORE deleting from the map. Kill failures
   // are logged at warn (not debug) so an orphan PTY surfaces in the log
-  // stream rather than silently accumulating (issues.md M6). The map
-  // delete still happens unconditionally in finally so a thrown kill
-  // never strands the entry — a re-attach is always possible.
+  // stream rather than silently accumulating. The map delete still happens
+  // unconditionally in finally so a thrown kill never strands the entry —
+  // a re-attach is always possible.
   try {
     if (entry.unsubscribe) {
       try { entry.unsubscribe(); } catch (e: unknown) { log.debug(`teardownPty: unsubscribe failed`, { session, error: errMsg(e) }); }
@@ -379,10 +379,10 @@ function setupNewPtyEntry(
       if (!backend.isSessionAlive(session)) {
         // Cache may be stale: BrokerBackend's isSessionAlive() only consults
         // the in-memory nameToId map, which lags behind broker truth after
-        // a broker restart or out-of-band session creation (issues.md H5).
-        // Refresh once via list() and re-check before closing 4001 —
-        // legitimate live sessions should not be rejected just because the
-        // local cache hasn't seen them yet.
+        // a broker restart or out-of-band session creation. Refresh once
+        // via list() and re-check before closing 4001 — legitimate live
+        // sessions should not be rejected just because the local cache
+        // hasn't seen them yet.
         try { await backend.list(); } catch (e: unknown) {
           log.debug("isSessionAlive miss: list() refresh failed", { session, error: errMsg(e) });
         }
@@ -616,11 +616,11 @@ function setupNewPtyEntry(
         _coalesceTimer = setTimeout(flushCoalesce, COALESCE_FLUSH_MS);
       }, {
         sinceSeq: prefillSeq,
-        // HIGH finding from edc-context/reports/issues.md: when the broker
-        // `subscribe` RPC fails after onSessionData returns, the backend
-        // unwinds locally but the WS would otherwise stay open with no
-        // data stream. Tear down so the client gets a 1011 close and can
-        // surface an error / retry, instead of staring at a dead viewer.
+        // When the broker `subscribe` RPC fails after onSessionData
+        // returns, the backend unwinds locally but the WS would otherwise
+        // stay open with no data stream. Tear down so the client gets a
+        // 1011 close and can surface an error / retry, instead of staring
+        // at a dead viewer.
         onSubscribeError: (err: unknown) => {
           log.warn("subscribe rpc failed — tearing down viewer", { session, error: errMsg(err) });
           if (!entry.alive) return;
@@ -656,10 +656,10 @@ function setupNewPtyEntry(
       const lifecycleUnsub = backend.onSessionLifecycle(session, (event) => {
         if (event.kind === "replay_truncated") {
           // Broker ring overran during a lag window — our cached prefill
-          // and any bytes since are out of sync with broker truth
-          // (issues.md M7 / L14). Tear the viewer down with 1011 so the
-          // client reconnects and re-prefills from a fresh snapshot,
-          // instead of staring at stale terminal content.
+          // and any bytes since are out of sync with broker truth. Tear
+          // the viewer down with 1011 so the client reconnects and
+          // re-prefills from a fresh snapshot, instead of staring at stale
+          // terminal content.
           if (!entry.alive) return;
           log.warn("replay_truncated — forcing client reconnect for fresh snapshot", { session });
           if (entry.viewer && entry.viewer.readyState === 1) {

--- a/src/shared/process-cleanup.ts
+++ b/src/shared/process-cleanup.ts
@@ -32,8 +32,7 @@ export function isProcessAlive(pid: number): boolean {
  * PID-reuse-safe liveness check for a ralph worker. `kill(pid, 0)` alone
  * returns true for ANY process at that PID, so a recycled PID (the OS
  * reusing the slot for an unrelated process after the ralph worker
- * exited) makes parseRalphLog report `active: true` for a dead loop
- * (issues.md H6).
+ * exited) would make parseRalphLog report `active: true` for a dead loop.
  *
  * Uses `ps -o command=` to confirm the process at `pid` is actually a
  * ralph-macchio worker. Returns false on:

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -96,7 +96,7 @@ export interface SrtSettings {
 }
 
 /**
- * Cached `rg` resolution (issues.md L4). Previously this ran a sync
+ * Cached `rg` resolution. Previously this ran a sync
  * `which rg` on every ralph iteration via buildSrtSettings → a hang in
  * `which` (slow PATH, NFS, broken `which` shim) would block iteration
  * startup, and the cost was paid N times per loop. PATH doesn't change

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -97,8 +97,8 @@ export function removeWorktree(worktreePath: string, projectDir?: string): void 
 
 /**
  * Best-effort directory mtime; returns 0 if stat fails so the caller's
- * sort treats inaccessible entries as oldest. Used as the L6 fallback
- * for cleanupAllExceptFinal when the explicit order file is unavailable.
+ * sort treats inaccessible entries as oldest. Used as the fallback for
+ * cleanupAllExceptFinal when the explicit order file is unavailable.
  */
 function mtimeOrZero(path: string): number {
   try { return statSync(path).mtimeMs; } catch { return 0; }
@@ -213,8 +213,8 @@ function _cleanupAllExceptFinalImpl(
       return mtimeOrZero(a.path) - mtimeOrZero(b.path);
     });
   } else {
-    // Fallback when the order file is missing or unreadable (issues.md L6):
-    // sort by directory mtime instead of numeric path sort. Path sort
+    // Fallback when the order file is missing or unreadable: sort by
+    // directory mtime instead of numeric path sort. Path sort
     // breaks when slug names collide and get timestamp suffixes — the
     // "final" worktree picked for preservation may not be the most recent
     // and `cleanupAllExceptFinal` would discard the latest agent work.

--- a/tests/helpers/fake-ralph-pid.ts
+++ b/tests/helpers/fake-ralph-pid.ts
@@ -1,11 +1,10 @@
 /**
  * Test helper: spawn a long-lived stand-in process whose argv[0] contains
  * "ralph-macchio" so `parseRalphLog`'s PID-reuse-safe filter
- * (`isRalphProcessAlive` — issues.md H6 in edc-context/reports/issues.md)
- * treats it as a live ralph worker. Use the returned PID in fixture log
- * lines `pid: ${fakeRalphPid}` instead of `process.pid`, which would (now
- * correctly) be rejected because the bun test runner's argv does not
- * contain "ralph-macchio".
+ * (`isRalphProcessAlive`) treats it as a live ralph worker. Use the
+ * returned PID in fixture log lines `pid: ${fakeRalphPid}` instead of
+ * `process.pid`, which would (correctly) be rejected because the bun test
+ * runner's argv does not contain "ralph-macchio".
  *
  * Lifecycle: call `startFakeRalph()` from `beforeAll`, store the pid,
  * call `stopFakeRalph()` from `afterAll`. The shell exec replaces argv[0]

--- a/tests/integration/ralph-api.test.ts
+++ b/tests/integration/ralph-api.test.ts
@@ -30,8 +30,8 @@ import { startFakeRalph, stopFakeRalph, type FakeRalph } from "../helpers/fake-r
 
 const TEST_DEV_DIR = join(tmpdir(), `wolfpack-ralph-test-${Date.now()}`);
 
-// Stand-in PID for fixtures that expect parseRalphLog active=true
-// (issues.md H6). See tests/helpers/fake-ralph-pid.ts.
+// Stand-in PID for fixtures that expect parseRalphLog active=true.
+// See tests/helpers/fake-ralph-pid.ts.
 let fakeRalphPid: number = process.pid;
 let fakeRalph: FakeRalph | null = null;
 

--- a/tests/unit/auth-startup.test.ts
+++ b/tests/unit/auth-startup.test.ts
@@ -1,6 +1,6 @@
 /**
- * Regression tests for the JWT auth startup contract (issues.md CRITICAL —
- * "JWT auth fails open when secret is absent or short").
+ * Regression tests for the JWT auth startup contract — must not fail open
+ * when the secret is absent or too short.
  *
  * Contract:
  *   - WOLFPACK_JWT_SECRET set, ≥32 chars  →  enforce auth ("ok")

--- a/tests/unit/broker-backend.test.ts
+++ b/tests/unit/broker-backend.test.ts
@@ -457,10 +457,9 @@ describe("BrokerBackend.isSessionAlive", () => {
 
 describe("BrokerBackend.onSessionData (refcounted broker subscribe)", () => {
   // Tests below that don't care about subscribe-error semantics still need
-  // to satisfy the now-required onSubscribeError contract (LOW-2 from
-  // review-tasks/report-server.md). This noop is fine because these tests
-  // exercise the success path or assert on the FakeBrokerClient state
-  // directly, not the callback.
+  // to satisfy the now-required onSubscribeError contract. This noop is
+  // fine because these tests exercise the success path or assert on the
+  // FakeBrokerClient state directly, not the callback.
   const noopErr = { onSubscribeError: () => {} };
 
   beforeEach(async () => {
@@ -564,10 +563,9 @@ describe("BrokerBackend.onSessionData (refcounted broker subscribe)", () => {
     expect(client.subscribeCallCount).toBe(2);
   });
 
-  // Regression: HIGH finding from .context/reports/issues.md
-  // "subscribe-RPC failure leaves WS open with no data stream".
-  // The fix: broker-backend invokes opts.onSubscribeError so the WS layer
-  // can tear down the viewer instead of leaving it idle.
+  // Regression: subscribe-RPC failure must not leave the WS open with no
+  // data stream. broker-backend invokes opts.onSubscribeError so the WS
+  // layer can tear down the viewer instead of leaving it idle.
   test("subscribe RPC failure invokes opts.onSubscribeError exactly once", async () => {
     const errors: unknown[] = [];
     client.nextSubscribeError = new Error("broker exploded");
@@ -618,11 +616,11 @@ describe("BrokerBackend.onSessionData (refcounted broker subscribe)", () => {
     }).not.toThrow();
     await new Promise((r) => setTimeout(r, 0));
     // Real refcount probe: FakeBrokerClient.subscribe rejects BEFORE
-    // activeSubscriptions.add runs, so checking that set is tautological
-    // (LOW-1 in review-tasks/report-tests.md). Instead, verify the
-    // BrokerBackend.subscriberRefs map was unwound by issuing a follow-up
-    // subscribe — if the prior ref leaked, this call would reuse it and
-    // subscribeCallCount would stay at 1. A clean unwind => fresh RPC.
+    // activeSubscriptions.add runs, so checking that set is tautological.
+    // Instead, verify the BrokerBackend.subscriberRefs map was unwound by
+    // issuing a follow-up subscribe — if the prior ref leaked, this call
+    // would reuse it and subscribeCallCount would stay at 1. A clean
+    // unwind => fresh RPC.
     expect(client.subscribeCallCount).toBe(1);
     backend.onSessionData("live", () => {}, noopErr);
     await new Promise((r) => setTimeout(r, 0));
@@ -771,9 +769,9 @@ describe("BrokerBackend.ingestEvent + onSessionLifecycle", () => {
     expect(seen.sort()).toEqual(["a", "b"]);
   });
 
-  // Regression: issues.md M7 / L14 — onReplayTruncated must reach
-  // lifecycle subscribers as a `replay_truncated` event so the WS layer
-  // can force a viewer reconnect for fresh prefill.
+  // Regression: onReplayTruncated must reach lifecycle subscribers as a
+  // `replay_truncated` event so the WS layer can force a viewer reconnect
+  // for fresh prefill.
   test("handleReplayTruncated fires a replay_truncated event to subscribers", () => {
     const seen: SessionLifecycleEvent[] = [];
     backend.onSessionLifecycle("live", (e) => seen.push(e));

--- a/tests/unit/ralph-lifecycle.test.ts
+++ b/tests/unit/ralph-lifecycle.test.ts
@@ -15,7 +15,7 @@ import { parseRalphLog, countProgressDone } from "../../src/server/ralph.js";
 import { startFakeRalph, stopFakeRalph, type FakeRalph } from "../helpers/fake-ralph-pid.js";
 
 // PID stand-in for fixtures that need parseRalphLog active=true under the
-// PID-reuse-safe filter (issues.md H6). See tests/helpers/fake-ralph-pid.ts.
+// PID-reuse-safe filter. See tests/helpers/fake-ralph-pid.ts.
 let fakeRalphPid: number = process.pid;
 let fakeRalph: FakeRalph | null = null;
 beforeAll(() => { fakeRalph = startFakeRalph(); fakeRalphPid = fakeRalph.pid; });

--- a/tests/unit/ralph-lock-prune.test.ts
+++ b/tests/unit/ralph-lock-prune.test.ts
@@ -7,9 +7,9 @@ import { parseRalphLog, pruneStaleRalphLock } from "../../src/server/ralph.js";
 /**
  * Returns a PID that is known to be dead at call time. Spawns `true`,
  * waits for it to exit, then verifies via `kill(pid, 0)` that the kernel
- * agrees. Avoids the LOW-2 flakiness from review-tasks/report-tests.md
- * where a hard-coded `999999` becomes valid on hosts with a raised
- * `kernel.pid_max` (large containers / big servers).
+ * agrees. Avoids the flakiness of hard-coding e.g. `999999`, which becomes
+ * a valid PID on hosts with a raised `kernel.pid_max` (large containers /
+ * big servers).
  */
 function deadPid(): number {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/unit/ralph-phase-status.test.ts
+++ b/tests/unit/ralph-phase-status.test.ts
@@ -6,7 +6,7 @@ import { parseRalphLog } from "../../src/server/ralph.ts";
 import { startFakeRalph, stopFakeRalph, type FakeRalph } from "../helpers/fake-ralph-pid.js";
 
 // PID stand-in for fixtures that need parseRalphLog active=true under the
-// PID-reuse-safe filter (issues.md H6). See tests/helpers/fake-ralph-pid.ts.
+// PID-reuse-safe filter. See tests/helpers/fake-ralph-pid.ts.
 let fakeRalphPid: number = process.pid;
 let fakeRalph: FakeRalph | null = null;
 beforeAll(() => { fakeRalph = startFakeRalph(); fakeRalphPid = fakeRalph.pid; });

--- a/tests/unit/ralph-shutdown-signals.test.ts
+++ b/tests/unit/ralph-shutdown-signals.test.ts
@@ -1,6 +1,7 @@
 /**
- * Regression test for HIGH finding from edc-context/reports/issues.md:
- * "SIGINT unhandled in ralph worker — orphan lock and worktrees".
+ * Regression: ralph worker must handle BOTH SIGTERM and SIGINT, otherwise
+ * Ctrl+C from a terminal leaves `.ralph.lock` and in-progress worktrees
+ * behind, and the next `POST /api/ralph/start` rejects with 409.
  *
  * Why a source-level test instead of a subprocess test:
  *   ralph-macchio.ts has top-level side effects (parses argv, calls main()
@@ -9,9 +10,6 @@
  *   bug warrants. The actual cleanup logic is shared between SIGTERM and
  *   SIGINT via `shutdownHandler`, so the test we need is "both signals are
  *   wired to the same handler". A grep is enough.
- *
- * If anyone deletes the SIGINT line again (or wires it to a different
- * handler), this test fails.
  */
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -23,14 +21,13 @@ const SOURCE = readFileSync(
 );
 
 describe("ralph-macchio shutdown signal registration", () => {
-  // Quote class is `["']` to tolerate either single or double quotes
-  // (LOW-3 in review-tasks/report-tests.md): a formatter switch should
-  // not produce a false negative.
+  // Quote class is `["']` to tolerate either single or double quotes —
+  // a formatter switch should not produce a false negative.
   test("registers a SIGTERM handler", () => {
     expect(SOURCE).toMatch(/process\.on\(\s*["']SIGTERM["']/);
   });
 
-  test("registers a SIGINT handler (regression for issues.md HIGH)", () => {
+  test("registers a SIGINT handler", () => {
     expect(SOURCE).toMatch(/process\.on\(\s*["']SIGINT["']/);
   });
 
@@ -53,8 +50,7 @@ describe("ralph-macchio shutdown signal registration", () => {
     // (closing brace on its own line followed by a blank line). If a
     // formatter ever emits `}` without a trailing blank line, fall back
     // to the next `\n}` so we don't over-capture the rest of the file
-    // and silently mask a removeLock() removal (LOW-3 in
-    // review-tasks/report-tests.md).
+    // and silently mask a removeLock() removal.
     let end = SOURCE.indexOf("\n}\n", start);
     if (end === -1) end = SOURCE.indexOf("\n}", start);
     expect(end).toBeGreaterThan(start);

--- a/tests/unit/sw-push-url-sanitize.test.ts
+++ b/tests/unit/sw-push-url-sanitize.test.ts
@@ -1,7 +1,5 @@
 /**
- * Regression test for HIGH finding in edc-context/reports/issues.md:
- * "sw.js open-redirect bypass via protocol-relative URL" (file was named
- * sw-push.js prior to L2 rename).
+ * Regression: sw.js open-redirect bypass via protocol-relative URL.
  *
  * The previous guard `if (url.startsWith("/"))` treated `//evil.com` as a
  * safe relative URL because it literally starts with `/`. Resolved against


### PR DESCRIPTION
Two commits:

**1. README rewrite for broker-only architecture**
The README still described pty vs tmux as a user-selectable backend, plus a 'Classic vs Ghostty' mobile mode that no longer exists. Brought it in line with the actual code:

- drop pty/tmux comparison table; broker is mandatory (`src/server/backend.ts`: tmux/in-process backends were removed)
- remove tmux history-limit guidance
- fix architecture diagram (server is broker client; rust broker owns PTYs over unix socket)
- remove 'Two terminal modes' section — only ghostty-web exists, no `termMode` setting
- fix setup wizard steps (no backend prompt in `src/cli/setup.ts`)
- fix dev-setup: `bun run src/cli/index.ts` (file `cli.ts` does not exist), add `cargo build` step, add rust prerequisite
- add `wolfpack ls`, `kill`, `doctor`, `migrate-plan` to usage
- add `tests/e2e/` category and `bunx playwright test`
- fix config example (no `backend` field in `Config`)
- note broker socket path

**2. Comment cleanup**
Stripped references to `issues.md` severity tags (L4, M3, H6, etc.), `review-tasks/report-*.md`, `edc-context/reports`, and HIGH/MEDIUM/LOW finding attributions across 28 files. Preserved every technical explanation; only dropped pure attribution noise. Also fixed stale 'Classic terminal WS handler' comment in `websocket.ts` (no such handler exists; only `/ws/pty`).

Tests: 1133 unit + 333 integration/snapshot, 0 fail.