### PR TITLE
Add adoption workflow guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ wolfpack uninstall --yes Remove everything
 
 Troubleshooting: [docs/troubleshooting.md](docs/troubleshooting.md).
 
+## Guides
+
+- [Pi / coding-agent quickstart](docs/pi-quickstart.md) — configure `pi`, start a session, and add Wolfpack to your phone.
+- [Mobile agent workflow](docs/mobile-agent-workflow.md) — triage many agents from your phone without doom-scrolling terminals.
+- [Multi-machine setup](docs/multi-machine.md) — manage laptop, workstation, and cloud VM sessions from one PWA.
+- [Troubleshooting](docs/troubleshooting.md) — Tailscale, services, broker health, stale PWA cache, and reset steps.
+
 ## Trust and security model
 
 Wolfpack is self-hosted software for machines you control. Those machines can be local laptops, workstations, or cloud VMs.

--- a/docs/mobile-agent-workflow.md
+++ b/docs/mobile-agent-workflow.md
@@ -1,0 +1,85 @@
+# Mobile Agent Workflow
+
+Wolfpack is built for the boring but real workflow: start agents on real machines, leave your desk, then answer only when something needs you.
+
+## Triage loop
+
+1. Open the Wolfpack PWA on your phone.
+2. Scan the session cards.
+3. Prioritize sessions marked needs-input or idle with a prompt visible.
+4. Open only the session that needs attention.
+5. Send the smallest useful response, then go back to the session list.
+
+Avoid doom-scrolling terminals. The card preview is there so you can decide whether to open the terminal at all.
+
+## Session states
+
+Wolfpack cards are intentionally coarse:
+
+- **running** — output changed recently; the agent is probably busy.
+- **idle** — output is stable; it may be waiting at a prompt or just done.
+- **needs input** — Wolfpack sees prompt-like output that likely needs you.
+
+These are triage hints, not a formal agent protocol. When in doubt, open the terminal.
+
+## Responding from phone
+
+The terminal view includes mobile-oriented controls:
+
+- keyboard toggle so the phone keyboard stays out of the way until needed.
+- accessory keys for common terminal input like arrows and Esc.
+- reconnect behavior for spotty mobile networks.
+- long-running sessions stay alive on the machine even if the phone disconnects.
+
+Good mobile responses are short:
+
+```text
+y
+```
+
+```text
+continue, but keep scope to docs only
+```
+
+```text
+run the focused test first, then stop
+```
+
+## Multi-session habits
+
+Use names that make the phone list obvious:
+
+```text
+<project>-<task>-<agent>
+```
+
+Examples:
+
+```text
+wolfpack-readme-claude
+api-regression-codex
+linux-build-pi
+```
+
+For many sessions, prefer one agent per task. If a task becomes broad, stop the agent and split the task instead of letting one terminal become a mystery blob.
+
+## PWA cache weirdness
+
+After upgrades, a home-screen PWA can hold onto stale assets longer than a normal browser tab.
+
+If the UI looks stale after an update:
+
+1. fully close the PWA.
+2. reopen it.
+3. if still stale, open the same URL in the browser and refresh.
+4. run `wolfpack doctor` on the machine.
+
+## When to use desktop grid instead
+
+Use desktop grid when you need to watch several terminals at once or copy larger text between sessions.
+
+Use phone view when you only need to answer prompts, check status, or kick off a quick command.
+
+## Safety reminder
+
+Anyone who can access Wolfpack can interact with shells on that machine. Use Tailscale, consider JWT auth for shared tailnets, and treat Wolfpack access like shell access.

--- a/docs/multi-machine.md
+++ b/docs/multi-machine.md
@@ -1,0 +1,93 @@
+# Multi-Machine Setup
+
+Wolfpack can show sessions from multiple machines in one PWA when those machines are reachable over the same Tailscale tailnet.
+
+## Model
+
+Each machine runs its own Wolfpack server and broker:
+
+```text
+phone/browser
+  ↓ Tailscale HTTPS
+machine A: wolfpack server → local broker → local PTYs
+machine B: wolfpack server → local broker → local PTYs
+machine C: wolfpack server → local broker → local PTYs
+```
+
+There is no central Wolfpack coordinator. Your browser stores the machine list and talks to each machine directly.
+
+## Install on every machine
+
+Run this on each macOS/Linux machine:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/almogdepaz/wolfpack/main/install.sh | bash
+wolfpack
+```
+
+During setup, use the same Tailscale tailnet and let Wolfpack configure the Tailscale HTTPS URL where possible.
+
+Check each machine:
+
+```bash
+wolfpack doctor
+wolfpack service status
+tailscale status
+```
+
+## Add machines
+
+Open Wolfpack, then go to **Settings → Machines**.
+
+Use one of these paths:
+
+- **Discover peers** — Wolfpack asks the local server for reachable tailnet peers.
+- **Manual add** — add another machine's Wolfpack HTTPS URL.
+
+Machine URLs should look like:
+
+```text
+https://your-machine.your-tailnet.ts.net
+```
+
+Avoid LAN IPs for phone access. The phone usually cannot reach those once you leave the local network.
+
+## Example workflow
+
+- MacBook: frontend/UI agent session.
+- Linux workstation: tests/builds agent session.
+- Cloud VM: long-running refactor or benchmark.
+- Phone: supervise all sessions and respond when one asks for input.
+
+This is current functionality: you manually control sessions across machines. Direct agent-to-agent messaging is roadmap material, not a current launch claim.
+
+## Failure behavior
+
+Remote machines are best-effort. If one machine is down or slow:
+
+- reachable machines still render.
+- failed machines get shorter future timeouts.
+- the local machine remains usable.
+
+If a machine disappears:
+
+```bash
+wolfpack doctor
+wolfpack service restart
+tailscale status
+```
+
+Then retry **Settings → Machines → Discover peers**.
+
+## Security model
+
+Treat each Wolfpack URL like shell access to that machine.
+
+Recommended baseline:
+
+- keep Wolfpack behind Tailscale.
+- do not expose it directly to the public internet.
+- use optional JWT auth if your tailnet is shared broadly.
+- remember agent commands run with your local user permissions.
+
+JWT docs are in the main [README](../README.md#optional-jwt-auth).

--- a/docs/pi-quickstart.md
+++ b/docs/pi-quickstart.md
@@ -1,0 +1,103 @@
+# Pi / Coding-Agent Quickstart
+
+Use this when your main agent command is `pi` and you want to supervise it from your phone.
+
+## 1. Install Wolfpack
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/almogdepaz/wolfpack/main/install.sh | bash
+wolfpack
+```
+
+During setup:
+
+1. choose the directory that contains your projects, for example `~/Dev`.
+2. keep the default port unless it conflicts.
+3. let Wolfpack configure Tailscale remote access if prompted.
+4. install the service if you want Wolfpack to keep running after login/reboot.
+
+## 2. Confirm `pi` is available
+
+Wolfpack runs agent commands from the machine where the session starts. Confirm `pi` works there:
+
+```bash
+which pi
+pi --help
+```
+
+If `pi` needs shell setup that is not available to login services, create a small wrapper script on `PATH` and use that wrapper as the Wolfpack command.
+
+Example:
+
+```bash
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/pi-agent <<'EOF'
+#!/usr/bin/env bash
+exec pi "$@"
+EOF
+chmod +x ~/.local/bin/pi-agent
+```
+
+Then add `pi-agent` in **Settings → Agents**.
+
+## 3. Start your first Pi session
+
+1. Open Wolfpack.
+2. Pick a project.
+3. Pick `pi` from the agent command list.
+4. Start the session.
+5. Leave it running and open the same Wolfpack URL from your phone.
+
+Useful naming convention for sessions:
+
+```text
+<project>-<task>-<agent>
+```
+
+Examples:
+
+```text
+wolfpack-docs-pi
+api-tests-pi
+mobile-ui-pi
+```
+
+## 4. Add Wolfpack to your phone
+
+Open the Tailscale HTTPS URL printed by `wolfpack`, then add it to your home screen.
+
+On iOS:
+
+1. open the URL in Safari.
+2. tap Share.
+3. tap **Add to Home Screen**.
+
+On Android:
+
+1. open the URL in Chrome.
+2. open the browser menu.
+3. tap **Add to Home screen** or **Install app**.
+
+## 5. Add a second machine
+
+Install Wolfpack on each machine you want to control. Use the same Tailscale tailnet.
+
+After both machines are reachable, Wolfpack can discover peers or you can add machine URLs in **Settings → Machines**.
+
+Common setup:
+
+- laptop: run UI/agent sessions.
+- workstation/cloud VM: run tests/builds/long jobs.
+- phone: watch triage cards and jump into whichever session needs input.
+
+## 6. Recovery checklist
+
+If something does not show up:
+
+```bash
+wolfpack doctor
+wolfpack service status
+tailscale status
+```
+
+More detail: [troubleshooting.md](troubleshooting.md).


### PR DESCRIPTION
## Summary
- add Pi/coding-agent quickstart
- add mobile agent workflow guide
- add multi-machine setup guide
- link the new guides from the README

## Verification
- git diff --check
- bun run typecheck
- bun test tests/unit/doctor.test.ts --timeout 15000
- bun test tests/integration/desktop-terminal.test.ts --timeout 45000
- bun test --timeout 45000

Note: an initial default-timeout full-suite run hit local environment-sensitive timeouts in doctor/desktop-terminal tests; focused reruns and the final full suite with explicit per-test timeout passed.