### PR TITLE
Detect Ralph plans in .plans directory

### DIFF
--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -670,11 +670,17 @@ export const routes: Record<
     const projectDir = resolveProjectDir(res, project);
     if (!projectDir) return;
     try {
-      const files = readdirSync(projectDir)
+      const rootPlans = readdirSync(projectDir)
         .filter((f) => f.endsWith(".md") && !f.startsWith(".") && !/^(readme|doc|changelog|contributing|license|code.of.conduct)\.md$/i.test(f))
-        .filter((f) => { try { return statSync(join(projectDir, f)).isFile(); } catch { /* race: file removed between readdir and stat */ return false; } })
-        .sort();
-      json(res, { plans: files });
+        .filter((f) => { try { return statSync(join(projectDir, f)).isFile(); } catch { /* race: file removed between readdir and stat */ return false; } });
+      const dotPlansDir = join(projectDir, ".plans");
+      const dotPlans = existsSync(dotPlansDir)
+        ? readdirSync(dotPlansDir)
+          .map((f) => `.plans/${f}`)
+          .filter((f) => isValidPlanFile(f))
+          .filter((f) => { try { return statSync(join(projectDir, f)).isFile(); } catch { /* race: file removed between readdir and stat */ return false; } })
+        : [];
+      json(res, { plans: [...rootPlans, ...dotPlans].sort() });
     } catch (e: unknown) {
       log.warn("failed to list plan files", { error: errMsg(e) });
       json(res, { plans: [] });
@@ -967,7 +973,7 @@ export const routes: Record<
     }
 
     if (deletePlan && status.planFile) {
-      if (SAFE_FILENAME.test(status.planFile) && !status.planFile.includes("..")) {
+      if (isValidPlanFile(status.planFile)) {
         tryDelete(join(projectDir, status.planFile), status.planFile);
       } else {
         failed.push(status.planFile);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -13,6 +13,7 @@ import type { RalphAgent } from "./ralph-agent.js";
 export const CMD_REGEX = /^[a-zA-Z0-9 \-._/=]+$/;
 export const BRANCH_REGEX = /^(?!.*\.\.)(?!.*\/\/)[a-zA-Z0-9._\-/]+$/;
 export const PLAN_FILE_REGEX = /^[a-zA-Z0-9._\- ]+\.md$/;
+export const DOT_PLANS_FILE_REGEX = /^\.plans\/[a-zA-Z0-9._\- ]+\.md$/;
 export const SAFE_FILENAME = /^[a-zA-Z0-9._\- ]+$/;
 
 // ── Validation functions ──
@@ -26,7 +27,7 @@ export function isValidSessionName(name: string): boolean {
 }
 
 export function isValidPlanFile(name: string): boolean {
-  return PLAN_FILE_REGEX.test(name) && name !== ".." && name !== ".";
+  return (PLAN_FILE_REGEX.test(name) || DOT_PLANS_FILE_REGEX.test(name)) && name !== ".." && name !== ".";
 }
 
 // ── Budget expansion ──

--- a/tests/integration/ralph-api.test.ts
+++ b/tests/integration/ralph-api.test.ts
@@ -18,7 +18,7 @@ import {
   statSync,
   lstatSync,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { parseRalphLog, countPlanTasks, type RalphStatus } from "../../src/server/ralph.ts";
 import { isValidPlanFile } from "../../src/validation.ts";
@@ -142,6 +142,29 @@ const routes: Record<
   "GET /api/ralph": async (_req, res) => {
     const loops = scanRalphLoops();
     json(res, { loops });
+  },
+
+  "GET /api/ralph/plans": async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const project = url.searchParams.get("project");
+    if (!project || !isValidProjectName(project)) {
+      return json(res, { error: "invalid project" }, 400);
+    }
+    const projectDir = join(TEST_DEV_DIR, project);
+    if (!existsSync(projectDir)) {
+      return json(res, { error: "project directory not found" }, 404);
+    }
+    const rootPlans = readdirSync(projectDir)
+      .filter((f) => f.endsWith(".md") && !f.startsWith(".") && !/^(readme|doc|changelog|contributing|license|code.of.conduct)\.md$/i.test(f))
+      .filter((f) => { try { return statSync(join(projectDir, f)).isFile(); } catch { return false; } });
+    const dotPlansDir = join(projectDir, ".plans");
+    const dotPlans = existsSync(dotPlansDir)
+      ? readdirSync(dotPlansDir)
+        .map((f) => `.plans/${f}`)
+        .filter((f) => isValidPlanFile(f))
+        .filter((f) => { try { return statSync(join(projectDir, f)).isFile(); } catch { return false; } })
+      : [];
+    json(res, { plans: [...rootPlans, ...dotPlans].sort() });
   },
 
   "GET /api/ralph/task-count": async (req, res) => {
@@ -363,7 +386,7 @@ const routes: Record<
 
     // conditionally delete plan file
     if (deletePlan && status.planFile) {
-      if (SAFE_FILENAME.test(status.planFile) && !status.planFile.includes("..")) {
+      if (isValidPlanFile(status.planFile)) {
         tryDelete(join(projectDir, status.planFile), status.planFile);
       } else {
         failed.push(status.planFile);
@@ -460,6 +483,7 @@ function setupProject(
     writeFileSync(join(dir, ".ralph.log"), opts.log);
   }
   if (opts?.plan) {
+    mkdirSync(dirname(join(dir, opts.plan.name)), { recursive: true });
     writeFileSync(join(dir, opts.plan.name), opts.plan.content);
   }
   return dir;
@@ -660,6 +684,22 @@ describe("POST /api/ralph/start", () => {
     expect(res.status).toBe(404);
     const data = await res.json();
     expect(data.error).toContain("not found");
+  });
+
+  test(".plans plan file starts ralph loop", async () => {
+    setupProject("start-test", {
+      plan: { name: ".plans/adoption.md", content: "- [ ] task\n" },
+    });
+
+    const res = await post("/api/ralph/start", {
+      project: "start-test",
+      planFile: ".plans/adoption.md",
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(lastSpawnArgs).not.toBeNull();
+    expect(valueAfterFlag(lastSpawnArgs!.args, "--plan")).toBe(".plans/adoption.md");
   });
 
   test("custom plan file not found → 404", async () => {
@@ -1238,6 +1278,21 @@ describe("POST /api/ralph/dismiss", () => {
     expect(existsSync(join(dir, "MY-PLAN.md"))).toBe(false);
   });
 
+  test("dismiss with deletePlan deletes .plans plan file", async () => {
+    const dir = setupProject("dismiss-test", {
+      plan: { name: ".plans/adoption.md", content: "- [x] done\n" },
+      log: `ralph — 5 iterations\nagent: claude\nplan: .plans/adoption.md\npid: 2\nstarted: 2025-01-01\nfinished: 2025-01-01\n`,
+    });
+
+    const res = await post("/api/ralph/dismiss", { project: "dismiss-test", deletePlan: true });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.ok).toBe(true);
+    expect(data.deleted).toContain(".plans/adoption.md");
+    expect(data.failed).not.toContain(".plans/adoption.md");
+    expect(existsSync(join(dir, ".plans", "adoption.md"))).toBe(false);
+  });
+
   test("path traversal in plan file name → rejected at parse, dismiss succeeds cleanly", async () => {
     const dir = setupProject("dismiss-traversal");
     writeFileSync(join(dir, ".ralph.log"),
@@ -1359,6 +1414,27 @@ describe("GET /api/ralph", () => {
   });
 });
 
+describe("GET /api/ralph/plans", () => {
+  afterEach(() => {
+    cleanupProject("plans-proj");
+  });
+
+  test("lists root plans and .plans markdown plans", async () => {
+    setupProject("plans-proj", {
+      plan: { name: "PLAN.md", content: "- [ ] root\n" },
+    });
+    const dir = join(TEST_DEV_DIR, "plans-proj");
+    mkdirSync(join(dir, ".plans"), { recursive: true });
+    writeFileSync(join(dir, ".plans", "adoption.md"), "- [ ] dot plan\n");
+    writeFileSync(join(dir, ".plans", "notes.txt"), "not a plan\n");
+
+    const res = await get("/api/ralph/plans?project=plans-proj");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.plans).toEqual([".plans/adoption.md", "PLAN.md"]);
+  });
+});
+
 describe("GET /api/ralph/task-count", () => {
   afterEach(() => {
     cleanupProject("tc-proj");
@@ -1454,6 +1530,21 @@ describe("GET /api/ralph/task-count", () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.error).toBe("invalid plan file");
+  });
+
+  test(".plans plan file works", async () => {
+    setupProject("tc-proj", {
+      plan: {
+        name: ".plans/adoption.md",
+        content: "- [x] a\n- [ ] b\n",
+      },
+    });
+
+    const res = await get("/api/ralph/task-count?project=tc-proj&plan=" + encodeURIComponent(".plans/adoption.md"));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.done).toBe(1);
+    expect(data.total).toBe(2);
   });
 
   test("custom plan file name works", async () => {

--- a/tests/unit/validation-extracted.test.ts
+++ b/tests/unit/validation-extracted.test.ts
@@ -200,10 +200,14 @@ describe("isValidPlanFile", () => {
   test("accepts valid plan files", () => {
     expect(isValidPlanFile("PLAN.md")).toBe(true);
     expect(isValidPlanFile("my plan.md")).toBe(true);
+    expect(isValidPlanFile(".plans/adoption.md")).toBe(true);
   });
 
   test("rejects traversal and non-md", () => {
     expect(isValidPlanFile("../evil.md")).toBe(false);
+    expect(isValidPlanFile(".plans/../evil.md")).toBe(false);
+    expect(isValidPlanFile("plans/adoption.md")).toBe(false);
+    expect(isValidPlanFile(".plans/nested/adoption.md")).toBe(false);
     expect(isValidPlanFile("plan.txt")).toBe(false);
     expect(isValidPlanFile("")).toBe(false);
   });

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -13,7 +13,7 @@ const CMD_REGEX = /^[a-zA-Z0-9 \-._/=]+$/;
 
 /** Mirrors serve.ts plan file validation (inline in ralph start handler) */
 function isValidPlanFile(name: string): boolean {
-  return /^[a-zA-Z0-9._\- ]+\.md$/.test(name) && name !== ".." && name !== ".";
+  return (/^[a-zA-Z0-9._\- ]+\.md$/.test(name) || /^\.plans\/[a-zA-Z0-9._\- ]+\.md$/.test(name)) && name !== ".." && name !== ".";
 }
 
 /** Mirrors validation.ts BRANCH_REGEX — rejects .. and // sequences */
@@ -279,6 +279,10 @@ describe("isValidPlanFile", () => {
     expect(isValidPlanFile("plan123.md")).toBe(true);
   });
 
+  test("accepts .plans markdown files", () => {
+    expect(isValidPlanFile(".plans/adoption.md")).toBe(true);
+  });
+
   test("rejects file not ending in .md", () => {
     expect(isValidPlanFile("plan.txt")).toBe(false);
   });
@@ -295,8 +299,13 @@ describe("isValidPlanFile", () => {
     expect(isValidPlanFile("../evil.md")).toBe(false);
   });
 
-  test("rejects path with slashes", () => {
+  test("rejects path with slashes outside .plans", () => {
     expect(isValidPlanFile("subdir/plan.md")).toBe(false);
+  });
+
+  test("rejects nested or traversing .plans paths", () => {
+    expect(isValidPlanFile(".plans/nested/plan.md")).toBe(false);
+    expect(isValidPlanFile(".plans/../evil.md")).toBe(false);
   });
 
   test("rejects empty string", () => {


### PR DESCRIPTION
## Summary
- allow Ralph plan paths of the exact form `.plans/<name>.md`
- include `.plans/*.md` in the Ralph plan picker API
- support task counting/start/dismiss flows for `.plans` plan files
- keep traversal and nested-path rejection tests in place

## Verification
- bun run typecheck
- bun test tests/unit/validation-extracted.test.ts tests/unit/validation.test.ts --timeout 15000
- bun test tests/integration/ralph-api.test.ts --timeout 15000
- bun test --timeout 45000