### PR TITLE
Document Ralph opt-in and add worker response tests

### DIFF
--- a/RALPH_SETTINGS_DOC_STATUS.md
+++ b/RALPH_SETTINGS_DOC_STATUS.md
@@ -1,0 +1,5 @@
+# ralph settings documentation status
+
+- [x] identify ralph-facing docs
+- [ ] update docs to state ralph must be enabled in settings
+- [ ] verify text occurrences

--- a/RALPH_WORKER_RESPONSE_TEST_STATUS.md
+++ b/RALPH_WORKER_RESPONSE_TEST_STATUS.md
@@ -1,0 +1,13 @@
+# ralph worker response test status
+
+- [x] identify coverage gap
+- [x] add fake-agent worker regression tests
+- [x] observe red failure before fixing test harness (`fake agent` script newline bug made the new tests fail)
+- [x] run narrow green verification
+- [x] run targeted broader verification
+
+## verification
+
+- `bun test tests/unit/ralph-worker-response.test.ts` → 4 pass
+- `bun test tests/unit/ralph-worker-response.test.ts tests/unit/ralph-response.test.ts tests/unit/ralph-agent-command.test.ts tests/unit/ralph-git-exclude.test.ts tests/unit/ralph-sandbox.test.ts tests/unit/plan-parsing.test.ts` → 117 pass
+- `bun run typecheck` → pass

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Scan the QR with your phone, tap **Add to Home Screen**, done.
 - **Desktop grid** — view up to 6 sessions side-by-side. Add via `+`, remove via `×`, `Cmd+ArrowLeft/Right` to navigate.
 - **Mobile-first terminal** — ghostty-web (WASM) emulator. Keyboard accessory bar (arrows, Esc, `git`, copy). On-screen keyboard suppressed until you ask for it. Long-press to select.
 - **PWA** — install on home screen. Notifications + vibration when sessions need attention. Reconnects on drop.
-- **Ralph loop** — autonomous task runner. Hand it a markdown plan, it iterates through tasks with an agent, committing along the way. See [docs/ralph-macchio.md](docs/ralph-macchio.md).
+- **Ralph loop** — autonomous task runner. Hand it a markdown plan, it iterates through tasks with an agent, committing along the way. Ralph controls are hidden until you enable **Settings → Ralph Loop → Enable Ralph Loop**. See [docs/ralph-macchio.md](docs/ralph-macchio.md).
 
 ## CLI
 

--- a/WOLFPACK_DIFFERENTIAL_REVIEW_2026-05-24.md
+++ b/WOLFPACK_DIFFERENTIAL_REVIEW_2026-05-24.md
@@ -1,0 +1,151 @@
+# wolfpack differential review — 2026-05-24
+
+**target:** `fix/ralph-codex-srt` (`d585ac0`)
+**baseline:** `main` (`git diff main...HEAD`, merge-base `ef18a86faded155208d98f3a9b5cb78f8bc3ffcf`)
+**mode:** standalone edc-review
+**strategy:** surgical/focused — large repo (2101 code files), high-risk ralph/sandbox paths reviewed deeply
+
+## executive summary
+
+| severity | count |
+|----------|-------|
+| 🔴 critical | 0 |
+| 🟠 high | 0 |
+| 🟡 medium | 1 |
+| 🟢 low | 0 |
+
+**overall risk:** medium  
+**recommendation:** conditional — code direction is sound; add a worker-level regression test before merge.
+
+**key metrics:**
+- files changed: 26
+- production files analyzed: 11/11 changed ts/rs files
+- tests run during review: targeted unit suite, typecheck, broker-bin unit tests
+- high-risk areas: ralph worker subprocess, srt sandbox policy, git metadata write scope, structured agent control channel
+- known edc issues touched: no direct open issue fix/regression found; change intersects core fragility cluster “ralph agent containment”
+
+## what changed
+
+**commit range:** `main..HEAD`  
+**commits:** 7 (`8edd81b` → `d585ac0`)  
+**timeline:** 2026-05-19 to 2026-05-24
+
+| file | + | - | risk | notes |
+|------|---:|---:|------|-------|
+| `src/ralph-macchio.ts` | 87 | 90 | high | replaces stdout tag parsing with response-file contract; changes agent invocation and sandbox settings use |
+| `src/ralph-agent-command.ts` | 55 | 0 | high | codex/claude/gemini/cursor args; codex structured output flags |
+| `src/ralph-response.ts` | 101 | 0 | medium | validates structured response JSON |
+| `src/ralph-prompt.ts` | 64 | 0 | medium | prompt contract for response file |
+| `src/validation.ts` | 39 | 2 | high | srt write/network policy widened for git metadata + codex |
+| `src/ralph-git-exclude.ts` | 37 | 0 | medium | mutates `.git/info/exclude` to avoid transient commits |
+| `src/wolfpack-context.ts` | 38 | 0 | medium | progress counting from `progress.txt` |
+| `src/server/routes.ts` | 3 | 2 | medium | agent selection uses shared typed list |
+| `src/server/shell.ts` | 5 | 3 | low | agent type extraction |
+| `src/ralph-agent.ts` | 7 | 0 | low | shared agent enum |
+| `broker/src/bin/wolfpack-broker.rs` | 81 | 4 | low | srt-specific bind failure explanation |
+
+**total:** +1324 / -194 across 26 files.
+
+## findings
+
+### 🟡 medium: structured-response runner path lacks an end-to-end worker regression
+
+**file:** `src/ralph-macchio.ts:L945-L985`  
+**commit:** `9e4fa87` (`fix ralph structured agent responses`)  
+**blast radius:** medium — all ralph iterations for all agents flow through `runIteration()` and response classification  
+**test coverage:** partial
+
+**description:**
+The core behavior changed from parsing `<subtasks>` in stdout to requiring `.ralph-response.json`. Unit tests cover `buildAgentArgs()`, `parseRalphResponseJson()`, and prompt text, but no test executes the worker loop with a fake agent to prove the actual orchestration works: cwd selection, response path, pre-run cleanup, post-run classification, subtask append, and progress marking.
+
+Current evidence:
+- `tests/integration/ralph-api.test.ts` verifies `/api/ralph/start` spawn args only; it does not run `src/ralph-macchio.ts`.
+- `runIteration()` is private, so the new path at `src/ralph-macchio.ts:L945-L985` is not directly covered.
+- Targeted tests passed, but they are mostly unit seams around the orchestration rather than the orchestration itself.
+
+**why it matters:**
+A wrong response file path, cwd mismatch under worktree/task mode, or cleanup ordering bug would silently turn every successful agent run into “missing ralph response file” retries. That is a functional DoS of ralph loops, and the current tests would not catch it.
+
+**attack/misuse scenario:**
+1. authenticated user starts ralph with codex or claude.
+2. agent completes the task and exits `0`.
+3. runner looks for `.ralph-response.json` at the wrong cwd or after premature cleanup.
+4. runner logs “missing ralph response file” and retries until iteration budget is exhausted.
+5. user sees no completed progress despite successful agent work.
+
+**recommendation:**
+Add a worker-level regression that runs `src/ralph-macchio.ts` in a temp git repo with a fake agent binary on `PATH` that writes `.ralph-response.json`. Assert:
+- `status: "done"` marks the task complete in `progress.txt`.
+- `status: "needs_subtasks"` appends checkboxes and marks parent done.
+- transient response/schema files are not staged by `git add -A`.
+- at least one worktree mode (`--worktree plan` or `--worktree task`) resolves the response file from the active working dir.
+
+## test coverage analysis
+
+**coverage of changed behavior:** partial.
+
+| area | status | evidence |
+|------|--------|----------|
+| response parser | covered | `tests/unit/ralph-response.test.ts` |
+| agent arg builder | covered | `tests/unit/ralph-agent-command.test.ts` |
+| git excludes | covered | `tests/unit/ralph-git-exclude.test.ts` |
+| srt git/codex policy | covered | `tests/unit/ralph-sandbox.test.ts` |
+| worker loop response orchestration | missing | no test runs the worker with fake agent output |
+| broker srt explanation | covered | `cargo test --manifest-path broker/Cargo.toml --bin wolfpack-broker` |
+
+## blast radius analysis
+
+| function/symbol | refs found | risk | priority |
+|-----------------|-----------:|------|----------|
+| `buildSrtSettings` | 22 | high | p1 |
+| `buildAgentArgs` | 10 | high | p1 |
+| `classifyRalphResponseResult` | 8 | medium | p2 |
+| `countRalphProgressFromContent` | 7 | medium | p2 |
+| `ensureRalphTransientGitExcludes` | 7 | medium | p2 |
+| `runIteration` | 6 | high | p1 |
+
+## historical context
+
+- removed `parseSubtasks()` was introduced in `5ddc682` (`feat: ralph loop — automated iterative task execution (#26)`). Replacing this is a net improvement: it removes a fragile string-as-protocol parser over agent stdout.
+- prior srt sandbox support came from `2d6a9ca` (`feat: add srt sandbox wrapping for ralph agent workers (#63)`). This branch widens sandbox write scope for git metadata and codex state; docs explicitly record the accepted risk.
+- `buildSrtSettings` had prior audit-related changes in `b10399e`; no security hardening was removed in this diff.
+
+## adversarial analysis
+
+**attacker/misuse models considered:**
+- buggy or malicious agent process producing misleading stdout or response files.
+- authenticated user starting ralph with chosen agent/worktree/sandbox settings.
+- sandboxed agent trying to escape active worktree via git metadata or broker/socket access.
+
+**results:**
+- structured response file removes the previous stdout control-channel weakness (`<subtasks>` tag injection in transcript text).
+- default srt policy still denies local binding and host broker socket access; broker error text is diagnostic only.
+- git metadata write access and full `~/.codex` write access are widened, but documented as intentional and covered by tests. This is risk acceptance, not a hidden regression.
+- no auth bypass, shell metacharacter injection, or broker socket exposure found in changed lines.
+
+## verification performed
+
+```text
+bun test tests/unit/ralph-response.test.ts tests/unit/ralph-agent-command.test.ts tests/unit/ralph-git-exclude.test.ts tests/unit/ralph-sandbox.test.ts tests/unit/plan-parsing.test.ts
+# 113 pass, 0 fail
+
+bun run typecheck
+# passed
+
+cargo test --manifest-path broker/Cargo.toml --bin wolfpack-broker
+# 3 passed, 0 failed
+
+git diff --check main...HEAD
+# no whitespace errors
+```
+
+## limitations
+
+- did not run full `bun test` or Playwright e2e.
+- did not execute real codex/claude/gemini/cursor against live APIs.
+- did not execute ralph worker end-to-end with srt enabled; finding above recommends that missing regression.
+- edc context is from 2026-05-18 on `main`; branch has newer ralph-specific changes.
+
+## final recommendation
+
+**conditional approve.** The design fixes a real fragility by replacing stdout tag parsing with structured JSON. The main gap is test depth: this needs one worker-level fake-agent regression before merge, because unit tests alone do not protect the high-risk orchestration path.

--- a/docs/ralph-behavior.md
+++ b/docs/ralph-behavior.md
@@ -4,6 +4,8 @@
 
 Ralph is an iterative AI agent loop. It reads a plan file (PLAN.md), extracts tasks one at a time, runs an agent (claude/codex/gemini/cursor) on each, and tracks completion in a separate progress file. Supports worktree isolation, cleanup/audit phases, and multi-machine deployment.
 
+Ralph is opt-in in the UI: users must enable **Settings → Ralph Loop → Enable Ralph Loop** before Ralph controls appear. API routes still exist server-side; the setting gates UI visibility/discoverability.
+
 ---
 
 ## Files & State
@@ -191,7 +193,7 @@ Main worktree + per-section sub-worktrees:
 
 | Endpoint | Method | Body | Effect |
 |----------|--------|------|--------|
-| `/api/ralph/start` | POST | `{ project, iterations, planFile, agent, cleanup, auditFix, worktree, ... }` | Spawn worker, acquire lock |
+| `/api/ralph/start` | POST | `{ project, iterations, planFile, agent, cleanup, auditFix, worktree, ... }` | Spawn worker, acquire lock. UI access requires **Settings → Ralph Loop → Enable Ralph Loop**. |
 | `/api/ralph/cancel` | POST | `{ project }` | SIGTERM process + group, delete progress.txt |
 | `/api/ralph/dismiss` | POST | `{ project, deletePlan? }` | Delete log + lock + progress, optionally plan, cleanup worktrees |
 

--- a/docs/ralph-macchio.md
+++ b/docs/ralph-macchio.md
@@ -2,6 +2,10 @@
 
 Autonomous task runner. Write a markdown plan file, pick an agent, set iterations, and let it rip. Ralph reads the plan, extracts the first incomplete task, hands it to the agent, marks it done, and moves on — implementing, testing, and committing along the way.
 
+## Enable Ralph
+
+Ralph is opt-in. Open **Settings → Ralph Loop** and turn on **Enable Ralph Loop** before trying to start, monitor, or cancel loops. Until this setting is enabled, Ralph controls are intentionally hidden from the UI.
+
 ## Plan File Format
 
 Tasks use numbered markdown headers. Ralph recognizes this pattern and nothing else:
@@ -43,4 +47,4 @@ Each Ralph iteration:
 
 A final cleanup pass identifies and removes dead code after all tasks complete.
 
-Start, monitor, and cancel loops from your phone via the Ralph panel, or from the CLI.
+Start, monitor, and cancel loops from your phone via the Ralph panel after **Settings → Ralph Loop → Enable Ralph Loop** is on, or from the CLI.

--- a/tests/unit/ralph-worker-response.test.ts
+++ b/tests/unit/ralph-worker-response.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+const WORKER_PATH = join(import.meta.dir, "..", "..", "src", "ralph-macchio.ts");
+const EXTRA_PATHS = [
+  join(homedir(), ".local", "bin"),
+  join(homedir(), ".cargo", "bin"),
+  join(homedir(), ".bun", "bin"),
+  join(homedir(), ".npm-global", "bin"),
+  "/usr/local/bin",
+  "/opt/homebrew/bin",
+  "/opt/homebrew/sbin",
+];
+
+interface WorkerRunResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+let tmpRoot: string;
+let repoDir: string;
+let fakeBinDir: string;
+let fakeStatePath: string;
+
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync("git", ["-c", "commit.gpgsign=false", ...args], {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function createFakeClaude(): void {
+  const script = `#!/usr/bin/env bun
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const args = process.argv.slice(2);
+const outputArgIndex = args.indexOf("--output-last-message");
+const explicitOutputPath = outputArgIndex >= 0 ? args[outputArgIndex + 1] : undefined;
+const joinedArgs = args.join("\\n");
+const promptOutputPath = joinedArgs.match(/\\S+\\.ralph-response\\.json/)?.[0];
+const responsePath = explicitOutputPath || promptOutputPath;
+const statePath = process.env.FAKE_RALPH_STATE;
+const sequence = JSON.parse(process.env.FAKE_RALPH_SEQUENCE || '["done"]');
+const prior = statePath && existsSync(statePath) ? Number(readFileSync(statePath, "utf-8")) || 0 : 0;
+const kind = sequence[Math.min(prior, sequence.length - 1)] || "done";
+if (statePath) writeFileSync(statePath, String(prior + 1));
+
+if (kind !== "missing") {
+  if (!responsePath) throw new Error("fake agent could not find response path in args");
+  mkdirSync(dirname(responsePath), { recursive: true });
+  if (kind === "invalid") {
+    writeFileSync(responsePath, "not json");
+  } else if (kind === "needs_subtasks") {
+    writeFileSync(responsePath, JSON.stringify({
+      version: 1,
+      status: "needs_subtasks",
+      prereqs: ["fake prereq"],
+      tests: ["fake test"],
+      done: ["fake breakdown"],
+      subtasks: ["implement parser regression", "wire worker regression"],
+    }));
+  } else {
+    writeFileSync(responsePath, JSON.stringify({
+      version: 1,
+      status: "done",
+      prereqs: ["fake prereq"],
+      tests: ["fake test"],
+      done: ["fake done"],
+      subtasks: [],
+    }));
+  }
+}
+
+console.log(\`fake-agent-kind: \${kind}\`);
+`;
+
+  const fakeClaude = join(fakeBinDir, "claude");
+  writeFileSync(fakeClaude, script, { mode: 0o755 });
+}
+
+function initRepo(planContent: string): void {
+  repoDir = join(tmpRoot, "repo");
+  execFileSync("mkdir", ["-p", repoDir]);
+  git(repoDir, ["init"]);
+  git(repoDir, ["config", "user.name", "Test"]);
+  git(repoDir, ["config", "user.email", "test@example.com"]);
+  git(repoDir, ["checkout", "-b", "main"]);
+  writeFileSync(join(repoDir, "README.md"), "# test repo\n");
+  writeFileSync(join(repoDir, "PLAN.md"), planContent);
+  git(repoDir, ["add", "README.md", "PLAN.md"]);
+  git(repoDir, ["commit", "-m", "initial"]);
+}
+
+function workerPathEnv(): string {
+  const existing = process.env.PATH || "";
+  const knownPaths = EXTRA_PATHS.filter(path => existsSync(path));
+  return [fakeBinDir, ...knownPaths, existing].join(":");
+}
+
+function runWorker(sequence: readonly string[], extraArgs: readonly string[] = []): WorkerRunResult {
+  writeFileSync(fakeStatePath, "0");
+  const result = spawnSync("bun", [
+    WORKER_PATH,
+    "--plan", "PLAN.md",
+    "--progress", "progress.txt",
+    "--iterations", "1",
+    "--agent", "claude",
+    "--cleanup", "false",
+    "--audit-fix", "false",
+    "--sandbox", "false",
+    ...extraArgs,
+  ], {
+    cwd: repoDir,
+    env: {
+      ...process.env,
+      PATH: workerPathEnv(),
+      FAKE_RALPH_STATE: fakeStatePath,
+      FAKE_RALPH_SEQUENCE: JSON.stringify(sequence),
+    },
+    encoding: "utf-8",
+    timeout: 20_000,
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+  };
+}
+
+function expectWorkerSuccess(result: WorkerRunResult): void {
+  expect({ status: result.status, stderr: result.stderr, stdout: result.stdout }).toEqual({
+    status: 0,
+    stderr: "",
+    stdout: "",
+  });
+}
+
+function workdirFromLog(): string {
+  const log = readFileSync(join(repoDir, ".ralph.log"), "utf-8");
+  const match = log.match(/^workdir:\s*(.+)$/m);
+  return match?.[1]?.trim() || repoDir;
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "ralph-worker-response-"));
+  fakeBinDir = join(tmpRoot, "bin");
+  fakeStatePath = join(tmpRoot, "fake-agent-state.txt");
+  execFileSync("mkdir", ["-p", fakeBinDir]);
+  createFakeClaude();
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("ralph worker structured response contract", () => {
+  test("done response marks the current task completed through the real worker loop", () => {
+    initRepo("- [ ] ship structured response\n");
+
+    const result = runWorker(["done"]);
+
+    expectWorkerSuccess(result);
+    const progress = readFileSync(join(repoDir, "progress.txt"), "utf-8");
+    const log = readFileSync(join(repoDir, ".ralph.log"), "utf-8");
+    expect(progress).toContain("DONE: checkbox: ship structured response");
+    expect(log).toContain("all_tasks_done: true");
+    expect(log).not.toContain("missing ralph response file");
+    expect(existsSync(join(repoDir, ".ralph-response.json"))).toBe(false);
+  });
+
+  test("needs_subtasks response appends subtasks and marks the parent completed", () => {
+    initRepo("- [ ] break down broad task\n");
+
+    const result = runWorker(["needs_subtasks", "done", "done"]);
+
+    expectWorkerSuccess(result);
+    const plan = readFileSync(join(repoDir, "PLAN.md"), "utf-8");
+    const progress = readFileSync(join(repoDir, "progress.txt"), "utf-8");
+    expect(plan).toContain("- [ ] implement parser regression");
+    expect(plan).toContain("- [ ] wire worker regression");
+    expect(progress).toContain("DONE: checkbox: break down broad task");
+    expect(progress).toContain("DONE: checkbox: implement parser regression");
+    expect(progress).toContain("DONE: checkbox: wire worker regression");
+  });
+
+  test("missing response file leaves the task incomplete and logs a hard warning", () => {
+    initRepo("- [ ] require explicit response file\n");
+
+    const result = runWorker(["missing"]);
+
+    expectWorkerSuccess(result);
+    const progress = readFileSync(join(repoDir, "progress.txt"), "utf-8");
+    const log = readFileSync(join(repoDir, ".ralph.log"), "utf-8");
+    expect(progress).not.toContain("DONE: checkbox: require explicit response file");
+    expect(log).toContain("Iteration did not complete: missing ralph response file");
+  });
+
+  test("plan worktree mode reads response from the active worktree and excludes runner transients from git", () => {
+    initRepo("- [ ] complete from plan worktree\n");
+
+    const result = runWorker(["done"], ["--worktree", "plan"]);
+
+    expectWorkerSuccess(result);
+    const workdir = workdirFromLog();
+    const progress = readFileSync(join(workdir, "progress.txt"), "utf-8");
+    expect(progress).toContain("DONE: checkbox: complete from plan worktree");
+    expect(workdir).not.toBe(repoDir);
+
+    writeFileSync(join(workdir, ".ralph-response.json"), "{}\n");
+    writeFileSync(join(workdir, ".ralph-response-schema-123.json"), "{}\n");
+    writeFileSync(join(workdir, ".ralph-srt-settings-123.json"), "{}\n");
+    writeFileSync(join(workdir, ".ralph_iter.tmp"), "tmp\n");
+    writeFileSync(join(workdir, "progress.txt"), progress);
+    writeFileSync(join(workdir, "feature.ts"), "export const covered = true;\n");
+
+    git(workdir, ["add", "-A"]);
+    const staged = git(workdir, ["diff", "--cached", "--name-only"]);
+    expect(staged).toContain("feature.ts");
+    expect(staged).not.toContain(".ralph-response.json");
+    expect(staged).not.toContain(".ralph-response-schema-123.json");
+    expect(staged).not.toContain(".ralph-srt-settings-123.json");
+    expect(staged).not.toContain(".ralph_iter.tmp");
+    expect(staged).not.toContain("progress.txt");
+
+  });
+});


### PR DESCRIPTION
## Summary
- document that Ralph UI controls are gated behind Settings → Ralph Loop → Enable Ralph Loop
- add Ralph worker structured response regression tests
- include generated status/review notes from the dirty worktree

## Tests
- bun test tests/unit/ralph-worker-response.test.ts