### PR TITLE
Add session control CLI/API methods

### DIFF
--- a/docs/session-control.md
+++ b/docs/session-control.md
@@ -1,0 +1,40 @@
+# Session Control CLI/API
+
+Wolfpack exposes a small scriptable surface for agent automation. The server
+stays authoritative for auth, session validation, and broker access; the CLI
+only calls the local authenticated HTTP API except for `current-context`, which
+reads Wolfpack-provided environment variables in an agent process.
+
+## Command Surface
+
+- `wolfpack session read <session> [--json]`
+  - prints the current broker snapshot for a live session.
+  - json: `{ "session": string, "output": string }`
+- `wolfpack session send <session> <text...> [--no-enter] [--json]`
+  - sends text through the server to the broker input plane.
+  - appends Enter unless `--no-enter` is set.
+  - json: `{ "ok": true, "session": string }`
+- `wolfpack session wait <session> <text> [--timeout-ms <ms>] [--json]`
+  - waits for literal UTF-8 output text in the broker output stream.
+  - checks the current snapshot first, then subscribes to structured broker
+    output frames until timeout.
+  - json: `{ "ok": true, "session": string, "matched": true }`
+- `wolfpack session current-context [--json|--shell]`
+  - reports only context Wolfpack injected into the current process:
+    `WOLFPACK_SESSION_NAME` and `WOLFPACK_PROJECT_DIR`.
+  - it never guesses a target from terminal text or process ancestry.
+
+`split` is deliberately not part of this surface. Wolfpack grid/layout state is
+browser-owned today, and adding a CLI layout command would create a second
+authority path.
+
+## Exit Codes
+
+- `0`: success
+- `1`: unexpected server/API failure
+- `2`: command usage error
+- `3`: missing or unknown session/context
+- `4`: wait timeout
+- `5`: auth failure
+- `6`: backend/broker unavailable
+

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import {
 import { setup } from "./setup.js";
 import { doctor } from "./doctor.js";
 import { lsSessions, killSession } from "./sessions.js";
+import { runSessionCommand } from "./session-control.js";
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { migratePlanFormat, detectOldPlanFormat } from "../wolfpack-context.js";
@@ -171,6 +172,8 @@ async function main() {
     process.exit(await doctor());
   } else if (cmd === "ls" || cmd === "list") {
     process.exit(await lsSessions());
+  } else if (cmd === "session") {
+    process.exit(await runSessionCommand(process.argv.slice(3)));
   } else if (cmd === "kill") {
     process.exit(await killSession(subcmd));
   } else if (cmd === "uninstall") {

--- a/src/cli/session-control.ts
+++ b/src/cli/session-control.ts
@@ -1,0 +1,211 @@
+import { createHmac, randomBytes } from "node:crypto";
+import { print, red, yellow } from "./formatting.js";
+import { loadConfig } from "./config.js";
+
+export const SESSION_EXIT = {
+  OK: 0,
+  GENERAL: 1,
+  USAGE: 2,
+  NOT_FOUND: 3,
+  TIMEOUT: 4,
+  AUTH: 5,
+  BACKEND_UNAVAILABLE: 6,
+} as const;
+
+type OutputMode = "plain" | "json" | "shell";
+type SessionAction = "read" | "send" | "wait" | "current-context";
+
+export type ParsedSessionCommand =
+  | { ok: true; action: "read"; session: string; output: OutputMode }
+  | { ok: true; action: "send"; session: string; text: string; noEnter: boolean; output: OutputMode }
+  | { ok: true; action: "wait"; session: string; text: string; timeoutMs: number; output: OutputMode }
+  | { ok: true; action: "current-context"; output: OutputMode }
+  | { ok: false; message: string };
+
+interface ApiError {
+  readonly status: number;
+  readonly body: string;
+}
+
+function baseUrl(): string {
+  const config = loadConfig();
+  const port = config?.port ?? 18790;
+  return `http://127.0.0.1:${port}`;
+}
+
+function issueJwt(): string | null {
+  const secret = process.env.WOLFPACK_JWT_SECRET;
+  if (!secret || secret.length < 32) return null;
+  const now = Math.floor(Date.now() / 1000);
+  const payload: Record<string, unknown> = {
+    iat: now,
+    exp: now + 60,
+    jti: randomBytes(8).toString("hex"),
+  };
+  const iss = process.env.WOLFPACK_JWT_ISSUER?.trim();
+  if (iss) payload.iss = iss;
+  const aud = process.env.WOLFPACK_JWT_AUDIENCE?.trim();
+  if (aud) payload.aud = aud;
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const data = `${header}.${body}`;
+  const sig = createHmac("sha256", secret).update(data).digest("base64url");
+  return `${data}.${sig}`;
+}
+
+async function call(path: string, init: RequestInit = {}): Promise<unknown> {
+  const headers = new Headers(init.headers);
+  const jwt = issueJwt();
+  if (jwt) headers.set("Authorization", `Bearer ${jwt}`);
+  if (!headers.has("Content-Type") && init.body) headers.set("Content-Type", "application/json");
+  let resp: Response;
+  try {
+    resp = await fetch(`${baseUrl()}${path}`, { ...init, headers });
+  } catch (e: unknown) {
+    throw { status: 0, body: e instanceof Error ? e.message : String(e) } satisfies ApiError;
+  }
+  if (!resp.ok) throw { status: resp.status, body: await resp.text() } satisfies ApiError;
+  return resp.json();
+}
+
+function consumeFlag(args: string[], flag: string): boolean {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return false;
+  args.splice(idx, 1);
+  return true;
+}
+
+function consumeValue(args: string[], flag: string): string | null {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return null;
+  const value = args[idx + 1];
+  if (!value || value.startsWith("--")) return "";
+  args.splice(idx, 2);
+  return value;
+}
+
+function parseOutputMode(args: string[]): { mode: OutputMode; shellRequested: boolean } {
+  const json = consumeFlag(args, "--json");
+  const shell = consumeFlag(args, "--shell");
+  return { mode: shell ? "shell" : json ? "json" : "plain", shellRequested: shell };
+}
+
+export function parseSessionCommand(argv: readonly string[]): ParsedSessionCommand {
+  const args = [...argv];
+  const action = args.shift() as SessionAction | undefined;
+  if (!action) return { ok: false, message: "Usage: wolfpack session <read|send|wait|current-context> ..." };
+  if (!["read", "send", "wait", "current-context"].includes(action)) {
+    return { ok: false, message: `Unknown session command: ${action}` };
+  }
+  const { mode: output, shellRequested } = parseOutputMode(args);
+  if (action === "current-context") {
+    if (args.length > 0) return { ok: false, message: "Usage: wolfpack session current-context [--json|--shell]" };
+    return { ok: true, action, output };
+  }
+  if (shellRequested) {
+    return { ok: false, message: "--shell is only valid for current-context" };
+  }
+  const session = args.shift();
+  if (!session) return { ok: false, message: `Usage: wolfpack session ${action} <session> ...` };
+  if (action === "read") {
+    if (args.length > 0) return { ok: false, message: "Usage: wolfpack session read <session> [--json]" };
+    return { ok: true, action, session, output };
+  }
+  if (action === "send") {
+    const noEnter = consumeFlag(args, "--no-enter");
+    const text = args.join(" ");
+    if (!text) return { ok: false, message: "Usage: wolfpack session send <session> <text...> [--no-enter] [--json]" };
+    return { ok: true, action, session, text, noEnter, output };
+  }
+  const timeoutRaw = consumeValue(args, "--timeout-ms");
+  const timeoutMs = timeoutRaw == null ? 30_000 : Number(timeoutRaw);
+  const text = args.join(" ");
+  if (!text || !Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 600_000) {
+    return { ok: false, message: "Usage: wolfpack session wait <session> <text> [--timeout-ms <1..600000>] [--json]" };
+  }
+  return { ok: true, action, session, text, timeoutMs, output };
+}
+
+function jsonOut(value: unknown): void {
+  process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function mapApiError(e: unknown): number {
+  const err = e as Partial<ApiError>;
+  if (err.status === 401) {
+    print(red("auth required"));
+    return SESSION_EXIT.AUTH;
+  }
+  if (err.status === 404) {
+    print(yellow("session not found"));
+    return SESSION_EXIT.NOT_FOUND;
+  }
+  if (err.status === 408) {
+    print(yellow("timeout"));
+    return SESSION_EXIT.TIMEOUT;
+  }
+  if (err.status === 503) {
+    print(red("backend unavailable"));
+    return SESSION_EXIT.BACKEND_UNAVAILABLE;
+  }
+  print(red(`session command failed: ${err.body ?? String(e)}`));
+  return SESSION_EXIT.GENERAL;
+}
+
+export async function runSessionCommand(argv: readonly string[]): Promise<number> {
+  const parsed = parseSessionCommand(argv);
+  if (!parsed.ok) {
+    print(red(parsed.message));
+    return SESSION_EXIT.USAGE;
+  }
+
+  if (parsed.action === "current-context") {
+    const context = {
+      session: process.env.WOLFPACK_SESSION_NAME || "",
+      projectDir: process.env.WOLFPACK_PROJECT_DIR || "",
+    };
+    if (!context.session && !context.projectDir) {
+      if (parsed.output === "json") jsonOut(context);
+      else print(yellow("no wolfpack context in this process"));
+      return SESSION_EXIT.NOT_FOUND;
+    }
+    if (parsed.output === "json") jsonOut(context);
+    else if (parsed.output === "shell") {
+      process.stdout.write(`WOLFPACK_SESSION_NAME=${shellQuote(context.session)}\n`);
+      process.stdout.write(`WOLFPACK_PROJECT_DIR=${shellQuote(context.projectDir)}\n`);
+    } else {
+      if (context.session) print(context.session);
+      if (context.projectDir) print(context.projectDir);
+    }
+    return SESSION_EXIT.OK;
+  }
+
+  try {
+    if (parsed.action === "read") {
+      const data = await call(`/api/session-control/read?session=${encodeURIComponent(parsed.session)}`) as { output: string };
+      if (parsed.output === "json") jsonOut({ session: parsed.session, output: data.output });
+      else process.stdout.write(data.output);
+      return SESSION_EXIT.OK;
+    }
+    if (parsed.action === "send") {
+      await call("/api/session-control/send", {
+        method: "POST",
+        body: JSON.stringify({ session: parsed.session, text: parsed.text, noEnter: parsed.noEnter }),
+      });
+      if (parsed.output === "json") jsonOut({ ok: true, session: parsed.session });
+      return SESSION_EXIT.OK;
+    }
+    await call("/api/session-control/wait", {
+      method: "POST",
+      body: JSON.stringify({ session: parsed.session, text: parsed.text, timeoutMs: parsed.timeoutMs }),
+    });
+    if (parsed.output === "json") jsonOut({ ok: true, session: parsed.session, matched: true });
+    return SESSION_EXIT.OK;
+  } catch (e: unknown) {
+    return mapApiError(e);
+  }
+}

--- a/src/server/broker-backend.ts
+++ b/src/server/broker-backend.ts
@@ -212,6 +212,7 @@ export class BrokerBackend implements SessionBackend, PtyBackendMethods {
       ["TERM", "xterm-256color"],
       ["LANG", "en_US.UTF-8"],
       ["WOLFPACK_PROJECT_DIR", cwd],
+      ["WOLFPACK_SESSION_NAME", name],
     ];
 
     let resp: ControlResponse;

--- a/src/server/mock-backend.ts
+++ b/src/server/mock-backend.ts
@@ -29,6 +29,9 @@ export class MockBackend implements SessionBackend {
   lastCreateArgs: { name: string; cwd: string; cmd: string | undefined } | null = null;
   /** Last arguments passed to resize (name, cols, rows). */
   lastResizeArgs: { name: string; cols: number; rows: number } | null = null;
+  /** Last arguments passed to send (name, text, noEnter). */
+  lastSendArgs: { name: string; text: string; noEnter: boolean | undefined } | null = null;
+  private readonly _outputSubscribers = new Map<string, Set<(data: Uint8Array) => void>>();
 
   constructor(opts: MockBackendOptions = {}) {
     this._sessions = new Set(opts.sessions ?? []);
@@ -90,8 +93,8 @@ export class MockBackend implements SessionBackend {
     this.lastResizeArgs = { name, cols, rows };
   }
 
-  async send(): Promise<void> {
-    // no-op in mock
+  async send(name: string, text: string, noEnter?: boolean): Promise<void> {
+    this.lastSendArgs = { name, text, noEnter };
   }
 
   async sendKey(): Promise<void> {
@@ -123,12 +126,28 @@ export class MockBackend implements SessionBackend {
   }
 
   onSessionData(
-    _name: string,
-    _cb: (data: Uint8Array) => void,
+    name: string,
+    cb: (data: Uint8Array) => void,
     _opts: { sinceSeq?: bigint; onSubscribeError: (err: unknown) => void },
   ): (() => void) | null {
-    // No real data stream — return a no-op unsubscribe
-    return () => {};
+    if (!this._sessions.has(name)) return null;
+    let subscribers = this._outputSubscribers.get(name);
+    if (!subscribers) {
+      subscribers = new Set();
+      this._outputSubscribers.set(name, subscribers);
+    }
+    subscribers.add(cb);
+    return () => {
+      const current = this._outputSubscribers.get(name);
+      if (!current) return;
+      current.delete(cb);
+      if (current.size === 0) this._outputSubscribers.delete(name);
+    };
+  }
+
+  emitSessionData(name: string, text: string): void {
+    const data = new TextEncoder().encode(text);
+    for (const cb of this._outputSubscribers.get(name) ?? []) cb(data);
   }
 
   writeToTerminal(_name: string, _data: Buffer | string): void {

--- a/src/server/mock-backend.ts
+++ b/src/server/mock-backend.ts
@@ -32,6 +32,9 @@ export class MockBackend implements SessionBackend {
   /** Last arguments passed to send (name, text, noEnter). */
   lastSendArgs: { name: string; text: string; noEnter: boolean | undefined } | null = null;
   private readonly _outputSubscribers = new Map<string, Set<(data: Uint8Array) => void>>();
+  private readonly _outputHistory = new Map<string, Array<{ seq: bigint; data: Uint8Array }>>();
+  private _nextOutputSeq = 1n;
+  private _onAfterPrefill: ((name: string, seq: bigint) => void) | null = null;
 
   constructor(opts: MockBackendOptions = {}) {
     this._sessions = new Set(opts.sessions ?? []);
@@ -47,6 +50,10 @@ export class MockBackend implements SessionBackend {
   /** Override capturePane at runtime. */
   setCapturePane(fn: (session: string) => Promise<string>): void {
     this._capturePane = fn;
+  }
+
+  setOnAfterPrefill(fn: ((name: string, seq: bigint) => void) | null): void {
+    this._onAfterPrefill = fn;
   }
 
   async list(): Promise<string[]> {
@@ -128,9 +135,14 @@ export class MockBackend implements SessionBackend {
   onSessionData(
     name: string,
     cb: (data: Uint8Array) => void,
-    _opts: { sinceSeq?: bigint; onSubscribeError: (err: unknown) => void },
+    opts: { sinceSeq?: bigint; onSubscribeError: (err: unknown) => void },
   ): (() => void) | null {
     if (!this._sessions.has(name)) return null;
+    if (opts.sinceSeq !== undefined) {
+      for (const event of this._outputHistory.get(name) ?? []) {
+        if (event.seq > opts.sinceSeq) queueMicrotask(() => cb(event.data));
+      }
+    }
     let subscribers = this._outputSubscribers.get(name);
     if (!subscribers) {
       subscribers = new Set();
@@ -147,6 +159,10 @@ export class MockBackend implements SessionBackend {
 
   emitSessionData(name: string, text: string): void {
     const data = new TextEncoder().encode(text);
+    const seq = this._nextOutputSeq++;
+    const history = this._outputHistory.get(name) ?? [];
+    history.push({ seq, data });
+    this._outputHistory.set(name, history);
     for (const cb of this._outputSubscribers.get(name) ?? []) cb(data);
   }
 
@@ -154,8 +170,11 @@ export class MockBackend implements SessionBackend {
     // no-op in mock
   }
 
-  getSessionPrefill(_name: string, _cols?: number, _options?: { scrollbackLines?: number }): { data: Buffer; seq?: bigint } {
-    return { data: Buffer.alloc(0) };
+  async getSessionPrefill(name: string, _cols?: number, _options?: { scrollbackLines?: number }): Promise<{ data: Buffer; seq?: bigint }> {
+    const seq = this._nextOutputSeq - 1n;
+    const data = Buffer.from(this._sessions.has(name) ? stripAnsi(await this._capturePane(name)) : "");
+    this._onAfterPrefill?.(name, seq);
+    return { data, seq };
   }
 
   onSessionLifecycle(_name: string, _cb: (event: unknown) => void): (() => void) | null {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -167,16 +167,21 @@ function parseTimeoutMs(value: unknown): number | null {
 }
 
 async function waitForSessionText(session: string, text: string, timeoutMs: number): Promise<"matched" | "timeout" | "unavailable"> {
-  const existing = await getBackend().capturePane(session);
-  if (existing.includes(text)) return "matched";
-
   const streaming = getRouter().getStreamingBackendForSession(session);
-  if (!streaming) return "unavailable";
+  if (!streaming) {
+    const existing = await getBackend().capturePane(session);
+    return existing.includes(text) ? "matched" : "unavailable";
+  }
+
+  const decoder = new TextDecoder();
+  const prefill = await streaming.getSessionPrefill(session);
+  const initial = decoder.decode(prefill.data);
+  if (initial.includes(text)) return "matched";
+  if (prefill.seq === undefined) return "unavailable";
 
   return await new Promise((resolve) => {
-    const decoder = new TextDecoder();
     let done = false;
-    let buffer = "";
+    let buffer = initial.slice(-SESSION_WAIT_BUFFER_MAX_CHARS);
     let unsubscribe: (() => void) | null = null;
     const finish = (result: "matched" | "timeout" | "unavailable") => {
       if (done) return;
@@ -193,6 +198,7 @@ async function waitForSessionText(session: string, text: string, timeoutMs: numb
       }
       if (buffer.includes(text)) finish("matched");
     }, {
+      sinceSeq: prefill.seq,
       onSubscribeError: () => finish("unavailable"),
     });
     if (!unsubscribe) finish("unavailable");

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -53,6 +53,9 @@ import {
 const PEER_FETCH_TIMEOUT_MS = 3_000;
 const RALPH_LOG_MAX_TAIL_BYTES = 128 * 1024;
 const RALPH_LOG_MAX_LINES = 500;
+const SESSION_WAIT_DEFAULT_TIMEOUT_MS = 30_000;
+const SESSION_WAIT_MAX_TIMEOUT_MS = 600_000;
+const SESSION_WAIT_BUFFER_MAX_CHARS = 128 * 1024;
 
 // ── Peer ralph-response validation ──
 
@@ -154,6 +157,46 @@ function resolveProjectDir(res: ServerResponse, project: string | null | undefin
   const dir = join(DEV_DIR, project);
   if (!validateProjectDir(res, dir)) return null;
   return dir;
+}
+
+function parseTimeoutMs(value: unknown): number | null {
+  if (value == null) return SESSION_WAIT_DEFAULT_TIMEOUT_MS;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1 || n > SESSION_WAIT_MAX_TIMEOUT_MS) return null;
+  return n;
+}
+
+async function waitForSessionText(session: string, text: string, timeoutMs: number): Promise<"matched" | "timeout" | "unavailable"> {
+  const existing = await getBackend().capturePane(session);
+  if (existing.includes(text)) return "matched";
+
+  const streaming = getRouter().getStreamingBackendForSession(session);
+  if (!streaming) return "unavailable";
+
+  return await new Promise((resolve) => {
+    const decoder = new TextDecoder();
+    let done = false;
+    let buffer = "";
+    let unsubscribe: (() => void) | null = null;
+    const finish = (result: "matched" | "timeout" | "unavailable") => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try { unsubscribe?.(); } catch { /* cleanup best effort */ }
+      resolve(result);
+    };
+    const timer = setTimeout(() => finish("timeout"), timeoutMs);
+    unsubscribe = streaming.onSessionData(session, (data) => {
+      buffer += decoder.decode(data, { stream: true });
+      if (buffer.length > SESSION_WAIT_BUFFER_MAX_CHARS) {
+        buffer = buffer.slice(-SESSION_WAIT_BUFFER_MAX_CHARS);
+      }
+      if (buffer.includes(text)) finish("matched");
+    }, {
+      onSubscribeError: () => finish("unavailable"),
+    });
+    if (!unsubscribe) finish("unavailable");
+  });
 }
 
 const VERSION: string = pkg.version;
@@ -514,6 +557,66 @@ export const routes: Record<
     prevPaneContent.delete(session);
     await getBackend().killSession(session);
     json(res, { ok: true });
+  },
+
+  "GET /api/session-control/read": async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const session = url.searchParams.get("session");
+    if (!session) return json(res, { error: "missing session" }, 400);
+    if (!(await isAllowedSession(session))) {
+      return json(res, { error: "session not found" }, 404);
+    }
+    try {
+      const output = await getBackend().capturePane(session);
+      json(res, { session, output });
+    } catch (e: unknown) {
+      log.warn("session-control read failed", { session, error: errMsg(e) });
+      json(res, { error: "backend unavailable" }, 503);
+    }
+  },
+
+  "POST /api/session-control/send": async (req, res) => {
+    const body = await parseBody<{ session?: string; text?: string; noEnter?: boolean }>(req, res);
+    if (!body) return;
+    const session = body.session;
+    if (!session) return json(res, { error: "missing session" }, 400);
+    if (typeof body.text !== "string") return json(res, { error: "missing text" }, 400);
+    if (!(await isAllowedSession(session))) {
+      return json(res, { error: "session not found" }, 404);
+    }
+    try {
+      await getBackend().send(session, body.text, body.noEnter === true);
+      json(res, { ok: true, session });
+    } catch (e: unknown) {
+      log.warn("session-control send failed", { session, error: errMsg(e) });
+      json(res, { error: "backend unavailable" }, 503);
+    }
+  },
+
+  "POST /api/session-control/wait": async (req, res) => {
+    const body = await parseBody<{ session?: string; text?: string; timeoutMs?: number }>(req, res);
+    if (!body) return;
+    const session = body.session;
+    if (!session) return json(res, { error: "missing session" }, 400);
+    if (typeof body.text !== "string" || body.text.length === 0) {
+      return json(res, { error: "missing text" }, 400);
+    }
+    const timeoutMs = parseTimeoutMs(body.timeoutMs);
+    if (timeoutMs === null) {
+      return json(res, { error: `timeoutMs must be an integer from 1 to ${SESSION_WAIT_MAX_TIMEOUT_MS}` }, 400);
+    }
+    if (!(await isAllowedSession(session))) {
+      return json(res, { error: "session not found" }, 404);
+    }
+    try {
+      const result = await waitForSessionText(session, body.text, timeoutMs);
+      if (result === "matched") return json(res, { ok: true, session, matched: true });
+      if (result === "timeout") return json(res, { error: "timeout", session, matched: false }, 408);
+      return json(res, { error: "backend unavailable" }, 503);
+    } catch (e: unknown) {
+      log.warn("session-control wait failed", { session, error: errMsg(e) });
+      json(res, { error: "backend unavailable" }, 503);
+    }
   },
 
   "POST /api/resize": async (req, res) => {

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -346,6 +346,78 @@ describe("POST /api/create", () => {
   });
 });
 
+describe("session control API", () => {
+  beforeEach(() => {
+    mockBackend.setSessions(["wolf-1", "wolf-2"]);
+    mockBackend.setCapturePane(async (s: string) => `captured output for ${s}\n`);
+    mockBackend.lastSendArgs = null;
+  });
+
+  test("reads current output from backend snapshot", async () => {
+    const res = await get("/api/session-control/read?session=wolf-1");
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ session: "wolf-1", output: "captured output for wolf-1\n" });
+  });
+
+  test("send validates session then delegates to backend", async () => {
+    const res = await post("/api/session-control/send", {
+      session: "wolf-1",
+      text: "echo hi",
+      noEnter: true,
+    });
+    expect(res.status).toBe(200);
+    expect(mockBackend.lastSendArgs).toEqual({ name: "wolf-1", text: "echo hi", noEnter: true });
+  });
+
+  test("send returns 404 for unknown session", async () => {
+    const res = await post("/api/session-control/send", {
+      session: "ghost",
+      text: "echo hi",
+    });
+    expect(res.status).toBe(404);
+    expect(mockBackend.lastSendArgs).toBeNull();
+  });
+
+  test("wait succeeds from existing snapshot without subscribing", async () => {
+    const res = await post("/api/session-control/wait", {
+      session: "wolf-1",
+      text: "output for wolf-1",
+      timeoutMs: 50,
+    });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ ok: true, session: "wolf-1", matched: true });
+  });
+
+  test("wait succeeds from later broker output", async () => {
+    mockBackend.setCapturePane(async () => "booting\n");
+    const wait = post("/api/session-control/wait", {
+      session: "wolf-1",
+      text: "ready",
+      timeoutMs: 500,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    mockBackend.emitSessionData("wolf-1", "system ready\n");
+    const res = await wait;
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ ok: true, session: "wolf-1", matched: true });
+  });
+
+  test("wait returns 408 on timeout", async () => {
+    mockBackend.setCapturePane(async () => "booting\n");
+    const res = await post("/api/session-control/wait", {
+      session: "wolf-1",
+      text: "never appears",
+      timeoutMs: 10,
+    });
+    expect(res.status).toBe(408);
+    const data = await res.json();
+    expect(data.matched).toBe(false);
+  });
+});
+
 describe("GET /api/next-session-name", () => {
   beforeEach(() => {
     mockBackend.setSessions(["wolf-1", "wolf-2"]);

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -350,6 +350,7 @@ describe("session control API", () => {
   beforeEach(() => {
     mockBackend.setSessions(["wolf-1", "wolf-2"]);
     mockBackend.setCapturePane(async (s: string) => `captured output for ${s}\n`);
+    mockBackend.setOnAfterPrefill(null);
     mockBackend.lastSendArgs = null;
   });
 
@@ -400,6 +401,23 @@ describe("session control API", () => {
     await new Promise((resolve) => setTimeout(resolve, 25));
     mockBackend.emitSessionData("wolf-1", "system ready\n");
     const res = await wait;
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual({ ok: true, session: "wolf-1", matched: true });
+  });
+
+  test("wait replays output emitted between snapshot and subscribe", async () => {
+    mockBackend.setCapturePane(async () => "booting\n");
+    mockBackend.setOnAfterPrefill((session) => {
+      mockBackend.emitSessionData(session, "system ready\n");
+    });
+
+    const res = await post("/api/session-control/wait", {
+      session: "wolf-1",
+      text: "ready",
+      timeoutMs: 100,
+    });
+
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data).toEqual({ ok: true, session: "wolf-1", matched: true });

--- a/tests/unit/broker-backend.test.ts
+++ b/tests/unit/broker-backend.test.ts
@@ -215,6 +215,7 @@ describe("BrokerBackend.createSession", () => {
     const envKeys = params.env.map(([k]) => k);
     expect(envKeys).toContain("TERM");
     expect(envKeys).toContain("WOLFPACK_PROJECT_DIR");
+    expect(params.env).toContainEqual(["WOLFPACK_SESSION_NAME", "newone"]);
     // sessionDir is now resolvable without another list call
     expect(backend.sessionDir("newone")).toBe("/tmp/work");
   });

--- a/tests/unit/session-control.test.ts
+++ b/tests/unit/session-control.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { SESSION_EXIT, parseSessionCommand } from "../../src/cli/session-control.ts";
+
+describe("session control cli parsing", () => {
+  test("parses read with json output", () => {
+    expect(parseSessionCommand(["read", "alpha", "--json"])).toEqual({
+      ok: true,
+      action: "read",
+      session: "alpha",
+      output: "json",
+    });
+  });
+
+  test("parses send text and no-enter flag", () => {
+    expect(parseSessionCommand(["send", "alpha", "echo", "hi", "--no-enter"])).toEqual({
+      ok: true,
+      action: "send",
+      session: "alpha",
+      text: "echo hi",
+      noEnter: true,
+      output: "plain",
+    });
+  });
+
+  test("parses wait timeout", () => {
+    expect(parseSessionCommand(["wait", "alpha", "ready", "--timeout-ms", "250"])).toEqual({
+      ok: true,
+      action: "wait",
+      session: "alpha",
+      text: "ready",
+      timeoutMs: 250,
+      output: "plain",
+    });
+  });
+
+  test("rejects invalid wait timeout", () => {
+    const parsed = parseSessionCommand(["wait", "alpha", "ready", "--timeout-ms", "0"]);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test("parses current context shell output", () => {
+    expect(parseSessionCommand(["current-context", "--shell"])).toEqual({
+      ok: true,
+      action: "current-context",
+      output: "shell",
+    });
+  });
+
+  test("rejects shell output for server-backed commands", () => {
+    const parsed = parseSessionCommand(["read", "alpha", "--shell"]);
+    expect(parsed.ok).toBe(false);
+  });
+
+  test("exit code map is stable", () => {
+    expect(SESSION_EXIT).toEqual({
+      OK: 0,
+      GENERAL: 1,
+      USAGE: 2,
+      NOT_FOUND: 3,
+      TIMEOUT: 4,
+      AUTH: 5,
+      BACKEND_UNAVAILABLE: 6,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add session read/send/wait/current-context control surface
- add CLI/API/backend wiring and tests

Source plan: `.plans/h-cli-socket-control-methods.md`

## Verification
- cherry-picked Ralph task commit onto fresh branch from `main`
