### PR TITLE
chore: release v1.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wolfpack-bridge",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "description": "Mobile command center for tmux-based AI agent sessions",
   "bin": {
@@ -17,10 +17,10 @@
     "postinstall": "node bin/install.cjs"
   },
   "optionalDependencies": {
-    "wolfpack-bridge-darwin-arm64": "1.6.2",
-    "wolfpack-bridge-darwin-x64": "1.6.2",
-    "wolfpack-bridge-linux-arm64": "1.6.2",
-    "wolfpack-bridge-linux-x64": "1.6.2"
+    "wolfpack-bridge-darwin-arm64": "1.6.3",
+    "wolfpack-bridge-darwin-x64": "1.6.3",
+    "wolfpack-bridge-linux-arm64": "1.6.3",
+    "wolfpack-bridge-linux-x64": "1.6.3"
   },
   "keywords": [
     "tmux",


### PR DESCRIPTION
Version bump to 1.6.3.

Tagging this on main will trigger `.github/workflows/release.yml` → cross-builds the broker for all 4 targets, builds the bun-compiled wolfpack binaries, publishes to npm (5 packages), and creates a GitHub release with checksums.

## what landed since 1.6.2

- **#136** drop wolfpack context auto-injection; skills available as opt-in installables under `.claude/skills/wolfpack-{ralph,plan}/SKILL.md`
- **#135** broker zombie/wedge recovery — TS client request-timeout circuit breaker + BackendRouter recovery watchdog
- **#134** README accuracy pass + dev-process comment cleanup
- **#127** audit findings tier 1 (CRITICAL + HIGH)
- **#126** post-attach scrolldown fix via quiescence + coalesce + silence reveal
- **#125** user-managed agents list with checkbox toggles
- **#124** `--locked` on all cargo invocations
- **#123** rust PTY broker replaces tmux + in-process session ownership

## verification

- `bun test` — 1473 pass / 0 fail (verified on the #136 branch pre-merge)
- CI Tests workflow green on main post-#136 merge
