### PR TITLE
refactor: drop wolfpack context auto-injection, keep skills as optional installables

### DIFF
--- a/.claude/skills/wolfpack-plan/SKILL.md
+++ b/.claude/skills/wolfpack-plan/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: wolfpack-plan
+description: Context injected into interactive claude sessions via --append-system-prompt. Defines the plan-file header conventions the task extractor recognizes. Loaded by src/wolfpack-context.ts.
+---
+
+## Wolfpack Plan Conventions
+
+Plan task headers MUST use: `## N. Title` (e.g. `## 1. Add auth`), subtasks: `## Na. Title` (e.g. `## 1a. Tests`). Completed: wrap in `~~` (e.g. `## ~~1. Done~~`). No other header styles — the task extractor only recognizes this pattern.
+
+Each task = a meaningful deliverable (3-5 per feature). NOT individual lines of code — a unit of work a senior dev would recognize. Subtask breakdowns follow the same rule: 3-5 max, each coherent.

--- a/.claude/skills/wolfpack-ralph/SKILL.md
+++ b/.claude/skills/wolfpack-ralph/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: wolfpack-ralph
+description: Context injected into every ralph iteration prompt. Defines the subtask-breakdown output protocol and the user-notification endpoint. Loaded by src/wolfpack-context.ts and prepended to the prompt sent to claude/codex/cursor/gemini.
+---
+
+## Ralph Agent Context
+
+When a task is too large to implement directly, output a <subtasks> block instead of making changes:
+```
+<subtasks>
+Implement auth middleware with JWT validation
+Add integration tests for auth endpoints
+</subtasks>
+```
+Each subtask = a meaningful deliverable (3-5 per breakdown). NOT single lines of code or imports — a unit of work a senior dev would recognize as coherent.
+
+To notify the user (push notification to their phone/desktop):
+curl -s http://localhost:18790/api/notify -H 'Content-Type: application/json' -d '{"message": "your message"}'

--- a/src/ralph-macchio.ts
+++ b/src/ralph-macchio.ts
@@ -17,7 +17,7 @@ import { execFileSync, spawn as nodeSpawn } from "node:child_process";
 import { writeFileSync, appendFileSync, readFileSync, existsSync, unlinkSync, copyFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
-import { RALPH_AGENT_CONTEXT, TASK_HEADER, countTasksInContent, validatePlanFormat } from "./wolfpack-context.js";
+import { TASK_HEADER, countTasksInContent, validatePlanFormat } from "./wolfpack-context.js";
 import { expandBudget, resolveCleanupDiffBase, buildSrtSettings, shellEscape } from "./validation.js";
 import { buildAuditFixPrompt } from "./ralph-skill-audit.js";
 import { buildCleanupPrompt } from "./ralph-skill-cleanup.js";
@@ -344,12 +344,11 @@ INSTRUCTIONS:
 BEGIN.`;
 }
 
-/** Build the per-iteration prompt. RALPH_AGENT_CONTEXT is prepended so the agent
- *  knows subtask protocol and task conventions (see wolfpack-context.ts). */
+/** Build the per-iteration prompt. Plan-format and subtask conventions are
+ *  not injected — if the user wants them, they can install the
+ *  `.claude/skills/wolfpack-{ralph,plan}` skills into their project. */
 function buildPrompt(taskDesc: string): string {
-  return `${RALPH_AGENT_CONTEXT}
-
-You may ONLY create/edit/delete files under ${workingDir}. Do NOT touch files outside this directory.
+  return `You may ONLY create/edit/delete files under ${workingDir}. Do NOT touch files outside this directory.
 
 YOUR TASK:
 ${taskDesc}

--- a/src/server/broker-backend.ts
+++ b/src/server/broker-backend.ts
@@ -25,7 +25,7 @@
 import type { SessionBackend, PtyBackendMethods, SessionLifecycleEvent, SessionPrefill } from "./backend.js";
 import type { BrokerClient, OutputSubscriber } from "../broker/client.js";
 import type { ControlResponse, EventBody } from "../broker/codec.js";
-import { SHELL, injectAgentContext } from "./shell.js";
+import { SHELL } from "./shell.js";
 import { CMD_REGEX } from "../validation.js";
 import { createLogger, errMsg } from "../log.js";
 import {
@@ -205,8 +205,7 @@ export class BrokerBackend implements SessionBackend, PtyBackendMethods {
     if (agentCmd === "shell") {
       shellCmd = SHELL;
     } else {
-      const fullCmd = injectAgentContext(agentCmd);
-      shellCmd = `{ setopt nonotify nomonitor 2>/dev/null; set +m 2>/dev/null; } ; clear; ${fullCmd}; exec ${SHELL}`;
+      shellCmd = `{ setopt nonotify nomonitor 2>/dev/null; set +m 2>/dev/null; } ; clear; ${agentCmd}; exec ${SHELL}`;
     }
 
     const env: Array<[string, string]> = [

--- a/src/server/shell.ts
+++ b/src/server/shell.ts
@@ -4,8 +4,6 @@
  */
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
-import { shellEscape } from "../validation.js";
-import { INTERACTIVE_CONTEXT } from "../wolfpack-context.js";
 
 const _realExec = promisify(execFile);
 type ExecFn = (file: string, args: readonly string[], options?: { timeout?: number; encoding?: BufferEncoding; maxBuffer?: number }) => Promise<{ stdout: string; stderr: string }>;
@@ -38,22 +36,6 @@ export function detectAgent(agentCmd: string): "claude" | "gemini" | "codex" | "
     if (new RegExp(`^${agent}\\b`).test(agentCmd)) return agent as "claude" | "gemini" | "codex" | "cursor";
   }
   return null;
-}
-
-/** Build the full command with context injection for the detected agent. */
-export function injectAgentContext(agentCmd: string): string {
-  const agent = detectAgent(agentCmd);
-  switch (agent) {
-    case "claude": {
-      const withCtx = agentCmd + " --append-system-prompt " + shellEscape(INTERACTIVE_CONTEXT);
-      return withCtx + " || " + agentCmd;
-    }
-    case "gemini": {
-      return agentCmd + " -i " + shellEscape(INTERACTIVE_CONTEXT);
-    }
-    default:
-      return agentCmd;
-  }
 }
 
 export type { ExecFn };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,8 +1,3 @@
-declare module "*.md" {
-  const content: string;
-  export default content;
-}
-
 declare module "qrcode-terminal" {
   const qr: {
     generate(url: string, opts: { small: boolean }, cb: (code: string) => void): void;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,8 @@
+declare module "*.md" {
+  const content: string;
+  export default content;
+}
+
 declare module "qrcode-terminal" {
   const qr: {
     generate(url: string, opts: { small: boolean }, cb: (code: string) => void): void;

--- a/src/wolfpack-context.ts
+++ b/src/wolfpack-context.ts
@@ -5,8 +5,21 @@
  *  - RALPH_AGENT_CONTEXT:  ralph-macchio.ts prepends to the `-p` prompt
  *  - INTERACTIVE_CONTEXT:  serve.ts appends via `claude --append-system-prompt`
  *
+ * The two context strings are sourced from skill files under
+ * `.claude/skills/{wolfpack-ralph,wolfpack-plan}/SKILL.md`, embedded at
+ * build time via bun's text imports so the prompt content survives
+ * `bun build --compile`. YAML frontmatter is stripped at module load.
+ *
  * Plus a validatePlanFormat() helper for checking plan file structure.
  */
+import ralphSkill from "../.claude/skills/wolfpack-ralph/SKILL.md" with { type: "text" };
+import planSkill from "../.claude/skills/wolfpack-plan/SKILL.md" with { type: "text" };
+
+/** Strip YAML frontmatter (--- ... ---) from a skill markdown file. */
+function stripFrontmatter(md: string): string {
+  const m = md.match(/^---\n[\s\S]*?\n---\n+/);
+  return m ? md.slice(m[0].length) : md;
+}
 
 /** Matches plan task headers: ## 1. Title, ### 2a. Title, ## ~~3. Title~~, ## Phase 1. Title */
 export const TASK_HEADER = /^#{2,3} (?:~~)?(?:\w+ )?\d+[a-z]?[\.\):]\s+/;
@@ -14,27 +27,13 @@ export const TASK_HEADER = /^#{2,3} (?:~~)?(?:\w+ )?\d+[a-z]?[\.\):]\s+/;
 /** Checkbox task pattern: - [ ] or - [x] */
 const CHECKBOX = /^- \[[ x]\] /;
 
-/** Context for ralph iterations — subtask output protocol + granularity only. */
-export const RALPH_AGENT_CONTEXT = `## Ralph Agent Context
+/** Context for ralph iterations — subtask output protocol + granularity only.
+ *  Source: .claude/skills/wolfpack-ralph/SKILL.md */
+export const RALPH_AGENT_CONTEXT = stripFrontmatter(ralphSkill).trimEnd();
 
-When a task is too large to implement directly, output a <subtasks> block instead of making changes:
-\`\`\`
-<subtasks>
-Implement auth middleware with JWT validation
-Add integration tests for auth endpoints
-</subtasks>
-\`\`\`
-Each subtask = a meaningful deliverable (3-5 per breakdown). NOT single lines of code or imports — a unit of work a senior dev would recognize as coherent.
-
-To notify the user (push notification to their phone/desktop):
-curl -s http://localhost:18790/api/notify -H 'Content-Type: application/json' -d '{"message": "your message"}'`;
-
-/** Context for interactive claude sessions — plan format + granularity. */
-export const INTERACTIVE_CONTEXT = `## Wolfpack Plan Conventions
-
-Plan task headers MUST use: \`## N. Title\` (e.g. \`## 1. Add auth\`), subtasks: \`## Na. Title\` (e.g. \`## 1a. Tests\`). Completed: wrap in \`~~\` (e.g. \`## ~~1. Done~~\`). No other header styles — the task extractor only recognizes this pattern.
-
-Each task = a meaningful deliverable (3-5 per feature). NOT individual lines of code — a unit of work a senior dev would recognize. Subtask breakdowns follow the same rule: 3-5 max, each coherent.`;
+/** Context for interactive claude sessions — plan format + granularity.
+ *  Source: .claude/skills/wolfpack-plan/SKILL.md */
+export const INTERACTIVE_CONTEXT = stripFrontmatter(planSkill).trimEnd();
 
 /** Ambiguous header patterns that look like tasks but don't match TASK_HEADER */
 const AMBIGUOUS_HEADERS = [

--- a/src/wolfpack-context.ts
+++ b/src/wolfpack-context.ts
@@ -1,39 +1,18 @@
 /**
- * Shared context injected into AI agent sessions spawned by wolfpack.
+ * Plan-format helpers shared between the ralph worker and the server.
  *
- * Two focused contexts replace the old monolithic WOLFPACK_CONTEXT:
- *  - RALPH_AGENT_CONTEXT:  ralph-macchio.ts prepends to the `-p` prompt
- *  - INTERACTIVE_CONTEXT:  serve.ts appends via `claude --append-system-prompt`
- *
- * The two context strings are sourced from skill files under
- * `.claude/skills/{wolfpack-ralph,wolfpack-plan}/SKILL.md`, embedded at
- * build time via bun's text imports so the prompt content survives
- * `bun build --compile`. YAML frontmatter is stripped at module load.
- *
- * Plus a validatePlanFormat() helper for checking plan file structure.
+ * Note: prior versions of this module also exported `RALPH_AGENT_CONTEXT`
+ * and `INTERACTIVE_CONTEXT` prompt strings that were auto-injected into
+ * agent commands. That injection was removed — the content now lives at
+ * `.claude/skills/wolfpack-{ralph,plan}/SKILL.md` for anyone who wants
+ * to opt in by installing the skills into their own project.
  */
-import ralphSkill from "../.claude/skills/wolfpack-ralph/SKILL.md" with { type: "text" };
-import planSkill from "../.claude/skills/wolfpack-plan/SKILL.md" with { type: "text" };
-
-/** Strip YAML frontmatter (--- ... ---) from a skill markdown file. */
-function stripFrontmatter(md: string): string {
-  const m = md.match(/^---\n[\s\S]*?\n---\n+/);
-  return m ? md.slice(m[0].length) : md;
-}
 
 /** Matches plan task headers: ## 1. Title, ### 2a. Title, ## ~~3. Title~~, ## Phase 1. Title */
 export const TASK_HEADER = /^#{2,3} (?:~~)?(?:\w+ )?\d+[a-z]?[\.\):]\s+/;
 
 /** Checkbox task pattern: - [ ] or - [x] */
 const CHECKBOX = /^- \[[ x]\] /;
-
-/** Context for ralph iterations — subtask output protocol + granularity only.
- *  Source: .claude/skills/wolfpack-ralph/SKILL.md */
-export const RALPH_AGENT_CONTEXT = stripFrontmatter(ralphSkill).trimEnd();
-
-/** Context for interactive claude sessions — plan format + granularity.
- *  Source: .claude/skills/wolfpack-plan/SKILL.md */
-export const INTERACTIVE_CONTEXT = stripFrontmatter(planSkill).trimEnd();
 
 /** Ambiguous header patterns that look like tasks but don't match TASK_HEADER */
 const AMBIGUOUS_HEADERS = [

--- a/tests/integration/csp.test.ts
+++ b/tests/integration/csp.test.ts
@@ -16,7 +16,6 @@ await mock.module("../../src/public-assets.js", () => ({
 await mock.module("../../src/server/shell.js", () => ({
   exec: mock(async () => ({ stdout: "", stderr: "" })),
   SHELL: "/bin/zsh",
-  injectAgentContext: (s: string) => s,
   RALPH_AGENTS: new Set(["claude", "codex", "gemini", "cursor"]),
   detectAgent: () => null,
   __setExecOverride: () => {},


### PR DESCRIPTION
Removes the auto-injection of `RALPH_AGENT_CONTEXT` and `INTERACTIVE_CONTEXT` into agent commands. The actual prompt content is preserved as in-repo skill files under `.claude/skills/wolfpack-{ralph,plan}/SKILL.md` for anyone who wants to install them into their own project.

## why

Auto-injection only ever reached two agents:
- `claude` via `--append-system-prompt`
- `gemini` via `-i`

Everyone else (`codex`, `cursor`, `pi`, `shell`, and any user-added cmd) got nothing. The split was invisible to users and made claude/gemini sessions silently different from every other agent. Removing the injection makes all agents behave consistently — what you typed is what runs.

The plan-format conventions and subtask-output protocol are still useful guidance, just not something wolfpack should inject on the user's behalf. They now live as opt-in skills.

## changes

**commit 1** — extract prompt content into skill files

- adds `.claude/skills/wolfpack-ralph/SKILL.md` (subtask protocol + notify endpoint)
- adds `.claude/skills/wolfpack-plan/SKILL.md` (plan-header conventions)
- temporarily wired them up via bun text imports as the injection source

**commit 2** — drop the auto-injection

- `src/server/shell.ts`: delete `injectAgentContext()` and the `INTERACTIVE_CONTEXT` import. Keep `RALPH_AGENTS` + `detectAgent` (used elsewhere).
- `src/server/broker-backend.ts`: spawn the user's `agentCmd` directly, no wrapper.
- `src/ralph-macchio.ts`: stop prepending `RALPH_AGENT_CONTEXT` to each iteration prompt.
- `src/wolfpack-context.ts`: drop the two prompt-string exports, the `.md` text imports, and the `stripFrontmatter` helper. Plan-parsing helpers (`TASK_HEADER`, `countTasksInContent`, `validatePlanFormat`, `detectOldPlanFormat`, `migratePlanFormat`) stay.
- `src/types.d.ts`: drop the now-unused `declare module "*.md"`.
- `tests/integration/csp.test.ts`: drop the `injectAgentContext` mock entry.

Net diff after both commits: skill files added, ~60 LOC of injection plumbing removed, plan-parsing helpers untouched.

## verification

- `bun test` — 1473 pass / 0 fail
- `bunx tsc` — same 8 pre-existing errors as main, no new ones
- compiled binary smoke tested with `bun build --compile`

## migration note

Users who previously relied on the injected behavior on claude or gemini sessions will see those agents behave like the others now (no auto plan-format context). To opt back in, install the skills into the target project (e.g. copy `.claude/skills/wolfpack-{ralph,plan}` into the user's project repo) and claude code will pick them up.

🤖 generated with claude code
