### PR TITLE
Restore EDC review regression fixes

### DIFF
--- a/.claude/skills/wolfpack-ralph/SKILL.md
+++ b/.claude/skills/wolfpack-ralph/SKILL.md
@@ -1,18 +1,41 @@
 ---
 name: wolfpack-ralph
-description: Context injected into every ralph iteration prompt. Defines the subtask-breakdown output protocol and the user-notification endpoint. Loaded by src/wolfpack-context.ts and prepended to the prompt sent to claude/codex/cursor/gemini.
+description: Optional Ralph skill context for agents/users who install it. Defines the structured response expectations and user-notification endpoint; Wolfpack does not runtime-inject this skill into prompts.
 ---
 
 ## Ralph Agent Context
 
-When a task is too large to implement directly, output a <subtasks> block instead of making changes:
-```
-<subtasks>
-Implement auth middleware with JWT validation
-Add integration tests for auth endpoints
-</subtasks>
+Before exiting, write the structured JSON response file requested by the runner prompt. The response file is the ONLY runner control channel for every supported agent; do not emit XML-ish control tags in stdout.
+
+When a task is too large to implement directly, do not make code changes. Write a response with `"status": "needs_subtasks"` and `"subtasks"` as an array of meaningful deliverables:
+```json
+{
+  "version": 1,
+  "status": "needs_subtasks",
+  "prereqs": ["assumption or prerequisite"],
+  "tests": ["test command or planned test"],
+  "done": ["completion criterion"],
+  "subtasks": [
+    "Implement auth middleware with JWT validation",
+    "Add integration tests for auth endpoints"
+  ]
+}
 ```
 Each subtask = a meaningful deliverable (3-5 per breakdown). NOT single lines of code or imports — a unit of work a senior dev would recognize as coherent.
 
 To notify the user (push notification to their phone/desktop):
 curl -s http://localhost:18790/api/notify -H 'Content-Type: application/json' -d '{"message": "your message"}'
+
+## Srt Sandbox and Local Sockets
+
+Default Ralph srt is intentionally restrictive. Do not plan default-srt work that requires starting local listeners unless the plan explicitly includes a host/non-srt verification phase.
+
+Known default-srt blockers:
+- Unix domain socket bind/listen, including starting `wolfpack-broker` inside srt.
+- Localhost TCP bind/listen unless a socket-capable profile explicitly enables local binding.
+- Broker-backed perf/integration tests that spawn their own broker process.
+
+Preferred handling:
+- Normal Ralph tasks must not access Wolfpack's host broker socket from inside srt; broker socket access is equivalent to host PTY control.
+- For broker startup tests, perf harnesses, browser/dev servers, or anything that must bind/listen locally, run that step with `--sandbox false` or ask for an explicit socket-capable srt profile.
+- Do not enable `allowAllUnixSockets` in default Ralph runs. If a task truly needs Unix sockets inside srt, scope `network.allowUnixSockets` to the exact socket path/dir and ensure the socket directory is writable only when bind/listen is required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Startup Orientation
+
+This repository has EDC v2 architectural context.
+
+- Start with `edc-context/index.md` for the architecture overview.
+- Use `edc-context/manifest.json` as the authoritative routing and policy contract.
+- Current EDC runtime mode: `advisory`.

--- a/GRID_RENDER_FIX_STATUS.md
+++ b/GRID_RENDER_FIX_STATUS.md
@@ -1,0 +1,7 @@
+# grid render + loading transition fix status
+
+- [x] evidence: traced `addToGrid()` single→grid path; new grid cells are appended before async terminal mount starts hydration/loading.
+- [x] regression: added e2e assertion that grid cells show loading immediately after `addToGrid()`; observed red before fix.
+- [x] fix: new grid cells now enter `grid-loading` synchronously before async terminal mount.
+- [x] verify: narrow e2e passed after bundle/assets; full desktop grid e2e passed; typecheck passed; `bun test` passed.
+- [ ] verify: full Playwright suite has pre-existing/non-grid mobile broker failures at `POST /api/create`; desktop grid coverage passed.

--- a/RALPH_JSON_RESPONSE_STATUS.md
+++ b/RALPH_JSON_RESPONSE_STATUS.md
@@ -1,0 +1,48 @@
+# ralph json response status
+
+Goal: replace stdout `<subtasks>` control parsing with a dedicated json response file written by the agent and read by ralph.
+
+## status
+
+- [x] switch to pr branch `fix/ralph-codex-srt`
+- [x] inspect current ralph prompt/subtask flow
+- [x] add failing regression tests for json response parsing/prompting
+- [x] implement minimal json response reader + prompt wiring
+- [x] inspect stopped ralph log
+- [x] identify missing-response false-completion bug
+- [x] verify focused tests after missing-response fix
+- [x] run broader typecheck/tests if feasible
+
+## 2026-05-22 debug notes
+
+- `.ralph.log` shows the run was on `TERMINAL_LOAD_OPTIMIZATION_PLAN.md`, not the review-finding task.
+- Codex repeatedly logged `failed to refresh available models` from `https://chatgpt.com/backend-api/codex/models`; no srt permission-denied error appeared in the retained log.
+- User sent SIGTERM at `03:06:10`; shutdown cleanup ran and removed one worktree.
+- After SIGTERM, the main loop still resumed, logged `Missing ralph response file`, marked iteration 1 complete, and wrote a summary. root cause: missing/invalid `.ralph-response.json` was only warned, not treated as non-completion, and the loop did not bail after `stopping` became true.
+- Added `classifyRalphResponseResult()` tests: missing/invalid response files classify as `not_completed`; only explicit `done` marks completion; `needs_subtasks` expands subtasks.
+- Focused verification passed: `bun test tests/unit/ralph-response.test.ts tests/unit/ralph-prompt.test.ts tests/unit/ralph-sandbox.test.ts tests/unit/plan-parsing.test.ts` (103 pass).
+- Broader verification passed: `bun run typecheck`; `bun test` (1487 pass).
+- Full code-path trace found another cross-agent issue: the prompt showed invalid JSON (`"status": "done" | "needs_subtasks"`). Added a failing prompt test and replaced it with two valid JSON examples for every supported agent.
+- Fake-agent end-to-end smoke through `src/cli/index.ts worker` passed for `claude`, `codex`, `gemini`, and `cursor`: each fake binary extracted the response path from the real prompt, wrote `.ralph-response.json`, and ralph marked the checkbox done.
+- Smoke also exposed misleading summary progress (`plan progress: 0/1 done`) because `logSummary()` counted plan markers, not `progress.txt`. Added `countRalphProgressFromContent()` regression tests and changed the summary to use progress DONE keys. Re-run smoke now shows `plan progress: 1/1 done` for all four agents.
+- Second real Codex run still thrashed: repeated model-refresh noise plus apply_patch failures, no `.ralph-response.json` after several minutes. Root cause is Codex orchestration, not the JSON parser: ralph was asking Codex to manually write the response file instead of using Codex's native structured-output path.
+- Added `src/ralph-agent-command.ts`: Codex now runs with `codex exec --dangerously-bypass-approvals-and-sandbox --output-last-message <response-file> --output-schema <schema-file> <prompt>`. Removed legacy `--yolo` for Codex. Other agents keep existing invocations.
+- Added `tests/unit/ralph-agent-command.test.ts`; fake-agent smoke verifies the schema file exists and all four agents complete. Verification passed: `bun run typecheck`; `bun test` (1493 pass).
+- Real loop after deploy failed with proof in `.ralph.log`: Codex contacted the backend and got `400 invalid_json_schema` because `version`/`status` schema properties omitted `type`. This was not the primary sandbox failure: log showed ralph `sandbox: srt`, Codex internal `sandbox: danger-full-access`, then an OpenAI schema validation response. Fixed schema by adding `type: "number"` to `version` and `type: "string"` to `status`; regression test now covers both. Verification passed: `bun run typecheck`; `bun test` (1494 pass).
+- Debugged Codex refresh/app warnings with direct vs srt diagnostic runs. `wham/apps` reproduced only under srt and disappeared with `codex exec --disable apps`; Codex still completed and wrote the same `.ralph-response.json` contract. Added `--disable apps` to Codex invocation and a regression test that all agents receive the `.ralph-response.json` contract.
+- Real installed Codex+srt smoke after `--disable apps` completed successfully and had `wham=0`, `schema=0`, but still logged `failed to refresh available models` 7 times. The model-refresh warning is therefore not fixed by disabling apps and remains a Codex/backend/cache issue; it did not block completion in that smoke.
+- The same real smoke exposed Codex committing `.ralph-response.json`, then the runner deleting it as a transient file and leaving a `D .ralph-response.json` worktree status. Updated the prompt and regression tests to tell all agents not to commit runner-owned files: `.ralph-response.json`, progress/log/temp/schema/srt settings. Added `ensureRalphTransientGitExcludes()` so the active worktree's `.git/info/exclude` ignores runner-owned files and `git add -A` does not stage them.
+- Real Codex+srt smoke then failed at `git commit` because srt allowed the worktree but not linked-worktree git metadata. Added git metadata write allowances for normal repos and linked worktrees, documented the sandbox scope, and covered both cases in `ralph-sandbox.test.ts`.
+
+## why the initial review missed these follow-on bugs
+
+- The differential review explicitly scoped itself to committed `main...HEAD`. The JSON response files were dirty/untracked after the review, so the missing-response and invalid-json-shape bugs were not in the reviewed diff.
+- The review did catch the underlying design hole as M1: no trusted completion/subtask channel, and recommended a JSON response file plus loop-decision regression coverage.
+- The review did not execute a loop smoke. Static review found the contract gap, but the bad implementation details only surfaced once the new contract existed and a stopped/fake loop exercised it.
+- The misleading `plan progress: 0/1 done` summary was pre-existing/non-differential behavior from `logSummary()` counting plan markers instead of `progress.txt`; it was outside the codex+srt PR diff and not security-significant enough for that review mode.
+
+## assumptions
+
+1. every agent uses `.ralph-response.json` as the runner control channel.
+2. json schema should be tiny: response kind plus subtasks/tests/done/prereqs fields.
+3. stdout is never a runner control channel; missing/invalid response file means not complete.

--- a/RALPH_LOOP_INCIDENT.md
+++ b/RALPH_LOOP_INCIDENT.md
@@ -1,0 +1,81 @@
+# ralph loop incident — codex + srt + transcript subtask blow-up
+
+## summary
+
+ralph originally failed because `agent: codex` was run under `sandbox: srt`, but the srt settings only allowed writes to the worktree, `/tmp`, and `~/.claude`. codex needs writable state under `~/.codex`, so startup failed with a misleading ownership-style error:
+
+```text
+Codex cannot access session files at /Users/home/.codex/sessions (permission denied)
+```
+
+outside srt, `~/.codex/sessions` was writable, so ownership was not the root cause. the sandbox denied it.
+
+## quick local mitigation attempted
+
+we reran the same ralph loop with:
+
+```text
+--agent codex
+--sandbox false
+--worktree plan
+--worktree-branch edc-triage
+```
+
+this confirmed the sandbox was the immediate blocker: `.ralph.log` showed `sandbox: off`, codex started successfully, and iteration 1 completed.
+
+## what went wrong next
+
+once codex was allowed to run, ralph went runaway.
+
+root cause: ralph parses subtasks from raw agent stdout using a fragile text regex:
+
+```ts
+/<subtasks>([\s\S]*?)<\/subtasks>/
+```
+
+codex echoes the full prompt/transcript to stdout. the ralph prompt itself contains literal `<subtasks>` instructions, and later codex printed source/test content containing `</subtasks>`. ralph interpreted the giant transcript span between those markers as a real subtask block.
+
+result:
+
+- ralph appended thousands of bogus `- [ ] ...` checkbox tasks into `PLAN-edc-report-triage.md`
+- it logged `subtasks added: 5103`
+- iteration budget expanded from `5` to the ceiling `100`
+- ralph started executing garbage tasks from transcript/source text, e.g. `interface RalphStatus {` and `project: string;`
+- the root plan file was also corrupted because shutdown synced the worktree plan back to the project root
+
+## shutdown behavior observed
+
+we sent `SIGTERM`, then `SIGINT`. ralph logged shutdown and removed the lock, but the active iteration still completed after shutdown began and marked another bogus task done before process exit.
+
+so there is a second bug: signal handling sets `stopping`, but the active `runIteration()` close path can still continue the main loop's post-iteration completion logic.
+
+## final observed state
+
+- ralph process stopped
+- `.ralph.lock` removed
+- root git status only showed untracked local notes/plans:
+  - `AGENTS.md`
+  - `RALPH_CODEX_SRT_FIX_PLAN.md`
+- `PLAN-edc-report-triage.md` in root was corrupted with bogus checkbox subtasks
+- `.worktrees/edc-triage` was clean but had many commits from the runaway loop
+- latest observed branch head in that worktree: `76a7d30 make project directory configurable`
+
+## actual issues to fix
+
+1. make srt settings agent-aware
+   - codex needs write access to minimal `~/.codex` state paths
+   - codex needs network domains like `chatgpt.com` / `*.chatgpt.com`
+   - current sandbox config is claude-shaped only
+
+2. stop parsing subtasks from raw transcript stdout
+   - current `<subtasks>...</subtasks>` regex is string-as-protocol on human/log output
+   - codex transcript echo makes it unsafe
+   - fix should parse a structured final answer if available, or use a channel/file/protocol that cannot be confused with echoed prompt text
+
+3. harden shutdown
+   - after `SIGTERM`/`SIGINT`, active iteration close must not mark tasks done, append subtasks, expand budget, sync corrupted plans, or continue loop cleanup as if successful
+
+4. add regression tests
+   - codex/srt settings include required codex paths/domains
+   - subtask parser ignores echoed prompt/transcript markers
+   - shutdown during active iteration does not mark progress or mutate plan after stop begins

--- a/RALPH_PR_STATUS.md
+++ b/RALPH_PR_STATUS.md
@@ -1,0 +1,19 @@
+# ralph codex/srt pr status
+
+- [x] branch identified: `fix/ralph-codex-srt`
+- [x] reverted default srt host broker socket access
+- [x] docs updated for default-srt socket policy
+- [x] regression tests updated for no default `allowUnixSockets` / `allowAllUnixSockets`
+- [x] verification rerun after revert
+
+verification:
+- `bun test tests/unit/ralph-sandbox.test.ts` — 19 pass
+- `bun test` — 1501 pass
+- `bun run typecheck` — pass
+- `cargo test --manifest-path broker/Cargo.toml --bin wolfpack-broker` — 3 pass
+- `cargo test --manifest-path broker/Cargo.toml` — 164 pass total
+
+notes:
+- base branch: `main`
+- README checked; no srt socket policy text needed there
+- commit/push requested after this status update

--- a/RALPH_SETTINGS_DOC_STATUS.md
+++ b/RALPH_SETTINGS_DOC_STATUS.md
@@ -1,0 +1,5 @@
+# ralph settings documentation status
+
+- [x] identify ralph-facing docs
+- [ ] update docs to state ralph must be enabled in settings
+- [ ] verify text occurrences

--- a/RALPH_SRT_SOCKET_STATUS.md
+++ b/RALPH_SRT_SOCKET_STATUS.md
@@ -1,0 +1,15 @@
+# ralph srt socket status
+
+- [x] confirmed failure mode: broker startup inside default srt fails on unix socket bind/listen
+- [x] add explicit broker startup diagnostic for srt unix socket denial
+- [x] keep default ralph srt from accessing Wolfpack's host broker socket
+- [x] document ralph rule for plans needing unix socket bind/listen or host broker socket access
+- [x] add regression coverage that default srt has no `allowUnixSockets` / `allowAllUnixSockets`
+- [x] rerun focused + full verification after this revert
+
+verification:
+- `bun test tests/unit/ralph-sandbox.test.ts` — 19 pass
+- `bun test` — 1501 pass
+- `bun run typecheck` — pass
+- `cargo test --manifest-path broker/Cargo.toml --bin wolfpack-broker` — 3 pass
+- `cargo test --manifest-path broker/Cargo.toml` — 164 pass total across lib/bin/integration/fixtures/doc-tests

--- a/RALPH_WORKER_RESPONSE_TEST_STATUS.md
+++ b/RALPH_WORKER_RESPONSE_TEST_STATUS.md
@@ -1,0 +1,13 @@
+# ralph worker response test status
+
+- [x] identify coverage gap
+- [x] add fake-agent worker regression tests
+- [x] observe red failure before fixing test harness (`fake agent` script newline bug made the new tests fail)
+- [x] run narrow green verification
+- [x] run targeted broader verification
+
+## verification
+
+- `bun test tests/unit/ralph-worker-response.test.ts` → 4 pass
+- `bun test tests/unit/ralph-worker-response.test.ts tests/unit/ralph-response.test.ts tests/unit/ralph-agent-command.test.ts tests/unit/ralph-git-exclude.test.ts tests/unit/ralph-sandbox.test.ts tests/unit/plan-parsing.test.ts` → 117 pass
+- `bun run typecheck` → pass

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Scan the QR with your phone, tap **Add to Home Screen**, done.
 - **Desktop grid** — view up to 6 sessions side-by-side. Add via `+`, remove via `×`, `Cmd+ArrowLeft/Right` to navigate.
 - **Mobile-first terminal** — ghostty-web (WASM) emulator. Keyboard accessory bar (arrows, Esc, `git`, copy). On-screen keyboard suppressed until you ask for it. Long-press to select.
 - **PWA** — install on home screen. Notifications + vibration when sessions need attention. Reconnects on drop.
-- **Ralph loop** — autonomous task runner. Hand it a markdown plan, it iterates through tasks with an agent, committing along the way. See [docs/ralph-macchio.md](docs/ralph-macchio.md).
+- **Ralph loop** — autonomous task runner. Hand it a markdown plan, it iterates through tasks with an agent, committing along the way. Ralph controls are hidden until you enable **Settings → Ralph Loop → Enable Ralph Loop**. See [docs/ralph-macchio.md](docs/ralph-macchio.md).
 
 ## CLI
 

--- a/REVIEW_FIX_STATUS.md
+++ b/REVIEW_FIX_STATUS.md
@@ -1,0 +1,32 @@
+# review/audit fix status
+
+## goal
+address EDC review follow-ups from `review-HEAD.md`:
+1. restore Ralph structured response/control-channel behavior and regression tests
+2. restore transient git excludes and prompt/docs coverage
+3. restore Codex+srt sandbox allowances and socket-denial diagnostics/tests
+4. restore Ralph opt-in and srt/socket docs; correct skill runtime-injection claim
+5. cover reconnect banner behavior separately from fast broker reconnect recovery tests
+
+## progress
+- [x] inspect history/context
+- [x] add/restore coverage for Ralph response, sandbox, git-exclude, prompt, broker diagnostic
+- [x] implement Ralph structured response, transient excludes, Codex+srt, docs/skill fixes
+- [x] add deterministic reconnect-banner e2e coverage
+- [x] run verification
+- [ ] commit and push
+
+## evidence
+- review run succeeded with final report `review-HEAD.md`.
+- current branch: `pr-149`.
+- red observed: `bun test tests/unit/ralph-sandbox.test.ts` failed because git metadata dirs were absent from `buildSrtSettings().filesystem.allowWrite`.
+- targeted green: `bun test tests/unit/ralph-control.test.ts tests/unit/plan-parsing.test.ts tests/unit/ralph-sandbox.test.ts tests/unit/deploy-local.test.ts tests/integration/pty-takeover.test.ts` — 128 pass, 0 fail.
+- deterministic reconnect-banner test initially failed because stalling Playwright's routed websocket still opened the browser-side socket and hid the banner; switched reproduction to a browser network outage.
+- green: `bunx tsc --noEmit -p .`
+- green: `bunx tsc --noEmit -p public/`
+- green: `bun test tests/unit/ralph-response.test.ts tests/unit/ralph-agent-command.test.ts tests/unit/ralph-prompt.test.ts tests/unit/ralph-git-exclude.test.ts tests/unit/ralph-sandbox.test.ts tests/unit/ralph-worker-response.test.ts` — 42 pass, 0 fail.
+- green: `cargo test --manifest-path broker/Cargo.toml --bin wolfpack-broker` — 3 pass, 0 fail.
+- green: `bunx playwright test tests/e2e/reconnect.e2e.ts --grep "network outage|shows reconnecting banner"` — 4 pass, 2 skipped.
+- green: `bun test` — 1515 pass, 0 fail.
+- green: `cargo test --manifest-path broker/Cargo.toml` — 164 pass, 0 fail across lib/bin/integration/fixtures, 0 doctests.
+- green: `git diff --check && git diff --cached --check`.

--- a/TERMINAL_LOAD_OPTIMIZATION_PLAN.md
+++ b/TERMINAL_LOAD_OPTIMIZATION_PLAN.md
@@ -1,0 +1,141 @@
+# Plan: Terminal Load Optimization
+
+Status: drafted, not started.
+
+Goal: minimize perceived time from opening a session/cell to a usable terminal in both single-terminal and grid modes, while preserving correctness: no lost output, no stale prefill, no cross-cell leaks, no reconnect loops, no jarring blank/flash states.
+
+Success metrics to establish before optimizing:
+- Single mode: tap/open → terminal shell visible; tap/open → input accepted; reconnect → hydrated view stable.
+- Grid mode: add cell → first visible terminal content; add N cells → all cells usable; focus switch → input accepted.
+- Server path: WS upgrade → attach received → snapshot/prefill sent → subscribe active → first live byte forwarded.
+- UX smoothness: no blank > 250ms after route transition if cached snapshot exists; no content flash during hydration; no layout jump after final fit.
+
+Constraints:
+- Do not weaken the snapshot→subscribe gap protection.
+- Do not bypass per-cell isolated Ghostty WASM in grid mode.
+- Keep instrumentation gated or low-overhead; do not expose session contents in telemetry.
+- Every behavior change gets regression coverage before production changes.
+
+## 1. Add terminal-load timing instrumentation
+
+Map the real critical path before optimizing.
+
+Work:
+- Add a dev/debug-only timing trace for single mode and grid mode using `performance.mark()` / `performance.measure()` or the existing opt-in `wolfpackDebug` tracer.
+- Capture at least: openSession/addToGrid start, DOM view/cell created, Ghostty ready, terminal instance created, first fit, WS open, attach sent, attach_ack, prefill first chunk, prefill_done, pty_ready, hydration revealed, first input accepted.
+- Add matching server-side log timing around `/ws/pty`: upgrade accepted, attach parsed, resize settle start/end, snapshot fetch start/end, prefill send start/end, subscribe start/success, first output forward.
+- Redact session data; log only session name/mode/timing numbers.
+
+Acceptance:
+- A local debug run can produce a single waterfall for single mode.
+- A local debug run can produce one waterfall per grid cell.
+- Instrumentation is disabled or near-zero overhead by default.
+- Tests cover any pure timing helper/formatting logic added.
+
+## 2. Build a repeatable performance reproduction harness
+
+Make terminal load measurable without vibes.
+
+Work:
+- Add a Playwright or Bun integration harness that opens a known broker-backed session and records client timing marks.
+- Cover single mode and grid mode with 1, 2, 4, and 6 cells if the real broker is available; otherwise skip with a clear reason.
+- Include a synthetic slow-prefill scenario if feasible through existing test hooks or a focused mock boundary.
+- Write baseline numbers into the plan/status output, not hardcoded as pass/fail thresholds yet.
+
+Acceptance:
+- One command produces timing summaries for single and grid modes.
+- The harness can distinguish Ghostty creation time, WS/server time, prefill time, and hydration reveal time.
+- Existing test suite remains deterministic; perf harness is opt-in if noisy.
+
+## 3. Optimize single-terminal first paint and hydration
+
+Reduce user-visible blank time without hiding correctness bugs.
+
+Work:
+- Use baseline data to identify whether the largest cost is Ghostty init, route animation, fit/resize, snapshot prefill, hydration silence timers, or server subscribe.
+- If cached snapshot exists, render a non-authoritative placeholder/skeleton immediately while the real terminal hydrates, or shorten the blank route transition safely.
+- Review hydration thresholds (`minPendingMs`, `silenceMs`, fallback/safety timers) against measured write completion timing; lower only where evidence says safe.
+- Avoid double work on session switch: prevent duplicate fit/repaint/resize cycles if the terminal is about to reconnect anyway.
+
+Acceptance:
+- Single mode improves measured open→visible and open→usable time versus baseline.
+- Reconnect still preserves snapshot→subscribe correctness and does not lose live bytes.
+- Tests cover hydration reveal timing decisions or reconnect behavior affected by the change.
+
+## 4. Optimize server attach/prefill path
+
+Shorten backend time before the client can display stable terminal content.
+
+Work:
+- Use server timing to inspect resize-settle, quiescence wait, snapshot rendering, prefill chunking, and subscribe ordering.
+- For `prefillMode: viewport`, avoid full-scrollback work and unnecessary waits that only help full prefill.
+- Confirm `prefillMode: none` short-circuits all snapshot/quiescence work.
+- Consider sending `attach_ack` as early as safely possible, then stream prefill/live data in the current ordering contract.
+- Keep replay gap handling and `onSubscribeError` teardown intact.
+
+Acceptance:
+- Server-side attach timing improves for viewport and none prefill modes.
+- Full prefill behavior remains correct on desktop single mode.
+- Regression tests cover the ordering: attach_ack, prefill chunks, prefill_done, subscribe/live output, replay-truncated close.
+
+## 5. Optimize grid mounting and multi-cell concurrency
+
+Make grid cells appear progressively and avoid N-cell startup waterfalls.
+
+Work:
+- Audit `addToGrid()`, `renderGridCells()`, `mountGridController()`, `Promise.all(mountPromises)`, and `runGridRelayoutTransition()` for serialized work.
+- Connect each new cell as soon as its controller and first fit are ready instead of waiting on unrelated cells, unless layout correctness requires a barrier.
+- Avoid redundant fits caused by layout transition + controller init; batch relayout reads/writes to reduce forced reflow.
+- Keep focused-cell stdin routing and per-cell WASM isolation unchanged.
+
+Acceptance:
+- Grid mode shows each cell progressively rather than all-or-nothing when possible.
+- Adding 2/4/6 cells improves measured all-cells usable time and first-cell visible time.
+- Tests cover no cross-cell input leakage, no stale controller after remove/re-add, and no regression to shared WASM fallback.
+
+## 6. Smooth loading UX and failure states
+
+Optimize perception, not just raw milliseconds.
+
+Work:
+- Replace jarring blank/loading states with consistent skeleton/hydrating states that match single and grid modes.
+- Ensure cached snapshot, prefill loading, viewer conflict, displaced, and reconnect states have distinct visual states without flicker.
+- Add a visible but unobtrusive slow-path indicator when load exceeds a measured threshold.
+- Respect reduced-motion/no-animations settings.
+
+Acceptance:
+- No white/black flash or empty grid cell gap during normal load in single or grid mode.
+- Slow paths are explainable to the user without blocking interaction.
+- Visual changes have browser-level or DOM-level regression coverage where practical.
+
+## 7. Lock in budgets and regression tests
+
+Prevent terminal load from getting slow again.
+
+Work:
+- After optimization, record baseline and improved timings in this plan or a linked report.
+- Add stable assertions for ordering/correctness in unit/integration tests.
+- Add optional perf thresholds only if the harness is stable enough on local/CI machines; otherwise keep them advisory.
+- Update docs for the terminal load pipeline and any debug tools added.
+
+Acceptance:
+- `bun run typecheck` passes.
+- Relevant unit/integration tests pass.
+- Full `bun test` passes before final handoff.
+- The final report lists measured before/after timings for single mode and grid mode.
+
+- [ ] run the perf harness on a host that allows localhost and unix socket binding, then update docs/terminal-load-performance.md with actual measured before/after timings for single mode and grid mode
+- [ ] run full bun test on a host/test configuration that allows required local sockets, localhost servers, pgrep/sysmond access, and test-owned WOLFPACK_DIR writes
+- [ ] commit the code/doc/test changes from a context allowed to write the shared git common dir
+
+- [ ] run `bun run perf:terminal-load` on a host where both localhost TCP listen and Unix socket listen succeed, capture the JSON summary for current improved timings
+- [ ] run the same harness against the pre-optimization baseline, capture single:1 and grid:2/grid:4/grid:6 hydration reveal timings, then update `docs/terminal-load-performance.md` with measured before/after values and commit only the doc change
+
+- [ ] run on a host profile where bun/node can bind localhost port 0 and listen on required unix sockets, including hardcoded /tmp broker-client sockets
+- [ ] allow pgrep/sysmond process-list access for ralph pid liveness tests
+- [ ] build/provide WOLFPACK_BROKER_BIN, then rerun full bun test with WOLFPACK_TEST=1 and test-owned HOME/WOLFPACK_DIR
+
+- [ ] run the perf harness on a host where localhost and unix socket binding are permitted and capture after-state json for single:1 and grid:2/grid:4/grid:6
+- [ ] measure the before baseline from main/base on the same host, update docs/terminal-load-performance.md with actual before/after timings, then commit only the doc change
+
+- [ ] commit the existing worktree changes from an execution context with write permission to the shared git common dir, excluding runner-owned transient files and TERMINAL_LOAD_OPTIMIZATION_PLAN.md

--- a/WOLFPACK_DIFFERENTIAL_REVIEW_2026-05-24.md
+++ b/WOLFPACK_DIFFERENTIAL_REVIEW_2026-05-24.md
@@ -1,0 +1,151 @@
+# wolfpack differential review — 2026-05-24
+
+**target:** `fix/ralph-codex-srt` (`d585ac0`)
+**baseline:** `main` (`git diff main...HEAD`, merge-base `ef18a86faded155208d98f3a9b5cb78f8bc3ffcf`)
+**mode:** standalone edc-review
+**strategy:** surgical/focused — large repo (2101 code files), high-risk ralph/sandbox paths reviewed deeply
+
+## executive summary
+
+| severity | count |
+|----------|-------|
+| 🔴 critical | 0 |
+| 🟠 high | 0 |
+| 🟡 medium | 1 |
+| 🟢 low | 0 |
+
+**overall risk:** medium
+**recommendation:** conditional — code direction is sound; add a worker-level regression test before merge.
+
+**key metrics:**
+- files changed: 26
+- production files analyzed: 11/11 changed ts/rs files
+- tests run during review: targeted unit suite, typecheck, broker-bin unit tests
+- high-risk areas: ralph worker subprocess, srt sandbox policy, git metadata write scope, structured agent control channel
+- known edc issues touched: no direct open issue fix/regression found; change intersects core fragility cluster “ralph agent containment”
+
+## what changed
+
+**commit range:** `main..HEAD`
+**commits:** 7 (`8edd81b` → `d585ac0`)
+**timeline:** 2026-05-19 to 2026-05-24
+
+| file | + | - | risk | notes |
+|------|---:|---:|------|-------|
+| `src/ralph-macchio.ts` | 87 | 90 | high | replaces stdout tag parsing with response-file contract; changes agent invocation and sandbox settings use |
+| `src/ralph-agent-command.ts` | 55 | 0 | high | codex/claude/gemini/cursor args; codex structured output flags |
+| `src/ralph-response.ts` | 101 | 0 | medium | validates structured response JSON |
+| `src/ralph-prompt.ts` | 64 | 0 | medium | prompt contract for response file |
+| `src/validation.ts` | 39 | 2 | high | srt write/network policy widened for git metadata + codex |
+| `src/ralph-git-exclude.ts` | 37 | 0 | medium | mutates `.git/info/exclude` to avoid transient commits |
+| `src/wolfpack-context.ts` | 38 | 0 | medium | progress counting from `progress.txt` |
+| `src/server/routes.ts` | 3 | 2 | medium | agent selection uses shared typed list |
+| `src/server/shell.ts` | 5 | 3 | low | agent type extraction |
+| `src/ralph-agent.ts` | 7 | 0 | low | shared agent enum |
+| `broker/src/bin/wolfpack-broker.rs` | 81 | 4 | low | srt-specific bind failure explanation |
+
+**total:** +1324 / -194 across 26 files.
+
+## findings
+
+### 🟡 medium: structured-response runner path lacks an end-to-end worker regression
+
+**file:** `src/ralph-macchio.ts:L945-L985`
+**commit:** `9e4fa87` (`fix ralph structured agent responses`)
+**blast radius:** medium — all ralph iterations for all agents flow through `runIteration()` and response classification
+**test coverage:** partial
+
+**description:**
+The core behavior changed from parsing `<subtasks>` in stdout to requiring `.ralph-response.json`. Unit tests cover `buildAgentArgs()`, `parseRalphResponseJson()`, and prompt text, but no test executes the worker loop with a fake agent to prove the actual orchestration works: cwd selection, response path, pre-run cleanup, post-run classification, subtask append, and progress marking.
+
+Current evidence:
+- `tests/integration/ralph-api.test.ts` verifies `/api/ralph/start` spawn args only; it does not run `src/ralph-macchio.ts`.
+- `runIteration()` is private, so the new path at `src/ralph-macchio.ts:L945-L985` is not directly covered.
+- Targeted tests passed, but they are mostly unit seams around the orchestration rather than the orchestration itself.
+
+**why it matters:**
+A wrong response file path, cwd mismatch under worktree/task mode, or cleanup ordering bug would silently turn every successful agent run into “missing ralph response file” retries. That is a functional DoS of ralph loops, and the current tests would not catch it.
+
+**attack/misuse scenario:**
+1. authenticated user starts ralph with codex or claude.
+2. agent completes the task and exits `0`.
+3. runner looks for `.ralph-response.json` at the wrong cwd or after premature cleanup.
+4. runner logs “missing ralph response file” and retries until iteration budget is exhausted.
+5. user sees no completed progress despite successful agent work.
+
+**recommendation:**
+Add a worker-level regression that runs `src/ralph-macchio.ts` in a temp git repo with a fake agent binary on `PATH` that writes `.ralph-response.json`. Assert:
+- `status: "done"` marks the task complete in `progress.txt`.
+- `status: "needs_subtasks"` appends checkboxes and marks parent done.
+- transient response/schema files are not staged by `git add -A`.
+- at least one worktree mode (`--worktree plan` or `--worktree task`) resolves the response file from the active working dir.
+
+## test coverage analysis
+
+**coverage of changed behavior:** partial.
+
+| area | status | evidence |
+|------|--------|----------|
+| response parser | covered | `tests/unit/ralph-response.test.ts` |
+| agent arg builder | covered | `tests/unit/ralph-agent-command.test.ts` |
+| git excludes | covered | `tests/unit/ralph-git-exclude.test.ts` |
+| srt git/codex policy | covered | `tests/unit/ralph-sandbox.test.ts` |
+| worker loop response orchestration | missing | no test runs the worker with fake agent output |
+| broker srt explanation | covered | `cargo test --manifest-path broker/Cargo.toml --bin wolfpack-broker` |
+
+## blast radius analysis
+
+| function/symbol | refs found | risk | priority |
+|-----------------|-----------:|------|----------|
+| `buildSrtSettings` | 22 | high | p1 |
+| `buildAgentArgs` | 10 | high | p1 |
+| `classifyRalphResponseResult` | 8 | medium | p2 |
+| `countRalphProgressFromContent` | 7 | medium | p2 |
+| `ensureRalphTransientGitExcludes` | 7 | medium | p2 |
+| `runIteration` | 6 | high | p1 |
+
+## historical context
+
+- removed `parseSubtasks()` was introduced in `5ddc682` (`feat: ralph loop — automated iterative task execution (#26)`). Replacing this is a net improvement: it removes a fragile string-as-protocol parser over agent stdout.
+- prior srt sandbox support came from `2d6a9ca` (`feat: add srt sandbox wrapping for ralph agent workers (#63)`). This branch widens sandbox write scope for git metadata and codex state; docs explicitly record the accepted risk.
+- `buildSrtSettings` had prior audit-related changes in `b10399e`; no security hardening was removed in this diff.
+
+## adversarial analysis
+
+**attacker/misuse models considered:**
+- buggy or malicious agent process producing misleading stdout or response files.
+- authenticated user starting ralph with chosen agent/worktree/sandbox settings.
+- sandboxed agent trying to escape active worktree via git metadata or broker/socket access.
+
+**results:**
+- structured response file removes the previous stdout control-channel weakness (`<subtasks>` tag injection in transcript text).
+- default srt policy still denies local binding and host broker socket access; broker error text is diagnostic only.
+- git metadata write access and full `~/.codex` write access are widened, but documented as intentional and covered by tests. This is risk acceptance, not a hidden regression.
+- no auth bypass, shell metacharacter injection, or broker socket exposure found in changed lines.
+
+## verification performed
+
+```text
+bun test tests/unit/ralph-response.test.ts tests/unit/ralph-agent-command.test.ts tests/unit/ralph-git-exclude.test.ts tests/unit/ralph-sandbox.test.ts tests/unit/plan-parsing.test.ts
+# 113 pass, 0 fail
+
+bun run typecheck
+# passed
+
+cargo test --manifest-path broker/Cargo.toml --bin wolfpack-broker
+# 3 passed, 0 failed
+
+git diff --check main...HEAD
+# no whitespace errors
+```
+
+## limitations
+
+- did not run full `bun test` or Playwright e2e.
+- did not execute real codex/claude/gemini/cursor against live APIs.
+- did not execute ralph worker end-to-end with srt enabled; finding above recommends that missing regression.
+- edc context is from 2026-05-18 on `main`; branch has newer ralph-specific changes.
+
+## final recommendation
+
+**conditional approve.** The design fixes a real fragility by replacing stdout tag parsing with structured JSON. The main gap is test depth: this needs one worker-level fake-agent regression before merge, because unit tests alone do not protect the high-risk orchestration path.

--- a/broker/src/bin/wolfpack-broker.rs
+++ b/broker/src/bin/wolfpack-broker.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::io;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use tokio::signal::unix::{signal, SignalKind};
@@ -30,7 +31,7 @@ async fn main() {
     let registry = Arc::new(Registry::new(events.clone()));
     spawn_exit_reaper(&registry);
     let server = match start(ServerConfig {
-        socket_path,
+        socket_path: socket_path.clone(),
         router: Arc::new(SessionRouter::new(Arc::clone(&registry), events.clone())),
         registry: Arc::clone(&registry),
         events,
@@ -41,6 +42,9 @@ async fn main() {
         Ok(s) => s,
         Err(e) => {
             error!(error = %e, "broker failed to start");
+            if let Some(explanation) = srt_unix_socket_bind_explanation(&socket_path, &e) {
+                eprintln!("{explanation}");
+            }
             std::process::exit(1);
         }
     };
@@ -52,12 +56,41 @@ async fn main() {
 }
 
 fn init_logging() {
-    let filter = EnvFilter::try_from_env("WOLFPACK_BROKER_LOG")
-        .unwrap_or_else(|_| EnvFilter::new("info"));
+    let filter =
+        EnvFilter::try_from_env("WOLFPACK_BROKER_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
     tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_writer(std::io::stderr)
         .init();
+}
+
+fn srt_unix_socket_bind_explanation(socket_path: &Path, error: &io::Error) -> Option<String> {
+    srt_unix_socket_bind_explanation_for(
+        std::env::var_os("SANDBOX_RUNTIME").is_some(),
+        socket_path,
+        error,
+    )
+}
+
+fn srt_unix_socket_bind_explanation_for(
+    sandbox_runtime: bool,
+    socket_path: &Path,
+    error: &io::Error,
+) -> Option<String> {
+    if !sandbox_runtime || error.kind() != io::ErrorKind::PermissionDenied {
+        return None;
+    }
+
+    let parent = socket_path
+        .parent()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| ".".to_string());
+
+    Some(format!(
+        "wolfpack-broker cannot start inside srt: default srt blocks Unix domain socket bind/listen. socket: {}. Run broker startup/perf tests outside srt, use a host broker and let sandboxed clients connect to it, or use a dedicated srt settings file with network.allowUnixSockets including this socket path and filesystem.allowWrite including its parent directory ({}). Do not enable allowAllUnixSockets for default Ralph runs.",
+        socket_path.display(),
+        parent,
+    ))
 }
 
 async fn wait_for_signal() {
@@ -78,5 +111,49 @@ async fn wait_for_signal() {
     tokio::select! {
         _ = term.recv() => info!("received SIGTERM"),
         _ = intr.recv() => info!("received SIGINT"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explains_srt_permission_denied_on_unix_socket_bind() {
+        let err = io::Error::from(io::ErrorKind::PermissionDenied);
+        let message = srt_unix_socket_bind_explanation_for(
+            true,
+            Path::new("/tmp/wolfpack-broker.sock"),
+            &err,
+        )
+        .expect("expected srt bind explanation");
+
+        assert!(message.contains("cannot start inside srt"));
+        assert!(message.contains("Unix domain socket bind/listen"));
+        assert!(message.contains("network.allowUnixSockets"));
+        assert!(message.contains("filesystem.allowWrite"));
+        assert!(message.contains("/tmp"));
+    }
+
+    #[test]
+    fn does_not_explain_non_srt_permission_denied() {
+        let err = io::Error::from(io::ErrorKind::PermissionDenied);
+        assert!(srt_unix_socket_bind_explanation_for(
+            false,
+            Path::new("/tmp/wolfpack-broker.sock"),
+            &err,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn does_not_explain_other_start_errors() {
+        let err = io::Error::from(io::ErrorKind::AddrInUse);
+        assert!(srt_unix_socket_bind_explanation_for(
+            true,
+            Path::new("/tmp/wolfpack-broker.sock"),
+            &err,
+        )
+        .is_none());
     }
 }

--- a/docs/ralph-behavior.md
+++ b/docs/ralph-behavior.md
@@ -4,6 +4,8 @@
 
 Ralph is an iterative AI agent loop. It reads a plan file (PLAN.md), extracts tasks one at a time, runs an agent (claude/codex/gemini/cursor) on each, and tracks completion in a separate progress file. Supports worktree isolation, cleanup/audit phases, and multi-machine deployment.
 
+Ralph is opt-in in the UI: users must enable **Settings → Ralph Loop → Enable Ralph Loop** before Ralph controls appear. API routes still exist server-side; the setting gates UI visibility/discoverability.
+
 ---
 
 ## Files & State
@@ -15,6 +17,7 @@ Ralph is an iterative AI agent loop. It reads a plan file (PLAN.md), extracts ta
 | `.ralph.log` | Iteration output, status detection, summary. Contains `all_tasks_done: true` when worker confirms completion. Overwritten each run. | Deleted on dismiss |
 | `.ralph.lock` | Empty file, presence = lock held. Prevents concurrent runs. | Deleted on cancel/dismiss/exit |
 | `.ralph_iter.tmp` | Last iteration's raw agent output. Cleaned up per iteration. | Transient |
+| `.ralph-response.json` | Structured per-iteration agent response. The runner reads this for completion/subtask decisions instead of parsing stdout. All agents use this same file/schema contract. | Transient |
 
 ---
 
@@ -98,13 +101,12 @@ For each iteration `i` from 1 to `maxIterations`:
 
 7. **Check exit code** — if non-zero, log failure, continue
 
-8. **Subtask detection** — parse `<subtasks>` block:
-   - Append to plan as `- [ ]` checkboxes
-   - Mark parent done in progress
-   - Expand iteration budget
-   - Continue (don't mark parent done again)
+8. **Structured response detection** — read `.ralph-response.json`:
+   - Require valid JSON with `version: 1` and `status: "done" | "needs_subtasks"`
+   - Missing/invalid response means the task is not complete
+   - For `needs_subtasks`, append `subtasks` strings to plan as `- [ ]` checkboxes, mark parent done, expand iteration budget, and continue
 
-9. **Mark task complete** — append to progress.txt
+9. **Mark task complete** — only after an explicit `status: "done"`, append to progress.txt
 
 10. **Sync** progress back from sub-worktree, sync plan to project dir
 
@@ -191,7 +193,7 @@ Main worktree + per-section sub-worktrees:
 
 | Endpoint | Method | Body | Effect |
 |----------|--------|------|--------|
-| `/api/ralph/start` | POST | `{ project, iterations, planFile, agent, cleanup, auditFix, worktree, ... }` | Spawn worker, acquire lock |
+| `/api/ralph/start` | POST | `{ project, iterations, planFile, agent, cleanup, auditFix, worktree, ... }` | Spawn worker, acquire lock. UI access requires **Settings → Ralph Loop → Enable Ralph Loop**. |
 | `/api/ralph/cancel` | POST | `{ project }` | SIGTERM process + group, delete progress.txt |
 | `/api/ralph/dismiss` | POST | `{ project, deletePlan? }` | Delete log + lock + progress, optionally plan, cleanup worktrees |
 
@@ -243,22 +245,41 @@ Task counts (for progress bar display): `tasksTotal` from plan file, `tasksDone`
 
 ---
 
-## Subtask Protocol
+## Structured Response Protocol
 
-When a task is too large, the agent outputs:
-```
-<subtasks>
-Subtask description A
-Subtask description B
-</subtasks>
+Every agent uses the same runner contract: write `.ralph-response.json` before exit. Codex is invoked with native structured-output flags (`--output-last-message` + `--output-schema`); claude/gemini/cursor are prompted to write the same file and schema. The response file and other `.ralph-*`/progress/log files are runner-owned transient files and must not be committed. Ralph also adds these transient paths to the active worktree's `.git/info/exclude` so `git add -A` does not stage them.
+
+Done response:
+```json
+{
+  "version": 1,
+  "status": "done",
+  "prereqs": ["assumption or prerequisite"],
+  "tests": ["test command or planned test"],
+  "done": ["completion criterion met"],
+  "subtasks": []
+}
 ```
 
-Ralph then:
-1. Strips markdown headers and `~~` from subtask text
-2. Appends as `- [ ] <subtask>` checkboxes to plan
-3. Marks parent task done in progress (never re-picked)
-4. Expands iteration budget: `maxIterations += subtasks.length`
-5. Cap: max 5 expansions, ceiling at `max(ITERATIONS*2, 100)`
+Needs-subtasks response:
+```json
+{
+  "version": 1,
+  "status": "needs_subtasks",
+  "prereqs": ["assumption or prerequisite"],
+  "tests": ["test command or planned test"],
+  "done": ["completion criterion"],
+  "subtasks": ["Subtask description A", "Subtask description B"]
+}
+```
+
+For `needs_subtasks`, Ralph then:
+1. Validates the JSON response schema
+2. Strips markdown headers and `~~` from subtask text
+3. Appends as `- [ ] <subtask>` checkboxes to plan
+4. Marks parent task done in progress (never re-picked)
+5. Expands iteration budget: `maxIterations += subtasks.length`
+6. Cap: max 5 expansions, ceiling at `max(ITERATIONS*2, 100)`
 
 ---
 
@@ -281,11 +302,17 @@ Ralph then:
 | Agent | Binary | Key flags |
 |-------|--------|-----------|
 | claude | `claude` | `--print --dangerously-skip-permissions --allowedTools [...]` |
-| codex | `codex` | Agent-specific flags |
+| codex | `codex` | `exec --disable apps --dangerously-bypass-approvals-and-sandbox --output-last-message <response> --output-schema <schema>` |
 | cursor | `cursor` | Agent-specific flags |
 | gemini | `gemini` | Agent-specific flags |
 
 Allowed tools: Edit, Write, Read, Glob, Grep, Bash (git, npm, bun, cargo, go, python, make, ls, mkdir, rm, mv, cp, cat, echo, touch)
+
+### Srt sandbox policy
+
+Ralph's srt settings are project-scoped by default: write access is limited to the active worktree, `/tmp`, the active repository's git metadata directories, and the agent's required home-state directory. Git metadata write access is required so sandboxed agents can create commits from normal repos and linked worktrees; it intentionally includes the common git dir for linked worktrees. For Codex, the sandbox intentionally allows writes to the full `~/.codex` directory and network access to `chatgpt.com` / `*.chatgpt.com`. This is broader persistent state access than the project worktree; it is accepted because Codex initializes mutable state under `~/.codex` before stable per-session subpaths exist. Codex is run with `--disable apps` because Ralph does not need Codex app/plugin tooling and the apps worker emits sandbox-specific `wham/apps` transport warnings. Do not widen this further without a failing Codex+srt smoke log and a regression test.
+
+Default Ralph srt does not allow local listener creation or host broker socket access. Plans or verification steps that need Unix domain socket bind/listen (for example, starting `wolfpack-broker` inside srt), localhost TCP bind/listen, browser/dev servers, broker-backed perf/integration tests, or direct access to Wolfpack's broker socket must run that phase outside srt (`--sandbox false`) or use an explicitly requested socket-capable profile. Do not enable `allowAllUnixSockets` in default Ralph runs. If a task truly needs Unix socket access inside srt, the profile must scope `network.allowUnixSockets` to the exact socket path/dir and ensure the socket directory is writable only when bind/listen is required.
 
 ---
 

--- a/docs/ralph-macchio.md
+++ b/docs/ralph-macchio.md
@@ -2,6 +2,10 @@
 
 Autonomous task runner. Write a markdown plan file, pick an agent, set iterations, and let it rip. Ralph reads the plan, extracts the first incomplete task, hands it to the agent, marks it done, and moves on — implementing, testing, and committing along the way.
 
+## Enable Ralph
+
+Ralph is opt-in. Open **Settings → Ralph Loop** and turn on **Enable Ralph Loop** before trying to start, monitor, or cancel loops. Until this setting is enabled, Ralph controls are intentionally hidden from the UI.
+
 ## Plan File Format
 
 Tasks use numbered markdown headers. Ralph recognizes this pattern and nothing else:
@@ -43,4 +47,4 @@ Each Ralph iteration:
 
 A final cleanup pass identifies and removes dead code after all tasks complete.
 
-Start, monitor, and cancel loops from your phone via the Ralph panel, or from the CLI.
+Start, monitor, and cancel loops from your phone via the Ralph panel after **Settings → Ralph Loop → Enable Ralph Loop** is on, or from the CLI.

--- a/src/ralph-agent-command.ts
+++ b/src/ralph-agent-command.ts
@@ -1,0 +1,55 @@
+import type { RalphAgent } from "./ralph-agent.js";
+import { RALPH_RESPONSE_VERSION, RalphResponseStatus } from "./ralph-response.js";
+
+export const RALPH_ALLOWED_TOOLS = [
+  "Edit", "Write", "Read", "Glob", "Grep",
+  "Bash(git *)", "Bash(npm *)", "Bash(npx *)", "Bash(pnpm *)",
+  "Bash(yarn *)", "Bash(bun *)", "Bash(cargo *)", "Bash(go *)",
+  "Bash(python *)", "Bash(pip *)", "Bash(pytest *)", "Bash(make *)",
+  "Bash(ls *)", "Bash(mkdir *)", "Bash(rm *)", "Bash(mv *)",
+  "Bash(cp *)", "Bash(cat *)", "Bash(echo *)", "Bash(touch *)",
+].join(",");
+
+export const RALPH_RESPONSE_JSON_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["version", "status", "prereqs", "tests", "done", "subtasks"],
+  properties: {
+    version: { type: "number", const: RALPH_RESPONSE_VERSION },
+    status: { type: "string", enum: [RalphResponseStatus.done, RalphResponseStatus.needsSubtasks] },
+    prereqs: { type: "array", items: { type: "string" } },
+    tests: { type: "array", items: { type: "string" } },
+    done: { type: "array", items: { type: "string" } },
+    subtasks: { type: "array", items: { type: "string" } },
+  },
+} as const;
+
+export interface BuildAgentArgsOptions {
+  readonly prompt: string;
+  readonly responseFile: string;
+  readonly responseSchemaFile: string;
+}
+
+export function agentBinaryName(agent: RalphAgent): string {
+  return agent === "cursor" ? "agent" : agent;
+}
+
+export function buildAgentArgs(agent: RalphAgent, options: BuildAgentArgsOptions): string[] {
+  switch (agent) {
+    case "claude":
+      return ["--model", "sonnet", "--print", "--dangerously-skip-permissions", "--allowedTools", RALPH_ALLOWED_TOOLS, "-p", options.prompt];
+    case "codex":
+      return [
+        "exec",
+        "--disable", "apps",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--output-last-message", options.responseFile,
+        "--output-schema", options.responseSchemaFile,
+        options.prompt,
+      ];
+    case "gemini":
+      return ["-p", options.prompt, "--yolo"];
+    case "cursor":
+      return ["-p", options.prompt, "--yolo"];
+  }
+}

--- a/src/ralph-agent.ts
+++ b/src/ralph-agent.ts
@@ -1,0 +1,7 @@
+export const RALPH_AGENTS = ["claude", "codex", "gemini", "cursor"] as const;
+
+export type RalphAgent = (typeof RALPH_AGENTS)[number];
+
+export function isRalphAgent(agent: string): agent is RalphAgent {
+  return (RALPH_AGENTS as readonly string[]).includes(agent);
+}

--- a/src/ralph-git-exclude.ts
+++ b/src/ralph-git-exclude.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join } from "node:path";
+
+export const RALPH_TRANSIENT_GIT_EXCLUDES = [
+  ".ralph-response.json",
+  ".ralph-response-schema-*.json",
+  ".ralph-srt-settings-*.json",
+  ".ralph.log",
+  ".ralph.lock",
+  ".ralph_iter.tmp",
+] as const;
+
+export function ensureRalphTransientGitExcludes(cwd: string, progressFile: string): void {
+  let excludePath: string;
+  try {
+    const gitPath = execFileSync("git", ["rev-parse", "--git-path", "info/exclude"], {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    excludePath = isAbsolute(gitPath) ? gitPath : join(cwd, gitPath);
+  } catch {
+    return;
+  }
+
+  const patterns = [...RALPH_TRANSIENT_GIT_EXCLUDES, progressFile];
+  const existing = existsSync(excludePath) ? readFileSync(excludePath, "utf-8") : "";
+  const existingLines = new Set(existing.split(/\r?\n/).map(line => line.trim()).filter(Boolean));
+  const missing = patterns.filter(pattern => !existingLines.has(pattern));
+  if (missing.length === 0) return;
+
+  mkdirSync(dirname(excludePath), { recursive: true });
+  const prefix = existing.endsWith("\n") || existing.length === 0 ? "" : "\n";
+  const header = existing.includes("# ralph transient files") ? "" : "# ralph transient files\n";
+  writeFileSync(excludePath, `${existing}${prefix}${header}${missing.join("\n")}\n`);
+}

--- a/src/ralph-macchio.ts
+++ b/src/ralph-macchio.ts
@@ -17,8 +17,13 @@ import { execFileSync, spawn as nodeSpawn } from "node:child_process";
 import { writeFileSync, appendFileSync, readFileSync, existsSync, unlinkSync, copyFileSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
-import { TASK_HEADER, countTasksInContent, validatePlanFormat } from "./wolfpack-context.js";
-import { classifyRalphIterationOutput } from "./ralph-control.js";
+import type { RalphAgent } from "./ralph-agent.js";
+import { RALPH_AGENTS, isRalphAgent } from "./ralph-agent.js";
+import { agentBinaryName, buildAgentArgs, RALPH_RESPONSE_JSON_SCHEMA } from "./ralph-agent-command.js";
+import { ensureRalphTransientGitExcludes } from "./ralph-git-exclude.js";
+import { buildIterationPrompt } from "./ralph-prompt.js";
+import { classifyRalphResponseResult, readRalphResponseFile } from "./ralph-response.js";
+import { TASK_HEADER, countRalphProgressFromContent, countTasksInContent, validatePlanFormat } from "./wolfpack-context.js";
 import { expandBudget, resolveCleanupDiffBase, buildSrtSettings, shellEscape } from "./validation.js";
 import { buildAuditFixPrompt } from "./ralph-skill-audit.js";
 import { buildCleanupPrompt } from "./ralph-skill-cleanup.js";
@@ -45,7 +50,12 @@ const { values: args } = parseArgs({
 const ITERATIONS = Number(args.iterations) || 5;
 const PLAN_FILE = args.plan!;
 const PROGRESS_FILE = args.progress!;
-const AGENT = args.agent!;
+const AGENT_ARG = args.agent!;
+if (!isRalphAgent(AGENT_ARG)) {
+  console.error(`unknown agent: ${AGENT_ARG}. available: ${RALPH_AGENTS.join(", ")}`);
+  process.exit(1);
+}
+const AGENT = AGENT_ARG;
 const FORMAT_PLAN = args.format!;
 const CLEANUP_ENABLED = args.cleanup !== "false";
 const AUDIT_FIX_ENABLED = args["audit-fix"] === "true";
@@ -71,19 +81,12 @@ let workingDir = PROJECT_DIR;
 
 const LOG_FILE = join(PROJECT_DIR, ".ralph.log");
 const ITER_FILE = join(PROJECT_DIR, ".ralph_iter.tmp");
+const RESPONSE_FILE = ".ralph-response.json";
+const RESPONSE_SCHEMA_PATH = join(PROJECT_DIR, `.ralph-response-schema-${process.pid}.json`);
 
 /** PLAN_PATH and PROGRESS_PATH point to mainWorkDir — the single source of truth. */
 let PLAN_PATH = join(PROJECT_DIR, PLAN_FILE);
 let PROGRESS_PATH = join(PROJECT_DIR, PROGRESS_FILE);
-
-const ALLOWED_TOOLS = [
-  "Edit", "Write", "Read", "Glob", "Grep",
-  "Bash(git *)", "Bash(npm *)", "Bash(npx *)", "Bash(pnpm *)",
-  "Bash(yarn *)", "Bash(bun *)", "Bash(cargo *)", "Bash(go *)",
-  "Bash(python *)", "Bash(pip *)", "Bash(pytest *)", "Bash(make *)",
-  "Bash(ls *)", "Bash(mkdir *)", "Bash(rm *)", "Bash(mv *)",
-  "Bash(cp *)", "Bash(cat *)", "Bash(echo *)", "Bash(touch *)",
-].join(",");
 
 // augment PATH with common bin dirs that may be missing in detached/non-interactive shells
 const IS_WIN = process.platform === "win32";
@@ -135,7 +138,7 @@ const SRT_SETTINGS_PATH = join(PROJECT_DIR, `.ralph-srt-settings-${process.pid}.
 
 /** Write srt settings file and return the path. */
 function writeSrtSettings(allowedWriteDir: string): string {
-  const settings = buildSrtSettings(allowedWriteDir);
+  const settings = buildSrtSettings(allowedWriteDir, { agent: AGENT });
   writeFileSync(SRT_SETTINGS_PATH, JSON.stringify(settings, null, 2));
   return SRT_SETTINGS_PATH;
 }
@@ -147,35 +150,17 @@ function cleanupSrtSettings(): void {
   }
 }
 
-interface AgentConfig {
-  bin: string;
-  args: (prompt: string) => string[];
+function writeResponseSchema(): void {
+  writeFileSync(RESPONSE_SCHEMA_PATH, JSON.stringify(RALPH_RESPONSE_JSON_SCHEMA, null, 2));
 }
 
-const AGENTS: Record<string, AgentConfig> = {
-  claude: {
-    bin: resolveBin("claude"),
-    args: (prompt) => ["--model", "sonnet", "--print", "--dangerously-skip-permissions", "--allowedTools", ALLOWED_TOOLS, "-p", prompt],
-  },
-  codex: {
-    bin: resolveBin("codex"),
-    args: (prompt) => ["exec", prompt, "--yolo"],
-  },
-  gemini: {
-    bin: resolveBin("gemini"),
-    args: (prompt) => ["-p", prompt, "--yolo"],
-  },
-  cursor: {
-    bin: resolveBin("agent"),
-    args: (prompt) => ["-p", prompt, "--yolo"],
-  },
-};
-
-const agent = AGENTS[AGENT];
-if (!agent) {
-  console.error(`unknown agent: ${AGENT}. available: ${Object.keys(AGENTS).join(", ")}`);
-  process.exit(1);
+function cleanupResponseSchema(): void {
+  try { unlinkSync(RESPONSE_SCHEMA_PATH); } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") console.warn("failed to clean up response schema:", errMsg(e));
+  }
 }
+
+const AGENT_BIN = resolveBin(agentBinaryName(AGENT));
 
 const LOCK_FILE = join(PROJECT_DIR, ".ralph.lock");
 
@@ -349,38 +334,14 @@ BEGIN.`;
  *  not injected — if the user wants them, they can install the
  *  `.claude/skills/wolfpack-{ralph,plan}` skills into their project. */
 function buildPrompt(taskDesc: string): string {
-  return `You may ONLY create/edit/delete files under ${workingDir}. Do NOT touch files outside this directory.
-
-YOUR TASK:
-${taskDesc}
-
-INSTRUCTIONS:
-1. If the task is concrete enough, implement it directly.
-2. If it's too large or vague, break it into subtasks instead of implementing.
-3. Run any relevant tests and type checks for what you built.
-4. Commit your changes with a descriptive message.
-5. Do NOT write to ${PROGRESS_FILE} — the task runner manages it automatically.
-
-OUTPUT (always include):
-<prereqs>
-- list any prerequisites or assumptions
-</prereqs>
-<tests>
-- list the tests you ran (or would run if not possible)
-</tests>
-<done>
-- explicit criteria proving the task is complete; if this block is missing or empty, the runner will NOT mark the task complete
-</done>
-
-RULES:
-- ONLY work on ONE task per iteration.
-- If a task has sub-tasks, complete one sub-task.
-- If you decide the task needs breakdown, output a <subtasks> block with one task per line, and DO NOT modify any files or make a commit in that iteration. Follow the Task Granularity rules from the context above.
-- Do NOT write to ${PLAN_FILE}. The task runner handles all plan mutations. If you need subtasks, output a <subtasks> block.
-- Do NOT remove or renumber tasks in the plan file.
-- Be thorough but focused.
-
-BEGIN.`;
+  return buildIterationPrompt({
+    agent: AGENT,
+    workingDir,
+    taskDesc,
+    planFile: PLAN_FILE,
+    progressFile: PROGRESS_FILE,
+    responseFile: join(workingDir, RESPONSE_FILE),
+  });
 }
 
 // create progress file if missing
@@ -398,7 +359,7 @@ appendFileSync(LOG_FILE, `phase_audit_fix: ${AUDIT_FIX_ENABLED ? "on" : "off"}\n
 appendFileSync(LOG_FILE, `worktree: ${WORKTREE_MODE}\n`);
 appendFileSync(LOG_FILE, `sandbox: ${SRT_AVAILABLE ? "srt" : SANDBOX_ENABLED ? "srt-not-found" : "off"}\n`);
 appendFileSync(LOG_FILE, `pid: ${process.pid}\n`);
-appendFileSync(LOG_FILE, `bin: ${agent.bin}\n`);
+appendFileSync(LOG_FILE, `bin: ${AGENT_BIN}\n`);
 appendFileSync(LOG_FILE, `started: ${new Date().toString()}\n\n`);
 
 if (SANDBOX_ENABLED && !SRT_AVAILABLE) {
@@ -478,15 +439,31 @@ function cleanupIterFile(): void {
   }
 }
 
+function responsePath(): string {
+  return join(workingDir, RESPONSE_FILE);
+}
+
+function cleanupResponseFile(path = responsePath()): void {
+  try { unlinkSync(path); } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException)?.code !== "ENOENT") console.warn(`failed to clean up response file:`, errMsg(e));
+  }
+}
+
 const ITERATION_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes per iteration
 
 // track active child for signal handling
 let activeChild: ReturnType<typeof nodeSpawn> | null = null;
 let stopping = false;
 
-function runIteration(prompt: string): Promise<{ exitCode: number; output: string }> {
+function runIteration(prompt: string, responseFile = responsePath()): Promise<{ exitCode: number; output: string }> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
+    writeResponseSchema();
+    const agentArgs = buildAgentArgs(AGENT, {
+      prompt,
+      responseFile,
+      responseSchemaFile: RESPONSE_SCHEMA_PATH,
+    });
 
     // Wrap with srt sandbox if available
     let spawnBin: string;
@@ -494,16 +471,15 @@ function runIteration(prompt: string): Promise<{ exitCode: number; output: strin
     if (SRT_AVAILABLE) {
       writeSrtSettings(workingDir);
       // srt joins positional args with spaces then runs via `bash -c`, so args
-      // containing shell metacharacters (e.g. parentheses in --allowedTools)
-      // must be passed through `-c` with proper quoting.
-      const innerCmd = [agent.bin, ...agent.args(prompt)]
+      // containing shell metacharacters must be passed through `-c` with proper quoting.
+      const innerCmd = [AGENT_BIN, ...agentArgs]
         .map(a => shellEscape(a))
         .join(" ");
       spawnBin = SRT_BIN;
       spawnArgs = ["--settings", SRT_SETTINGS_PATH, "-c", innerCmd];
     } else {
-      spawnBin = agent.bin;
-      spawnArgs = agent.args(prompt);
+      spawnBin = AGENT_BIN;
+      spawnArgs = agentArgs;
     }
 
     const child = nodeSpawn(spawnBin, spawnArgs, {
@@ -542,7 +518,7 @@ function runIteration(prompt: string): Promise<{ exitCode: number; output: strin
 }
 
 // last-resort lock + srt settings cleanup on any exit (covers unhandled exceptions, SIGINT, etc.)
-process.on("exit", () => { removeLock(); cleanupSrtSettings(); });
+process.on("exit", () => { removeLock(); cleanupSrtSettings(); cleanupResponseSchema(); });
 
 /**
  * Graceful shutdown shared by SIGTERM and SIGINT.
@@ -588,6 +564,7 @@ function shutdownHandler(signal: "SIGTERM" | "SIGINT"): void {
   appendFileSync(LOG_FILE, `finished: ${new Date().toString()}\n`);
   removeLock();
   cleanupSrtSettings();
+  cleanupResponseSchema();
   setTimeout(() => process.exit(0), 3500);
 }
 
@@ -601,9 +578,13 @@ function logSummary(tasksCompleted: number, subtasksAdded: number): void {
   const mins = Math.floor(elapsed / 60);
   const secs = elapsed % 60;
 
-  // task counts from plan file
+  // task counts from plan + progress file; completion is tracked in progress.txt,
+  // not by mutating plan checkboxes/headers.
   const plan = readPlan();
-  const { done, total } = countTasksInContent(plan);
+  const progress = (() => {
+    try { return readFileSync(PROGRESS_PATH, "utf-8"); } catch { return ""; }
+  })();
+  const { done, total } = countRalphProgressFromContent(plan, progress);
 
   // files changed via git (committed since start + uncommitted)
   let filesChanged: string[] = [];
@@ -954,11 +935,19 @@ async function main() {
     const planSnapshot = readPlan();
     const { total: totalBefore } = countTasksInContent(planSnapshot);
 
+    ensureRalphTransientGitExcludes(workingDir, PROGRESS_FILE);
+    cleanupResponseFile();
+    const responseFile = responsePath();
     const prompt = buildPrompt(task);
     appendFileSync(LOG_FILE, `\n=== 🥋 Wax On ${i}/${maxIterations} — ${new Date().toString()} ===\n`);
     appendFileSync(LOG_FILE, `task: ${task}\n\n`);
 
-    const { exitCode, output } = await runIteration(prompt);
+    const { exitCode, output } = await runIteration(prompt, responseFile);
+
+    if (stopping) {
+      cleanupResponseFile(responseFile);
+      return;
+    }
 
     // write iter file for inspection
     writeFileSync(ITER_FILE, output);
@@ -980,40 +969,46 @@ async function main() {
         appendFileSync(LOG_FILE, `\n=== ✅ Plan recovered (${recoveredCounts.total} tasks) ===\n`);
       }
       cleanupIterFile();
+      cleanupResponseFile(responseFile);
       continue;
     }
 
     if (exitCode !== 0) {
       appendFileSync(LOG_FILE, `\n=== ⚠️  Iteration ${i} FAILED (exit code ${exitCode}) — ${new Date().toString()} ===\n\n`);
       cleanupIterFile();
+      cleanupResponseFile(responseFile);
       continue;
     }
 
-    // check for explicit runner control output before marking completion
-    const control = classifyRalphIterationOutput(output);
+    // check structured runner control output before marking completion
+    const responseDecision = classifyRalphResponseResult(readRalphResponseFile(responseFile));
+    if (responseDecision.kind === "not_completed") {
+      appendFileSync(LOG_FILE, `\n=== ⚠️ Iteration did not complete: ${responseDecision.reason} (${responseFile}) ===\n`);
+      cleanupIterFile();
+      cleanupResponseFile(responseFile);
+      continue;
+    }
     const MAX_CEILING = Math.max(ITERATIONS * 2, 100);
-    if (control.kind === "subtasks") {
+    if (responseDecision.kind === "subtasks") {
       if (subtaskExpansions >= MAX_SUBTASK_EXPANSIONS) {
         appendFileSync(LOG_FILE, `\n=== ⚠️ Subtask expansion cap reached (${MAX_SUBTASK_EXPANSIONS}) — task not marked complete ===\n`);
         cleanupIterFile();
+        cleanupResponseFile(responseFile);
         continue;
       }
+      const subtasks = responseDecision.subtasks;
       subtaskExpansions++;
-      subtasksAdded += control.subtasks.length;
-      appendSubtasksToPlan(control.subtasks);
+      subtasksAdded += subtasks.length;
+      appendSubtasksToPlan(subtasks);
       // mark parent done so it's never re-picked
       markTaskCompleted(task, checkbox);
-      maxIterations = expandBudget(maxIterations, control.subtasks.length, MAX_CEILING);
-      appendFileSync(LOG_FILE, `\n=== 🧩 Subtasks detected (${control.subtasks.length}) — extended to ${maxIterations} iterations (ceiling ${MAX_CEILING}, expansions ${subtaskExpansions}/${MAX_SUBTASK_EXPANSIONS}) ===\n`);
-      for (const st of control.subtasks) appendFileSync(LOG_FILE, `  + ${st}\n`);
+      maxIterations = expandBudget(maxIterations, subtasks.length, MAX_CEILING);
+      appendFileSync(LOG_FILE, `\n=== 🧩 Subtasks detected (${subtasks.length}) — extended to ${maxIterations} iterations (ceiling ${MAX_CEILING}, expansions ${subtaskExpansions}/${MAX_SUBTASK_EXPANSIONS}) ===\n`);
+      for (const st of subtasks) appendFileSync(LOG_FILE, `  + ${st}\n`);
       lastTask = task;
       lastWasSubtaskEmission = true;
       cleanupIterFile();
-      continue;
-    }
-    if (control.kind === "incomplete") {
-      appendFileSync(LOG_FILE, `\n=== ⚠️ Iteration omitted completion signal: ${control.reason} — task not marked complete ===\n`);
-      cleanupIterFile();
+      cleanupResponseFile(responseFile);
       continue;
     }
 
@@ -1033,6 +1028,7 @@ async function main() {
     syncPlanToProject();
 
     cleanupIterFile();
+    cleanupResponseFile(responseFile);
   }
 
   // merge any outstanding task worktree at end of iterations
@@ -1089,6 +1085,7 @@ async function runAuditFix(): Promise<void> {
   // final phases run in mainWorkDir
   workingDir = mainWorkDir;
   const { exitCode, output } = await runIteration(getAuditFixPrompt());
+  if (stopping) return;
   writeFileSync(ITER_FILE, output);
 
   if (exitCode !== 0) {
@@ -1103,6 +1100,7 @@ async function runCleanup(): Promise<void> {
   appendFileSync(LOG_FILE, `\n=== 🥋 Wax Off — starting cleanup — ${new Date().toString()} ===\n\n`);
   workingDir = mainWorkDir;
   const { exitCode, output } = await runIteration(getCleanupPrompt());
+  if (stopping) return;
   writeFileSync(ITER_FILE, output);
 
   if (exitCode !== 0) {

--- a/src/ralph-prompt.ts
+++ b/src/ralph-prompt.ts
@@ -1,0 +1,64 @@
+import type { RalphAgent } from "./ralph-agent.js";
+import { RALPH_RESPONSE_VERSION, RalphResponseStatus } from "./ralph-response.js";
+
+export interface BuildIterationPromptOptions {
+  readonly agent: RalphAgent;
+  readonly workingDir: string;
+  readonly taskDesc: string;
+  readonly planFile: string;
+  readonly progressFile: string;
+  readonly responseFile: string;
+}
+
+export function buildIterationPrompt(options: BuildIterationPromptOptions): string {
+  const codexRule = options.agent === "codex"
+    ? "\n- Codex output can echo transcript text; DO NOT emit XML-ish control tags."
+    : "";
+
+  return `You may ONLY create/edit/delete files under ${options.workingDir}. Do NOT touch files outside this directory.
+
+YOUR TASK:
+${options.taskDesc}
+
+INSTRUCTIONS:
+1. If the task is concrete enough, implement it directly.
+2. If it's too large or vague, write a structured response with \"status\": \"${RalphResponseStatus.needsSubtasks}\" and one subtask per string; do not modify files or make a commit in that iteration.
+3. Run any relevant tests and type checks for what you built.
+4. Commit your code/doc/test changes with a descriptive message when you changed files.
+5. Do NOT write to ${options.progressFile} — the task runner manages it automatically.
+6. Do NOT commit .ralph-response.json, ${options.progressFile}, .ralph.log, .ralph_iter.tmp, .ralph-response-schema-*.json, or .ralph-srt-settings-*.json; these are runner-owned transient files.
+
+STRUCTURED RESPONSE:
+Before exiting, write valid JSON to ${options.responseFile}. Use exactly one of these valid shapes.
+
+Done response:
+{
+  "version": ${RALPH_RESPONSE_VERSION},
+  "status": "${RalphResponseStatus.done}",
+  "prereqs": ["list any prerequisites or assumptions"],
+  "tests": ["list tests you ran, or would run if not possible"],
+  "done": ["explicit criteria met by this iteration"],
+  "subtasks": []
+}
+
+Needs-subtasks response:
+{
+  "version": ${RALPH_RESPONSE_VERSION},
+  "status": "${RalphResponseStatus.needsSubtasks}",
+  "prereqs": ["list any prerequisites or assumptions"],
+  "tests": ["tests you would run after subtasks are implemented"],
+  "done": ["criteria for the subtasks to satisfy"],
+  "subtasks": ["first meaningful deliverable", "second meaningful deliverable"]
+}
+
+RULES:
+- ONLY work on ONE task per iteration.
+- If a task has sub-tasks, complete one sub-task.
+- The JSON response file is the only runner control channel.
+- Do NOT emit XML-ish runner control tags.${codexRule}
+- Do NOT write to ${options.planFile}. The task runner handles all plan mutations.
+- Do NOT remove or renumber tasks in the plan file.
+- Be thorough but focused.
+
+BEGIN.`;
+}

--- a/src/ralph-response.ts
+++ b/src/ralph-response.ts
@@ -1,0 +1,101 @@
+import { existsSync, readFileSync } from "node:fs";
+
+export const RALPH_RESPONSE_VERSION = 1;
+
+export const RalphResponseStatus = {
+  done: "done",
+  needsSubtasks: "needs_subtasks",
+} as const;
+
+export type RalphResponseStatus = (typeof RalphResponseStatus)[keyof typeof RalphResponseStatus];
+
+export interface RalphIterationResponse {
+  readonly version: typeof RALPH_RESPONSE_VERSION;
+  readonly status: RalphResponseStatus;
+  readonly prereqs: readonly string[];
+  readonly tests: readonly string[];
+  readonly done: readonly string[];
+  readonly subtasks: readonly string[];
+}
+
+export type RalphResponseParseResult =
+  | { readonly ok: true; readonly response: RalphIterationResponse }
+  | { readonly ok: false; readonly error: string };
+
+export type RalphResponseFileResult =
+  | RalphResponseParseResult
+  | { readonly ok: true; readonly response: null };
+
+export type RalphResponseDecision =
+  | { readonly kind: "done" }
+  | { readonly kind: "subtasks"; readonly subtasks: readonly string[] }
+  | { readonly kind: "not_completed"; readonly reason: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringArray(value: unknown, field: string): readonly string[] | string {
+  if (!Array.isArray(value) || value.some(item => typeof item !== "string")) {
+    return `response ${field} must be an array of strings`;
+  }
+  return value.map(item => item.trim()).filter(Boolean);
+}
+
+export function parseRalphResponseJson(content: string): RalphResponseParseResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return { ok: false, error: "response file is not valid json" };
+  }
+
+  if (!isPlainObject(parsed)) return { ok: false, error: "response must be a json object" };
+  if (parsed.version !== RALPH_RESPONSE_VERSION) return { ok: false, error: "response version must be 1" };
+  if (parsed.status !== RalphResponseStatus.done && parsed.status !== RalphResponseStatus.needsSubtasks) {
+    return { ok: false, error: "response status must be done or needs_subtasks" };
+  }
+
+  const prereqs = stringArray(parsed.prereqs, "prereqs");
+  if (typeof prereqs === "string") return { ok: false, error: prereqs };
+  const tests = stringArray(parsed.tests, "tests");
+  if (typeof tests === "string") return { ok: false, error: tests };
+  const done = stringArray(parsed.done, "done");
+  if (typeof done === "string") return { ok: false, error: done };
+  const subtasks = stringArray(parsed.subtasks, "subtasks");
+  if (typeof subtasks === "string") return { ok: false, error: subtasks };
+
+  if (parsed.status === RalphResponseStatus.needsSubtasks && subtasks.length === 0) {
+    return { ok: false, error: "needs_subtasks response must include at least one subtask" };
+  }
+
+  return {
+    ok: true,
+    response: {
+      version: RALPH_RESPONSE_VERSION,
+      status: parsed.status,
+      prereqs,
+      tests,
+      done,
+      subtasks,
+    },
+  };
+}
+
+export function readRalphResponseFile(path: string): RalphResponseFileResult {
+  if (!existsSync(path)) return { ok: true, response: null };
+  return parseRalphResponseJson(readFileSync(path, "utf-8"));
+}
+
+export function classifyRalphResponseResult(result: RalphResponseFileResult): RalphResponseDecision {
+  if (!result.ok) {
+    return { kind: "not_completed", reason: `invalid ralph response file: ${result.error}` };
+  }
+  if (!result.response) {
+    return { kind: "not_completed", reason: "missing ralph response file" };
+  }
+  if (result.response.status === RalphResponseStatus.needsSubtasks) {
+    return { kind: "subtasks", subtasks: result.response.subtasks };
+  }
+  return { kind: "done" };
+}

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -19,6 +19,7 @@ import { hostname, homedir } from "node:os";
 import { execFile, execFileSync, spawn } from "node:child_process";
 import { promisify } from "node:util";
 import { createLogger, errMsg } from "../log.js";
+import { isRalphAgent } from "../ralph-agent.js";
 import { isProcessAlive, isRalphProcessAlive } from "../shared/process-cleanup.js";
 import {
   CMD_REGEX,
@@ -39,7 +40,6 @@ import pkg from "../../package.json";
 const log = createLogger("routes");
 import { DEV_DIR } from "./dev-dir.js";
 import { validateProjectDir as validateProjectDirPure } from "./validate-project-dir.js";
-import { RALPH_AGENTS } from "./shell.js";
 import { getBackend, getRouter, DuplicateSessionError } from "./backend.js";
 import {
   listDevProjects,
@@ -852,12 +852,13 @@ export const routes: Record<
     // (plan mode creates one worktree at startup, task mode creates per-iteration).
     // The route only passes the mode flag — the worker manages the lifecycle.
 
+    const selectedAgent = isRalphAgent(agent || "claude") ? (agent || "claude") : "claude";
     const workerArgs = [
       ...RALPH_BIN_ARGS.slice(1),
       "worker",
       "--plan", resolvedPlan,
       "--iterations", String(iters),
-      "--agent", RALPH_AGENTS.has(agent || "claude") ? (agent || "claude") : "claude",
+      "--agent", selectedAgent,
       "--progress", "progress.txt",
       "--cleanup", String(cleanupEnabled),
       "--audit-fix", String(auditFixEnabled),

--- a/src/server/shell.ts
+++ b/src/server/shell.ts
@@ -3,6 +3,8 @@
  */
 import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
+import type { RalphAgent } from "../ralph-agent.js";
+import { RALPH_AGENTS as RALPH_AGENT_LIST } from "../ralph-agent.js";
 
 const _realExec = promisify(execFile);
 type ExecFn = (file: string, args: readonly string[], options?: { timeout?: number; encoding?: BufferEncoding; maxBuffer?: number }) => Promise<{ stdout: string; stderr: string }>;
@@ -28,11 +30,11 @@ export const SHELL = (() => {
   return "/bin/sh";
 })();
 
-export const RALPH_AGENTS = new Set(["claude", "codex", "gemini", "cursor"]);
+export const RALPH_AGENTS = new Set<RalphAgent>(RALPH_AGENT_LIST);
 
-export function detectAgent(agentCmd: string): "claude" | "gemini" | "codex" | "cursor" | null {
+export function detectAgent(agentCmd: string): RalphAgent | null {
   for (const agent of RALPH_AGENTS) {
-    if (new RegExp(`^${agent}\\b`).test(agentCmd)) return agent as "claude" | "gemini" | "codex" | "cursor";
+    if (new RegExp(`^${agent}\\b`).test(agentCmd)) return agent;
   }
   return null;
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -6,6 +6,7 @@ import { isAbsolute, resolve, join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { statSync } from "node:fs";
 import { homedir } from "node:os";
+import type { RalphAgent } from "./ralph-agent.js";
 
 // ── Regex patterns ──
 
@@ -95,6 +96,10 @@ export interface SrtSettings {
   };
 }
 
+export interface BuildSrtSettingsOptions {
+  readonly agent?: RalphAgent;
+}
+
 /**
  * Cached `rg` resolution. Previously this ran a sync
  * `which rg` on every ralph iteration via buildSrtSettings → a hang in
@@ -153,7 +158,7 @@ function resolveGitMetadataDirs(cwd: string): string[] {
 }
 
 /** Build srt settings scoped to the given working directory. */
-export function buildSrtSettings(allowedWriteDir: string): SrtSettings {
+export function buildSrtSettings(allowedWriteDir: string, options: BuildSrtSettingsOptions = {}): SrtSettings {
   const absDir = resolve(allowedWriteDir);
   const settings: SrtSettings = {
     network: {
@@ -178,7 +183,17 @@ export function buildSrtSettings(allowedWriteDir: string): SrtSettings {
       denyWrite: [".env", ".env.*", "*.pem", "*.key"],
     },
   };
+
   settings.filesystem.allowWrite.push(...resolveGitMetadataDirs(absDir));
+
+  if (options.agent === "codex") {
+    settings.network.allowedDomains.push("chatgpt.com", "*.chatgpt.com");
+    // Codex initializes mutable state under ~/.codex before stable per-session
+    // subpaths exist. This intentionally grants broad persistent Codex state
+    // access; docs/ralph-behavior.md records the accepted sandbox risk.
+    settings.filesystem.allowWrite.push(join(homedir(), ".codex"));
+  }
+
   const rg = resolveRipgrepBin();
   if (rg) settings.ripgrep = rg;
   return settings;

--- a/src/wolfpack-context.ts
+++ b/src/wolfpack-context.ts
@@ -92,6 +92,44 @@ export function countTasksInContent(content: string): { done: number; total: num
   return { done, total };
 }
 
+export function countRalphProgressFromContent(planContent: string, progressContent: string): { done: number; total: number } {
+  const keys = extractRalphTaskKeys(planContent);
+  const completed = new Set<string>();
+  for (const line of progressContent.split("\n")) {
+    if (line.startsWith("DONE: ")) completed.add(line.slice(6));
+  }
+  return {
+    done: keys.filter(key => completed.has(key)).length,
+    total: keys.length,
+  };
+}
+
+function extractRalphTaskKeys(planContent: string): string[] {
+  const keys: string[] = [];
+  const lines = planContent.split("\n");
+
+  for (const line of lines) {
+    const cbMatch = line.match(/^- \[ \] (.+)$/);
+    if (cbMatch) keys.push(`checkbox: ${cbMatch[1]}`);
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!TASK_HEADER.test(line)) continue;
+    const level = line.match(/^(#{2,3})/)?.[1] || "##";
+    const sectionLines = [line];
+    for (let j = i + 1; j < lines.length; j++) {
+      const nextMatch = lines[j].match(/^(#{1,3}) /);
+      if (nextMatch && nextMatch[1].length <= level.length) break;
+      sectionLines.push(lines[j]);
+    }
+    const hasChildren = sectionLines.some(l => /^- \[ \] /.test(l));
+    if (!hasChildren) keys.push(`section: ${line}`);
+  }
+
+  return keys;
+}
+
 /**
  * Validate plan file structure — checks for parseable tasks and ambiguous headers.
  * Reuses TASK_HEADER regex and checkbox pattern from countPlanTasks logic.

--- a/tests/e2e/reconnect.e2e.ts
+++ b/tests/e2e/reconnect.e2e.ts
@@ -22,6 +22,18 @@ test.afterAll(async () => {
   srv?.close();
 });
 
+function proxyToServer(ws: WebSocketRoute): void {
+  const server = ws.connectToServer();
+
+  // Proxy messages bidirectionally
+  ws.onMessage((msg) => server.send(msg));
+  server.onMessage((msg) => ws.send(msg));
+
+  // Forward close from either side (disables default auto-forwarding)
+  ws.onClose((code, reason) => server.close({ code, reason }));
+  server.onClose((code, reason) => ws.close({ code, reason }));
+}
+
 /** Helper: set up a WS proxy that exposes the page-facing route for later close(). */
 function setupWsProxy(page: import("@playwright/test").Page) {
   // Tracks the FIRST (active) page-facing route for disconnect simulation.
@@ -31,18 +43,9 @@ function setupWsProxy(page: import("@playwright/test").Page) {
   let connectionCount = 0;
 
   const ready = page.routeWebSocket(/\/ws\/pty/, (ws) => {
-    const server = ws.connectToServer();
     connectionCount++;
-
-    // Proxy messages bidirectionally
-    ws.onMessage((msg) => server.send(msg));
-    server.onMessage((msg) => ws.send(msg));
-
-    // Forward close from either side (disables default auto-forwarding)
-    ws.onClose((code, reason) => server.close({ code, reason }));
-    server.onClose((code, reason) => ws.close({ code, reason }));
-
     activeRoute = ws;
+    proxyToServer(ws);
   });
 
   return {
@@ -95,6 +98,39 @@ test("WS disconnect shows reconnecting banner then recovers", async ({
 
   // Verify canvas still present after reconnect
   await expect(page.locator("#desktop-terminal-container canvas")).toBeVisible({ timeout: 5000 });
+});
+
+test("WS disconnect keeps reconnecting banner visible during a network outage", async ({
+  page,
+  context,
+}, testInfo) => {
+  test.skip(
+    testInfo.project.name === "desktop",
+    "mobile-only viewport tests",
+  );
+
+  const proxy = setupWsProxy(page);
+  await proxy.ready;
+
+  await page.goto(srv.baseUrl);
+  await page.waitForSelector(".card", { timeout: 5000 });
+  await page.locator(".card", { hasText: "test-project" }).first().click();
+  await expect(page.locator("#desktop-terminal-container canvas")).toBeVisible({ timeout: 5000 });
+
+  const connStatus = page.locator("#conn-status");
+  await expect(connStatus).toBeHidden();
+
+  await context.setOffline(true);
+  proxy.disconnect();
+
+  try {
+    await expect(connStatus).toBeVisible({ timeout: 3000 });
+    await expect(connStatus).toContainText(/reconnecting/i, { timeout: 3000 });
+  } finally {
+    await context.setOffline(false);
+  }
+
+  await expect(connStatus).toBeHidden({ timeout: 15000 });
 });
 
 test("WS disconnect during active session preserves terminal content", async ({

--- a/tests/unit/plan-parsing.test.ts
+++ b/tests/unit/plan-parsing.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseSubtasks } from "../../src/ralph-control.js";
-import { TASK_HEADER, countTasksInContent, detectOldPlanFormat, migratePlanFormat } from "../../src/wolfpack-context.js";
+import { TASK_HEADER, countRalphProgressFromContent, countTasksInContent, detectOldPlanFormat, migratePlanFormat } from "../../src/wolfpack-context.js";
 
 // ── Plan-parsing functions from ralph-macchio.ts and serve.ts ──
 // These are module-private, replicated here as pure functions for testing.
@@ -243,64 +242,6 @@ describe("same-task-twice detection", () => {
     const planAfter = planBefore.replace("## 1. Big task", "## ~~1. Big task~~");
     const second = extractCurrentTask(planAfter);
     expect(second!.task).toContain("## 2. Other task");
-  });
-});
-
-// ── parseSubtasks tests ──
-
-describe("parseSubtasks", () => {
-  test("extracts subtasks from valid block", () => {
-    const output = "some preamble\n<subtasks>\ntask one\ntask two\ntask three\n</subtasks>\npostamble";
-    expect(parseSubtasks(output)).toEqual(["task one", "task two", "task three"]);
-  });
-
-  test("returns empty array when no subtasks block", () => {
-    expect(parseSubtasks("just some output with no subtasks")).toEqual([]);
-  });
-
-  test("returns empty array for empty subtasks block", () => {
-    expect(parseSubtasks("<subtasks>\n\n\n</subtasks>")).toEqual([]);
-  });
-
-  test("trims whitespace from each subtask", () => {
-    const output = "<subtasks>\n  padded task  \n   another one   \n</subtasks>";
-    expect(parseSubtasks(output)).toEqual(["padded task", "another one"]);
-  });
-
-  test("filters out empty lines", () => {
-    const output = "<subtasks>\ntask one\n\n\ntask two\n\n</subtasks>";
-    expect(parseSubtasks(output)).toEqual(["task one", "task two"]);
-  });
-
-  test("handles multi-word subtasks", () => {
-    const output = "<subtasks>\nimplement the authentication module with OAuth2\nwrite unit tests for login flow\n</subtasks>";
-    expect(parseSubtasks(output)).toEqual([
-      "implement the authentication module with OAuth2",
-      "write unit tests for login flow",
-    ]);
-  });
-
-  test("handles single subtask", () => {
-    const output = "<subtasks>\njust one task\n</subtasks>";
-    expect(parseSubtasks(output)).toEqual(["just one task"]);
-  });
-
-  test("uses first subtasks block if multiple present", () => {
-    const output = "<subtasks>\nfirst\n</subtasks>\nmore text\n<subtasks>\nsecond\n</subtasks>";
-    // non-greedy match means first block wins
-    expect(parseSubtasks(output)).toEqual(["first"]);
-  });
-
-  test("handles subtasks with special characters", () => {
-    const output = "<subtasks>\nfix `parseSubtasks()` in ralph-macchio.ts\nadd tests for <edge> cases\n</subtasks>";
-    expect(parseSubtasks(output)).toEqual([
-      "fix `parseSubtasks()` in ralph-macchio.ts",
-      "add tests for <edge> cases",
-    ]);
-  });
-
-  test("returns empty array for empty string", () => {
-    expect(parseSubtasks("")).toEqual([]);
   });
 });
 
@@ -616,6 +557,20 @@ describe("extractCurrentTask skips fully-completed sections", () => {
 });
 
 // ── detectOldPlanFormat tests ──
+
+describe("countRalphProgressFromContent", () => {
+  test("counts progress.txt DONE keys against unchanged plan checkboxes", () => {
+    const plan = "- [ ] smoke task\n";
+    const progress = "# Progress Log\nDONE: checkbox: smoke task\n";
+    expect(countRalphProgressFromContent(plan, progress)).toEqual({ done: 1, total: 1 });
+  });
+
+  test("does not count DONE keys that are not in the current plan", () => {
+    const plan = "- [ ] real task\n";
+    const progress = "DONE: checkbox: stale task\n";
+    expect(countRalphProgressFromContent(plan, progress)).toEqual({ done: 0, total: 1 });
+  });
+});
 
 describe("detectOldPlanFormat", () => {
   test("detects 'Task N: Title' format", () => {

--- a/tests/unit/ralph-agent-command.test.ts
+++ b/tests/unit/ralph-agent-command.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { buildAgentArgs, RALPH_RESPONSE_JSON_SCHEMA } from "../../src/ralph-agent-command.js";
+
+describe("buildAgentArgs", () => {
+  test("codex uses native structured output files instead of prompt-only response handling", () => {
+    const args = buildAgentArgs("codex", {
+      prompt: "do the task",
+      responseFile: "/tmp/work/.ralph-response.json",
+      responseSchemaFile: "/tmp/project/.ralph-response-schema.json",
+    });
+
+    expect(args).toEqual([
+      "exec",
+      "--disable", "apps",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "--output-last-message", "/tmp/work/.ralph-response.json",
+      "--output-schema", "/tmp/project/.ralph-response-schema.json",
+      "do the task",
+    ]);
+    expect(args).not.toContain("--yolo");
+  });
+
+  test("all agents receive the same ralph response file contract", () => {
+    for (const agent of ["claude", "codex", "gemini", "cursor"] as const) {
+      const args = buildAgentArgs(agent, {
+        prompt: "write /tmp/work/.ralph-response.json before exiting",
+        responseFile: "/tmp/work/.ralph-response.json",
+        responseSchemaFile: "/tmp/project/.ralph-response-schema.json",
+      });
+
+      expect(args.join("\n")).toContain("/tmp/work/.ralph-response.json");
+    }
+  });
+
+  test("other agents keep their existing prompt-driven invocation", () => {
+    expect(buildAgentArgs("claude", {
+      prompt: "do the task",
+      responseFile: "/tmp/work/.ralph-response.json",
+      responseSchemaFile: "/tmp/project/.ralph-response-schema.json",
+    })).toContain("do the task");
+
+    expect(buildAgentArgs("gemini", {
+      prompt: "do the task",
+      responseFile: "/tmp/work/.ralph-response.json",
+      responseSchemaFile: "/tmp/project/.ralph-response-schema.json",
+    })).toEqual(["-p", "do the task", "--yolo"]);
+
+    expect(buildAgentArgs("cursor", {
+      prompt: "do the task",
+      responseFile: "/tmp/work/.ralph-response.json",
+      responseSchemaFile: "/tmp/project/.ralph-response-schema.json",
+    })).toEqual(["-p", "do the task", "--yolo"]);
+  });
+});
+
+describe("RALPH_RESPONSE_JSON_SCHEMA", () => {
+  test("pins the response status enum to runner-supported values", () => {
+    expect(RALPH_RESPONSE_JSON_SCHEMA.properties.status).toEqual({
+      type: "string",
+      enum: ["done", "needs_subtasks"],
+    });
+  });
+
+  test("uses codex/openai-compatible typed const fields", () => {
+    expect(RALPH_RESPONSE_JSON_SCHEMA.properties.version).toEqual({
+      type: "number",
+      const: 1,
+    });
+  });
+});

--- a/tests/unit/ralph-git-exclude.test.ts
+++ b/tests/unit/ralph-git-exclude.test.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { ensureRalphTransientGitExcludes } from "../../src/ralph-git-exclude.js";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+describe("ensureRalphTransientGitExcludes", () => {
+  test("excludes runner-owned transient files from git add -A", () => {
+    const repo = mkdtempSync(join(tmpdir(), "ralph-git-exclude-"));
+    git(repo, ["init"]);
+    git(repo, ["config", "user.email", "test@example.com"]);
+    git(repo, ["config", "user.name", "Test"]);
+    git(repo, ["config", "commit.gpgsign", "false"]);
+    writeFileSync(join(repo, "README.md"), "init\n");
+    git(repo, ["add", "README.md"]);
+    git(repo, ["commit", "-m", "init"]);
+
+    ensureRalphTransientGitExcludes(repo, "progress.txt");
+
+    writeFileSync(join(repo, ".ralph-response.json"), "{}\n");
+    writeFileSync(join(repo, ".ralph-response-schema-123.json"), "{}\n");
+    writeFileSync(join(repo, ".ralph-srt-settings-123.json"), "{}\n");
+    writeFileSync(join(repo, ".ralph.log"), "log\n");
+    writeFileSync(join(repo, "progress.txt"), "# Progress Log\n");
+    writeFileSync(join(repo, "feature.ts"), "export const ok = true;\n");
+
+    git(repo, ["add", "-A"]);
+    const staged = git(repo, ["diff", "--cached", "--name-only"]);
+
+    expect(staged).toContain("feature.ts");
+    expect(staged).not.toContain(".ralph-response.json");
+    expect(staged).not.toContain(".ralph-response-schema-123.json");
+    expect(staged).not.toContain(".ralph-srt-settings-123.json");
+    expect(staged).not.toContain(".ralph.log");
+    expect(staged).not.toContain("progress.txt");
+
+    const exclude = readFileSync(join(repo, ".git", "info", "exclude"), "utf-8");
+    expect(exclude).toContain("# ralph transient files");
+    expect(exclude).toContain(".ralph-response.json");
+    expect(exclude).toContain("progress.txt");
+  });
+
+  test("is a no-op outside git repositories", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ralph-no-git-"));
+    mkdirSync(join(dir, "sub"));
+    expect(() => ensureRalphTransientGitExcludes(join(dir, "sub"), "progress.txt")).not.toThrow();
+  });
+});

--- a/tests/unit/ralph-prompt.test.ts
+++ b/tests/unit/ralph-prompt.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { buildIterationPrompt } from "../../src/ralph-prompt.js";
+
+describe("buildIterationPrompt", () => {
+  test("prompt uses a json response file as the runner control channel", () => {
+    const prompt = buildIterationPrompt({
+      agent: "claude",
+      workingDir: "/tmp/project",
+      taskDesc: "implement the feature",
+      planFile: "PLAN.md",
+      progressFile: "progress.txt",
+      responseFile: "/tmp/project/.ralph-response.json",
+    });
+
+    expect(prompt).toContain("/tmp/project/.ralph-response.json");
+    expect(prompt).toContain('"status": "needs_subtasks"');
+    expect(prompt).toContain('"subtasks": [');
+    expect(prompt).not.toContain('"status": "done" | "needs_subtasks"');
+    expect(prompt).not.toContain("<subtasks>");
+  });
+
+  test("prompt shows valid json examples for every supported agent", () => {
+    for (const agent of ["claude", "codex", "gemini", "cursor"] as const) {
+      const prompt = buildIterationPrompt({
+        agent,
+        workingDir: "/tmp/project",
+        taskDesc: "implement the feature",
+        planFile: "PLAN.md",
+        progressFile: "progress.txt",
+        responseFile: "/tmp/project/.ralph-response.json",
+      });
+
+      expect(prompt).toContain('"status": "done"');
+      expect(prompt).toContain('"status": "needs_subtasks"');
+      expect(prompt).not.toContain('"status": "done" | "needs_subtasks"');
+      expect(prompt).not.toContain("<subtasks>");
+    }
+  });
+
+  test("prompt tells agents not to commit runner-owned files", () => {
+    const prompt = buildIterationPrompt({
+      agent: "claude",
+      workingDir: "/tmp/project",
+      taskDesc: "implement the feature",
+      planFile: "PLAN.md",
+      progressFile: "progress.txt",
+      responseFile: "/tmp/project/.ralph-response.json",
+    });
+
+    expect(prompt).toContain("Do NOT commit .ralph-response.json");
+    expect(prompt).toContain("progress.txt");
+    expect(prompt).toContain(".ralph.log");
+    expect(prompt).toContain(".ralph-response-schema-*.json");
+  });
+
+  test("codex prompt uses the same json response protocol", () => {
+    const prompt = buildIterationPrompt({
+      agent: "codex",
+      workingDir: "/tmp/project",
+      taskDesc: "implement the feature",
+      planFile: "PLAN.md",
+      progressFile: "progress.txt",
+      responseFile: "/tmp/project/.ralph-response.json",
+    });
+
+    expect(prompt).toContain("/tmp/project/.ralph-response.json");
+    expect(prompt).toContain("DO NOT emit XML-ish control tags");
+    expect(prompt).not.toContain("break it into subtasks");
+    expect(prompt).not.toContain("<subtasks>");
+  });
+});

--- a/tests/unit/ralph-response.test.ts
+++ b/tests/unit/ralph-response.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { classifyRalphResponseResult, parseRalphResponseJson } from "../../src/ralph-response.js";
+
+describe("parseRalphResponseJson", () => {
+  test("extracts subtasks from the structured response file", () => {
+    const parsed = parseRalphResponseJson(JSON.stringify({
+      version: 1,
+      status: "needs_subtasks",
+      prereqs: ["repo builds locally"],
+      tests: ["bun test"],
+      done: ["runner appends subtasks"],
+      subtasks: ["add parser tests", "wire response file into runner"],
+    }));
+
+    expect(parsed).toEqual({
+      ok: true,
+      response: {
+        version: 1,
+        status: "needs_subtasks",
+        prereqs: ["repo builds locally"],
+        tests: ["bun test"],
+        done: ["runner appends subtasks"],
+        subtasks: ["add parser tests", "wire response file into runner"],
+      },
+    });
+  });
+
+  test("rejects invalid json instead of treating stdout prose as control data", () => {
+    expect(parseRalphResponseJson("<subtasks>lol no</subtasks>")).toEqual({
+      ok: false,
+      error: "response file is not valid json",
+    });
+  });
+
+  test("rejects needs_subtasks responses without string subtasks", () => {
+    expect(parseRalphResponseJson(JSON.stringify({
+      version: 1,
+      status: "needs_subtasks",
+      prereqs: [],
+      tests: [],
+      done: [],
+      subtasks: ["good", 42],
+    }))).toEqual({
+      ok: false,
+      error: "response subtasks must be an array of strings",
+    });
+  });
+
+  test("accepts done responses without subtasks", () => {
+    const parsed = parseRalphResponseJson(JSON.stringify({
+      version: 1,
+      status: "done",
+      prereqs: [],
+      tests: ["bun test tests/unit/ralph-response.test.ts"],
+      done: ["task complete"],
+      subtasks: [],
+    }));
+
+    expect(parsed).toEqual({
+      ok: true,
+      response: {
+        version: 1,
+        status: "done",
+        prereqs: [],
+        tests: ["bun test tests/unit/ralph-response.test.ts"],
+        done: ["task complete"],
+        subtasks: [],
+      },
+    });
+  });
+
+  test("classifies missing response files as not completed", () => {
+    expect(classifyRalphResponseResult({ ok: true, response: null })).toEqual({
+      kind: "not_completed",
+      reason: "missing ralph response file",
+    });
+  });
+
+  test("classifies invalid response files as not completed", () => {
+    expect(classifyRalphResponseResult({ ok: false, error: "response file is not valid json" })).toEqual({
+      kind: "not_completed",
+      reason: "invalid ralph response file: response file is not valid json",
+    });
+  });
+
+  test("classifies done responses as completed", () => {
+    const parsed = parseRalphResponseJson(JSON.stringify({
+      version: 1,
+      status: "done",
+      prereqs: [],
+      tests: [],
+      done: ["task complete"],
+      subtasks: [],
+    }));
+
+    expect(classifyRalphResponseResult(parsed)).toEqual({ kind: "done" });
+  });
+
+  test("classifies needs_subtasks responses as subtask expansion", () => {
+    const parsed = parseRalphResponseJson(JSON.stringify({
+      version: 1,
+      status: "needs_subtasks",
+      prereqs: [],
+      tests: [],
+      done: [],
+      subtasks: ["one", "two"],
+    }));
+
+    expect(classifyRalphResponseResult(parsed)).toEqual({
+      kind: "subtasks",
+      subtasks: ["one", "two"],
+    });
+  });
+});

--- a/tests/unit/ralph-sandbox.test.ts
+++ b/tests/unit/ralph-sandbox.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { writeFileSync, mkdtempSync, rmSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { buildSrtSettings } from "../../src/validation.js";
 import { parseRalphLog } from "../../src/server/ralph.js";
 
@@ -89,9 +89,44 @@ describe("buildSrtSettings", () => {
     expect(domains).toContain("api.anthropic.com");
   });
 
+  test("codex settings intentionally allow the full persistent codex state directory", () => {
+    const settings = buildSrtSettings("/tmp/test", { agent: "codex" });
+    // Codex initializes mutable state under ~/.codex before per-session paths exist.
+    // This is intentionally broader than project-local writes; docs record the risk.
+    expect(settings.filesystem.allowWrite).toContain(join(homedir(), ".codex"));
+  });
+
+  test("codex settings allow chatgpt network domains", () => {
+    const settings = buildSrtSettings("/tmp/test", { agent: "codex" });
+    expect(settings.network.allowedDomains).toContain("chatgpt.com");
+    expect(settings.network.allowedDomains).toContain("*.chatgpt.com");
+  });
+
+  test("claude/default settings do not include codex-specific permissions", () => {
+    const defaultSettings = buildSrtSettings("/tmp/test");
+    const claudeSettings = buildSrtSettings("/tmp/test", { agent: "claude" });
+    expect(claudeSettings).toEqual(defaultSettings);
+    expect(defaultSettings.filesystem.allowWrite).not.toContain(join(homedir(), ".codex"));
+    expect(defaultSettings.network.allowedDomains).not.toContain("chatgpt.com");
+  });
+
   test("network disallows local binding", () => {
     const settings = buildSrtSettings("/tmp/test");
     expect(settings.network.allowLocalBinding).toBe(false);
+  });
+
+  test("network does not allow host broker Unix socket access by default", () => {
+    const originalSocket = process.env.WOLFPACK_BROKER_SOCKET;
+    const brokerSocket = join(tmpdir(), "configured-wolfpack-broker.sock");
+    process.env.WOLFPACK_BROKER_SOCKET = brokerSocket;
+    try {
+      const settings = buildSrtSettings("/tmp/test");
+      expect(settings.network).not.toHaveProperty("allowUnixSockets");
+      expect(settings.network).not.toHaveProperty("allowAllUnixSockets");
+    } finally {
+      if (originalSocket === undefined) delete process.env.WOLFPACK_BROKER_SOCKET;
+      else process.env.WOLFPACK_BROKER_SOCKET = originalSocket;
+    }
   });
 
   test("settings structure matches srt schema", () => {
@@ -104,6 +139,8 @@ describe("buildSrtSettings", () => {
     expect(settings.network).toHaveProperty("allowedDomains");
     expect(settings.network).toHaveProperty("deniedDomains");
     expect(settings.network).toHaveProperty("allowLocalBinding");
+    expect(settings.network).not.toHaveProperty("allowUnixSockets");
+    expect(settings.network).not.toHaveProperty("allowAllUnixSockets");
     // verify filesystem keys
     expect(settings.filesystem).toHaveProperty("denyRead");
     expect(settings.filesystem).toHaveProperty("allowWrite");

--- a/tests/unit/ralph-worker-response.test.ts
+++ b/tests/unit/ralph-worker-response.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+const WORKER_PATH = join(import.meta.dir, "..", "..", "src", "ralph-macchio.ts");
+const EXTRA_PATHS = [
+  join(homedir(), ".local", "bin"),
+  join(homedir(), ".cargo", "bin"),
+  join(homedir(), ".bun", "bin"),
+  join(homedir(), ".npm-global", "bin"),
+  "/usr/local/bin",
+  "/opt/homebrew/bin",
+  "/opt/homebrew/sbin",
+];
+
+interface WorkerRunResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+let tmpRoot: string;
+let repoDir: string;
+let fakeBinDir: string;
+let fakeStatePath: string;
+
+function git(cwd: string, args: readonly string[]): string {
+  return execFileSync("git", ["-c", "commit.gpgsign=false", ...args], {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function createFakeClaude(): void {
+  const script = `#!/usr/bin/env bun
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+const args = process.argv.slice(2);
+const outputArgIndex = args.indexOf("--output-last-message");
+const explicitOutputPath = outputArgIndex >= 0 ? args[outputArgIndex + 1] : undefined;
+const joinedArgs = args.join("\\n");
+const promptOutputPath = joinedArgs.match(/\\S+\\.ralph-response\\.json/)?.[0];
+const responsePath = explicitOutputPath || promptOutputPath;
+const statePath = process.env.FAKE_RALPH_STATE;
+const sequence = JSON.parse(process.env.FAKE_RALPH_SEQUENCE || '["done"]');
+const prior = statePath && existsSync(statePath) ? Number(readFileSync(statePath, "utf-8")) || 0 : 0;
+const kind = sequence[Math.min(prior, sequence.length - 1)] || "done";
+if (statePath) writeFileSync(statePath, String(prior + 1));
+
+if (kind !== "missing") {
+  if (!responsePath) throw new Error("fake agent could not find response path in args");
+  mkdirSync(dirname(responsePath), { recursive: true });
+  if (kind === "invalid") {
+    writeFileSync(responsePath, "not json");
+  } else if (kind === "needs_subtasks") {
+    writeFileSync(responsePath, JSON.stringify({
+      version: 1,
+      status: "needs_subtasks",
+      prereqs: ["fake prereq"],
+      tests: ["fake test"],
+      done: ["fake breakdown"],
+      subtasks: ["implement parser regression", "wire worker regression"],
+    }));
+  } else {
+    writeFileSync(responsePath, JSON.stringify({
+      version: 1,
+      status: "done",
+      prereqs: ["fake prereq"],
+      tests: ["fake test"],
+      done: ["fake done"],
+      subtasks: [],
+    }));
+  }
+}
+
+console.log(\`fake-agent-kind: \${kind}\`);
+`;
+
+  const fakeClaude = join(fakeBinDir, "claude");
+  writeFileSync(fakeClaude, script, { mode: 0o755 });
+}
+
+function initRepo(planContent: string): void {
+  repoDir = join(tmpRoot, "repo");
+  execFileSync("mkdir", ["-p", repoDir]);
+  git(repoDir, ["init"]);
+  git(repoDir, ["config", "user.name", "Test"]);
+  git(repoDir, ["config", "user.email", "test@example.com"]);
+  git(repoDir, ["checkout", "-b", "main"]);
+  writeFileSync(join(repoDir, "README.md"), "# test repo\n");
+  writeFileSync(join(repoDir, "PLAN.md"), planContent);
+  git(repoDir, ["add", "README.md", "PLAN.md"]);
+  git(repoDir, ["commit", "-m", "initial"]);
+}
+
+function workerPathEnv(): string {
+  const existing = process.env.PATH || "";
+  const knownPaths = EXTRA_PATHS.filter(path => existsSync(path));
+  return [fakeBinDir, ...knownPaths, existing].join(":");
+}
+
+function runWorker(sequence: readonly string[], extraArgs: readonly string[] = []): WorkerRunResult {
+  writeFileSync(fakeStatePath, "0");
+  const result = spawnSync("bun", [
+    WORKER_PATH,
+    "--plan", "PLAN.md",
+    "--progress", "progress.txt",
+    "--iterations", "1",
+    "--agent", "claude",
+    "--cleanup", "false",
+    "--audit-fix", "false",
+    "--sandbox", "false",
+    ...extraArgs,
+  ], {
+    cwd: repoDir,
+    env: {
+      ...process.env,
+      PATH: workerPathEnv(),
+      FAKE_RALPH_STATE: fakeStatePath,
+      FAKE_RALPH_SEQUENCE: JSON.stringify(sequence),
+    },
+    encoding: "utf-8",
+    timeout: 20_000,
+  });
+
+  return {
+    status: result.status,
+    stdout: result.stdout || "",
+    stderr: result.stderr || "",
+  };
+}
+
+function expectWorkerSuccess(result: WorkerRunResult): void {
+  expect({ status: result.status, stderr: result.stderr, stdout: result.stdout }).toEqual({
+    status: 0,
+    stderr: "",
+    stdout: "",
+  });
+}
+
+function workdirFromLog(): string {
+  const log = readFileSync(join(repoDir, ".ralph.log"), "utf-8");
+  const match = log.match(/^workdir:\s*(.+)$/m);
+  return match?.[1]?.trim() || repoDir;
+}
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "ralph-worker-response-"));
+  fakeBinDir = join(tmpRoot, "bin");
+  fakeStatePath = join(tmpRoot, "fake-agent-state.txt");
+  execFileSync("mkdir", ["-p", fakeBinDir]);
+  createFakeClaude();
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("ralph worker structured response contract", () => {
+  test("done response marks the current task completed through the real worker loop", () => {
+    initRepo("- [ ] ship structured response\n");
+
+    const result = runWorker(["done"]);
+
+    expectWorkerSuccess(result);
+    const progress = readFileSync(join(repoDir, "progress.txt"), "utf-8");
+    const log = readFileSync(join(repoDir, ".ralph.log"), "utf-8");
+    expect(progress).toContain("DONE: checkbox: ship structured response");
+    expect(log).toContain("all_tasks_done: true");
+    expect(log).not.toContain("missing ralph response file");
+    expect(existsSync(join(repoDir, ".ralph-response.json"))).toBe(false);
+  });
+
+  test("needs_subtasks response appends subtasks and marks the parent completed", () => {
+    initRepo("- [ ] break down broad task\n");
+
+    const result = runWorker(["needs_subtasks", "done", "done"]);
+
+    expectWorkerSuccess(result);
+    const plan = readFileSync(join(repoDir, "PLAN.md"), "utf-8");
+    const progress = readFileSync(join(repoDir, "progress.txt"), "utf-8");
+    expect(plan).toContain("- [ ] implement parser regression");
+    expect(plan).toContain("- [ ] wire worker regression");
+    expect(progress).toContain("DONE: checkbox: break down broad task");
+    expect(progress).toContain("DONE: checkbox: implement parser regression");
+    expect(progress).toContain("DONE: checkbox: wire worker regression");
+  });
+
+  test("missing response file leaves the task incomplete and logs a hard warning", () => {
+    initRepo("- [ ] require explicit response file\n");
+
+    const result = runWorker(["missing"]);
+
+    expectWorkerSuccess(result);
+    const progress = readFileSync(join(repoDir, "progress.txt"), "utf-8");
+    const log = readFileSync(join(repoDir, ".ralph.log"), "utf-8");
+    expect(progress).not.toContain("DONE: checkbox: require explicit response file");
+    expect(log).toContain("Iteration did not complete: missing ralph response file");
+  });
+
+  test("plan worktree mode reads response from the active worktree and excludes runner transients from git", () => {
+    initRepo("- [ ] complete from plan worktree\n");
+
+    const result = runWorker(["done"], ["--worktree", "plan"]);
+
+    expectWorkerSuccess(result);
+    const workdir = workdirFromLog();
+    const progress = readFileSync(join(workdir, "progress.txt"), "utf-8");
+    expect(progress).toContain("DONE: checkbox: complete from plan worktree");
+    expect(workdir).not.toBe(repoDir);
+
+    writeFileSync(join(workdir, ".ralph-response.json"), "{}\n");
+    writeFileSync(join(workdir, ".ralph-response-schema-123.json"), "{}\n");
+    writeFileSync(join(workdir, ".ralph-srt-settings-123.json"), "{}\n");
+    writeFileSync(join(workdir, ".ralph_iter.tmp"), "tmp\n");
+    writeFileSync(join(workdir, "progress.txt"), progress);
+    writeFileSync(join(workdir, "feature.ts"), "export const covered = true;\n");
+
+    git(workdir, ["add", "-A"]);
+    const staged = git(workdir, ["diff", "--cached", "--name-only"]);
+    expect(staged).toContain("feature.ts");
+    expect(staged).not.toContain(".ralph-response.json");
+    expect(staged).not.toContain(".ralph-response-schema-123.json");
+    expect(staged).not.toContain(".ralph-srt-settings-123.json");
+    expect(staged).not.toContain(".ralph_iter.tmp");
+    expect(staged).not.toContain("progress.txt");
+
+  });
+});


### PR DESCRIPTION
## summary

Restores the regression fixes called out by `review-HEAD.md` for `terminal_optimization2`.

### restored fixes and why

- restored the isolated Ralph structured JSON response channel (`.ralph-response.json` + schema) because parsing `<done>` / `<subtasks>` from mixed stdout/stderr lets echoed prompts, tool output, or malicious task text mark work complete incorrectly.
- restored Ralph worker/response/agent/prompt/git-exclude regression tests because the previous tests were added for real incidents (`fix ralph structured agent responses`, worker response regressions, transient file staging) and parser-only tests did not cover the repo-mutating worker path.
- restored runner-owned transient git excludes (`.ralph-*`, response/schema/srt temp files, `progress.txt`) because broad agent commits like `git add -A` can otherwise commit logs, prompt artifacts, and runner state.
- restored Codex-specific srt allowances (`~/.codex`, `chatgpt.com`) because Codex initializes mutable state and network access there under the default Ralph sandbox; removing this made `agent: codex` unreliable.
- restored negative srt socket policy assertions and broker startup diagnostics because default Ralph srt must not get broad Unix socket access; without the diagnostic, operators are pushed toward unsafe `allowAllUnixSockets` workarounds.
- restored Ralph opt-in docs because the UI still hides Ralph controls behind **Settings → Ralph Loop → Enable Ralph Loop**.
- corrected the Ralph skill description because Wolfpack no longer runtime-injects `.claude/skills/wolfpack-ralph`; claiming that misleads contributors.
- added deterministic reconnect-banner e2e coverage during a browser network outage because fast broker reconnect tests can skip the visible banner assertion without proving slow/outage UX.

## verification

- `bunx tsc --noEmit -p .`
- `bunx tsc --noEmit -p public/`
- `bun test`
- `cargo test --manifest-path broker/Cargo.toml`
- `bunx playwright test tests/e2e/reconnect.e2e.ts --grep "network outage|shows reconnecting banner"`
- `git diff --check && git diff --cached --check`

## notes

`review-HEAD.md` and `WOLFPACK_RESTART_DEBUG_STATUS.md` were left untracked and not included in this PR.
