### PR TITLE
Add agent UI detection manifests

### DIFF
--- a/docs/ralph-behavior.md
+++ b/docs/ralph-behavior.md
@@ -212,6 +212,23 @@ Main worktree + per-section sub-worktrees:
 | PID dead + finished timestamp present | `limit` (hit iteration cap) |
 | Otherwise | `idle` |
 
+Phase detection has two layers:
+
+1. Explicit worker lifecycle markers are authoritative: `=== 🥋 Wax Inspect —` and `=== 🥋 Wax Off —`, with their matching complete/failed markers.
+2. Data-only agent UI detection manifests are fallback signals for active processes when explicit markers do not match. They may set only fallback phase flags (`audit` or `cleanup`) and include diagnostics (`manifestId`, `version`, `source`, `sourceKind`, `matchedRule`, `confidence`) in the status response.
+
+Manifest semantics:
+
+- Schema version is `1`.
+- A manifest contains `manifestId`, `version`, `generatedAt`, optional `validUntil`, and agent entries.
+- A rule contains `id`, `status` (`audit` or `cleanup`), `confidence`, and bounded string patterns: `contains`, `startsWith`, and `notContains`.
+- Manifests are data only. Executable-looking fields such as `script`, `command`, `exec`, `eval`, `shell`, or `code` are rejected.
+- Matches are fallback UI/status hints, not completion authority. Completion remains strict via `all_tasks_done: true`.
+
+Fallback priority is explicit lifecycle markers, then user manifests from `WOLFPACK_AGENT_UI_MANIFEST` (colon-separated paths), then an opt-in cached manifest from `WOLFPACK_AGENT_UI_MANIFEST_CACHE`, then bundled defaults. Malformed, oversized, stale, or untrusted manifests are ignored and bundled defaults continue to load.
+
+Remote update safety is intentionally transport-neutral: no automatic network fetch is enabled. A caller that obtains remote bytes must opt in by calling the update acceptance path with an expected SHA-256 and JSON content type. The update is rejected unless it is under 64 KiB, integrity matches, schema validation passes, `validUntil` is fresh, executable-looking fields are absent, and the file can be atomically written to the cache path. The previous known-good cache remains in place when validation fails.
+
 Completion detection is strict: the worker writes `all_tasks_done: true` to the log only when `extractCurrentTask()` returns null and the plan has tasks. No count-based heuristics — the extractor is the single source of truth.
 
 Task counts (for progress bar display): `tasksTotal` from plan file, `tasksDone` from progress file `DONE:` line count. These are display-only and not used for completion detection.

--- a/src/agent-ui-detection-manifest.ts
+++ b/src/agent-ui-detection-manifest.ts
@@ -1,0 +1,388 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import { basename, dirname, join } from "node:path";
+
+export const AGENT_UI_MANIFEST_SCHEMA_VERSION = 1;
+export const AGENT_UI_MANIFEST_MAX_BYTES = 64 * 1024;
+export const AGENT_UI_PATTERN_MAX_CHARS = 256;
+export const AGENT_UI_MAX_RULES = 64;
+
+export type AgentUiStatus = "audit" | "cleanup";
+export type AgentUiManifestSourceKind = "bundled" | "user" | "cached";
+
+export interface AgentUiDetectionRule {
+  readonly id: string;
+  readonly status: AgentUiStatus;
+  readonly confidence: number;
+  readonly contains?: readonly string[];
+  readonly startsWith?: readonly string[];
+  readonly notContains?: readonly string[];
+}
+
+export interface AgentUiDetectionAgent {
+  readonly id: string;
+  readonly versionConstraints?: readonly string[];
+  readonly rules: readonly AgentUiDetectionRule[];
+}
+
+export interface AgentUiDetectionManifest {
+  readonly schemaVersion: 1;
+  readonly manifestId: string;
+  readonly version: string;
+  readonly generatedAt: string;
+  readonly validUntil?: string;
+  readonly agents: readonly AgentUiDetectionAgent[];
+}
+
+export interface LoadedAgentUiDetectionManifest {
+  readonly manifest: AgentUiDetectionManifest;
+  readonly source: string;
+  readonly sourceKind: AgentUiManifestSourceKind;
+}
+
+export interface AgentUiDetectionDiagnostics {
+  readonly manifestId: string;
+  readonly version: string;
+  readonly source: string;
+  readonly sourceKind: AgentUiManifestSourceKind;
+  readonly matchedRule?: string;
+  readonly confidence?: number;
+}
+
+export interface AgentUiDetectionMatch {
+  readonly status: AgentUiStatus;
+  readonly diagnostics: AgentUiDetectionDiagnostics;
+}
+
+export interface LoadAgentUiDetectionManifestsOptions {
+  readonly userManifestPaths?: readonly string[];
+  readonly cachedManifestPath?: string;
+  readonly now?: Date;
+}
+
+export interface AcceptAgentUiManifestUpdateOptions {
+  readonly bytes: string | Buffer;
+  readonly expectedSha256: string;
+  readonly contentType: string;
+  readonly cachePath: string;
+  readonly now?: Date;
+}
+
+export interface AcceptAgentUiManifestUpdateResult {
+  readonly accepted: boolean;
+  readonly reason?: string;
+  readonly manifest?: LoadedAgentUiDetectionManifest;
+}
+
+const BUNDLED_MANIFEST: AgentUiDetectionManifest = {
+  schemaVersion: AGENT_UI_MANIFEST_SCHEMA_VERSION,
+  manifestId: "wolfpack.ralph.bundled",
+  version: "2026.07.11",
+  generatedAt: "2026-07-11T00:00:00.000Z",
+  agents: [
+    {
+      id: "ralph",
+      versionConstraints: ["*"],
+      rules: [
+        {
+          id: "ralph.audit.wax-inspect",
+          status: "audit",
+          confidence: 0.82,
+          contains: ["Wax Inspect"],
+          notContains: ["Wax Inspect complete", "Wax Inspect FAILED"],
+        },
+        {
+          id: "ralph.cleanup.wax-off",
+          status: "cleanup",
+          confidence: 0.82,
+          contains: ["Wax Off"],
+          notContains: ["Wax Off complete", "Wax Off FAILED"],
+        },
+      ],
+    },
+  ],
+};
+
+const ALLOWED_CONTENT_TYPES = new Set([
+  "application/json",
+  "application/manifest+json",
+  "text/json",
+]);
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}t\d{2}:\d{2}:\d{2}(?:\.\d{3})?z$/i;
+const SAFE_ID_RE = /^[a-z0-9._-]{1,80}$/;
+const SAFE_VERSION_RE = /^[a-z0-9._:+-]{1,80}$/i;
+const FORBIDDEN_KEYS = new Set(["code", "command", "commands", "eval", "exec", "script", "shell"]);
+
+export function bundledAgentUiDetectionManifest(): LoadedAgentUiDetectionManifest {
+  return {
+    manifest: BUNDLED_MANIFEST,
+    source: "bundled",
+    sourceKind: "bundled",
+  };
+}
+
+export function loadAgentUiDetectionManifests(
+  options: LoadAgentUiDetectionManifestsOptions = {},
+): LoadedAgentUiDetectionManifest[] {
+  const now = options.now ?? new Date();
+  const loaded: LoadedAgentUiDetectionManifest[] = [bundledAgentUiDetectionManifest()];
+
+  if (options.cachedManifestPath) {
+    const cached = loadManifestFile(options.cachedManifestPath, "cached", now);
+    if (cached) loaded.push(cached);
+  }
+
+  for (const path of options.userManifestPaths ?? []) {
+    const user = loadManifestFile(path, "user", now);
+    if (user) loaded.push(user);
+  }
+
+  return loaded;
+}
+
+export function detectAgentUiStatusFromManifests(
+  manifests: readonly LoadedAgentUiDetectionManifest[],
+  agentId: string,
+  content: string,
+): AgentUiDetectionMatch | null {
+  for (const loaded of [...manifests].reverse()) {
+    const agent = loaded.manifest.agents.find((candidate) => candidate.id === agentId);
+    if (!agent) continue;
+
+    let best: { rule: AgentUiDetectionRule; score: number } | null = null;
+    for (const rule of agent.rules) {
+      if (!ruleMatches(rule, content)) continue;
+      if (!best || rule.confidence > best.score) best = { rule, score: rule.confidence };
+    }
+
+    if (best) {
+      return {
+        status: best.rule.status,
+        diagnostics: {
+          manifestId: loaded.manifest.manifestId,
+          version: loaded.manifest.version,
+          source: loaded.source,
+          sourceKind: loaded.sourceKind,
+          matchedRule: best.rule.id,
+          confidence: best.rule.confidence,
+        },
+      };
+    }
+  }
+
+  return null;
+}
+
+export function acceptAgentUiManifestUpdate(
+  options: AcceptAgentUiManifestUpdateOptions,
+): AcceptAgentUiManifestUpdateResult {
+  const contentType = options.contentType.split(";")[0]?.trim().toLowerCase();
+  if (!contentType || !ALLOWED_CONTENT_TYPES.has(contentType)) {
+    return { accepted: false, reason: "unsupported content type" };
+  }
+
+  const bytes = Buffer.isBuffer(options.bytes) ? options.bytes : Buffer.from(options.bytes, "utf-8");
+  if (bytes.byteLength > AGENT_UI_MANIFEST_MAX_BYTES) {
+    return { accepted: false, reason: "manifest too large" };
+  }
+
+  const actualSha256 = createHash("sha256").update(bytes).digest("hex");
+  if (!constantTimeHexEqual(actualSha256, options.expectedSha256)) {
+    return { accepted: false, reason: "sha256 mismatch" };
+  }
+
+  const parsed = parseManifestText(bytes.toString("utf-8"), options.now ?? new Date());
+  if (!parsed.ok) return { accepted: false, reason: parsed.reason };
+
+  mkdirSync(dirname(options.cachePath), { recursive: true, mode: 0o700 });
+  const tmpPath = join(dirname(options.cachePath), `.${basename(options.cachePath)}.${Date.now()}.tmp`);
+  writeFileSync(tmpPath, bytes, { mode: 0o600 });
+  renameSync(tmpPath, options.cachePath);
+
+  return {
+    accepted: true,
+    manifest: {
+      manifest: parsed.manifest,
+      source: options.cachePath,
+      sourceKind: "cached",
+    },
+  };
+}
+
+export function validateAgentUiDetectionManifest(
+  value: unknown,
+  now: Date = new Date(),
+): { ok: true; manifest: AgentUiDetectionManifest } | { ok: false; reason: string } {
+  if (!isPlainObject(value)) return { ok: false, reason: "manifest must be an object" };
+  if (hasForbiddenKey(value)) return { ok: false, reason: "manifest contains executable fields" };
+  if (value.schemaVersion !== AGENT_UI_MANIFEST_SCHEMA_VERSION) return { ok: false, reason: "unsupported schema version" };
+  if (!isSafeId(value.manifestId)) return { ok: false, reason: "invalid manifest id" };
+  if (!isSafeVersion(value.version)) return { ok: false, reason: "invalid manifest version" };
+  if (!isIsoDate(value.generatedAt)) return { ok: false, reason: "invalid generatedAt" };
+  if (value.validUntil !== undefined && !isIsoDate(value.validUntil)) return { ok: false, reason: "invalid validUntil" };
+  if (value.validUntil && Date.parse(value.validUntil) <= now.getTime()) return { ok: false, reason: "stale manifest" };
+  if (!Array.isArray(value.agents) || value.agents.length === 0) return { ok: false, reason: "agents required" };
+
+  const agents: AgentUiDetectionAgent[] = [];
+  let ruleCount = 0;
+  for (const agentValue of value.agents) {
+    if (!isPlainObject(agentValue)) return { ok: false, reason: "agent must be an object" };
+    if (!isSafeId(agentValue.id)) return { ok: false, reason: "invalid agent id" };
+    if (agentValue.versionConstraints !== undefined && !isStringArray(agentValue.versionConstraints, 12)) {
+      return { ok: false, reason: "invalid version constraints" };
+    }
+    if (!Array.isArray(agentValue.rules) || agentValue.rules.length === 0) return { ok: false, reason: "rules required" };
+
+    const rules: AgentUiDetectionRule[] = [];
+    for (const ruleValue of agentValue.rules) {
+      ruleCount++;
+      if (ruleCount > AGENT_UI_MAX_RULES) return { ok: false, reason: "too many rules" };
+      const rule = validateRule(ruleValue);
+      if (!rule.ok) return rule;
+      rules.push(rule.rule);
+    }
+
+    agents.push({
+      id: agentValue.id,
+      versionConstraints: agentValue.versionConstraints,
+      rules,
+    });
+  }
+
+  return {
+    ok: true,
+    manifest: {
+      schemaVersion: AGENT_UI_MANIFEST_SCHEMA_VERSION,
+      manifestId: value.manifestId,
+      version: value.version,
+      generatedAt: value.generatedAt,
+      validUntil: value.validUntil,
+      agents,
+    },
+  };
+}
+
+function loadManifestFile(
+  path: string,
+  sourceKind: AgentUiManifestSourceKind,
+  now: Date,
+): LoadedAgentUiDetectionManifest | null {
+  try {
+    if (!existsSync(path)) return null;
+    const bytes = readFileSync(path);
+    if (bytes.byteLength > AGENT_UI_MANIFEST_MAX_BYTES) return null;
+    const parsed = parseManifestText(bytes.toString("utf-8"), now);
+    if (!parsed.ok) return null;
+    return { manifest: parsed.manifest, source: path, sourceKind };
+  } catch {
+    return null;
+  }
+}
+
+function parseManifestText(
+  text: string,
+  now: Date,
+): { ok: true; manifest: AgentUiDetectionManifest } | { ok: false; reason: string } {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return { ok: false, reason: "invalid json" };
+  }
+  return validateAgentUiDetectionManifest(value, now);
+}
+
+function validateRule(
+  value: unknown,
+): { ok: true; rule: AgentUiDetectionRule } | { ok: false; reason: string } {
+  if (!isPlainObject(value)) return { ok: false, reason: "rule must be an object" };
+  if (!isSafeId(value.id)) return { ok: false, reason: "invalid rule id" };
+  if (value.status !== "audit" && value.status !== "cleanup") return { ok: false, reason: "invalid status" };
+  if (typeof value.confidence !== "number" || !Number.isFinite(value.confidence) || value.confidence < 0 || value.confidence > 1) {
+    return { ok: false, reason: "invalid confidence" };
+  }
+  if (value.contains !== undefined && !isPatternArray(value.contains)) return { ok: false, reason: "invalid contains patterns" };
+  if (value.startsWith !== undefined && !isPatternArray(value.startsWith)) return { ok: false, reason: "invalid startsWith patterns" };
+  if (value.notContains !== undefined && !isPatternArray(value.notContains)) return { ok: false, reason: "invalid notContains patterns" };
+  if (!value.contains && !value.startsWith) return { ok: false, reason: "positive pattern required" };
+
+  return {
+    ok: true,
+    rule: {
+      id: value.id,
+      status: value.status,
+      confidence: value.confidence,
+      contains: value.contains,
+      startsWith: value.startsWith,
+      notContains: value.notContains,
+    },
+  };
+}
+
+function ruleMatches(rule: AgentUiDetectionRule, content: string): boolean {
+  for (const needle of rule.contains ?? []) {
+    if (!content.includes(needle)) return false;
+  }
+  for (const prefix of rule.startsWith ?? []) {
+    if (!content.split("\n").some((line) => line.startsWith(prefix))) return false;
+  }
+  for (const needle of rule.notContains ?? []) {
+    if (content.includes(needle)) return false;
+  }
+  return true;
+}
+
+function hasForbiddenKey(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(hasForbiddenKey);
+  if (!isPlainObject(value)) return false;
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_KEYS.has(key.toLowerCase())) return true;
+    if (hasForbiddenKey(child)) return true;
+  }
+  return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSafeId(value: unknown): value is string {
+  return typeof value === "string" && SAFE_ID_RE.test(value);
+}
+
+function isSafeVersion(value: unknown): value is string {
+  return typeof value === "string" && SAFE_VERSION_RE.test(value);
+}
+
+function isIsoDate(value: unknown): value is string {
+  return typeof value === "string" && ISO_DATE_RE.test(value) && Number.isFinite(Date.parse(value));
+}
+
+function isStringArray(value: unknown, maxItems: number): value is string[] {
+  return Array.isArray(value)
+    && value.length <= maxItems
+    && value.every((item) => typeof item === "string" && item.length > 0 && item.length <= AGENT_UI_PATTERN_MAX_CHARS);
+}
+
+function isPatternArray(value: unknown): value is string[] {
+  return isStringArray(value, 12);
+}
+
+function constantTimeHexEqual(actual: string, expected: string): boolean {
+  if (!/^[a-f0-9]{64}$/i.test(expected)) return false;
+  const actualBytes = Buffer.from(actual, "hex");
+  const expectedBytes = Buffer.from(expected, "hex");
+  if (actualBytes.byteLength !== expectedBytes.byteLength) return false;
+  let diff = 0;
+  for (let i = 0; i < actualBytes.byteLength; i++) {
+    diff |= actualBytes[i] ^ expectedBytes[i];
+  }
+  return diff === 0;
+}

--- a/src/server/ralph.ts
+++ b/src/server/ralph.ts
@@ -13,8 +13,26 @@ import { isProcessAlive, isRalphProcessAlive } from "../shared/process-cleanup.j
 import { join, normalize, isAbsolute } from "node:path";
 import { countTasksInContent, validatePlanFormat } from "../wolfpack-context.js";
 import { DEV_DIR } from "./dev-dir.js";
+import {
+  detectAgentUiStatusFromManifests,
+  loadAgentUiDetectionManifests,
+  type LoadAgentUiDetectionManifestsOptions,
+  type AgentUiDetectionDiagnostics,
+} from "../agent-ui-detection-manifest.js";
 
 const log = createLogger("ralph");
+
+function agentUiManifestLoadOptions(): LoadAgentUiDetectionManifestsOptions {
+  const userManifestPaths = process.env.WOLFPACK_AGENT_UI_MANIFEST
+    ?.split(":")
+    .map((p) => p.trim())
+    .filter(Boolean);
+  const cachedManifestPath = process.env.WOLFPACK_AGENT_UI_MANIFEST_CACHE?.trim();
+  return {
+    userManifestPaths,
+    cachedManifestPath: cachedManifestPath || undefined,
+  };
+}
 
 /** Returns true if p is a safe relative path — no absolute paths, no .. traversal. */
 function isSafeRelativePath(p: string): boolean {
@@ -45,6 +63,7 @@ export interface RalphStatus {
   worktreeMode: string;
   worktreeBranch: string;
   sandbox: string;
+  detectionManifest?: AgentUiDetectionDiagnostics;
 }
 
 export function listDevProjects(): string[] {
@@ -187,6 +206,16 @@ export function parseRalphLog(projectDir: string): RalphStatus | null {
       }
       if (content.includes("=== 🥋 Wax Off —") && !content.includes("Wax Off complete") && !content.includes("Wax Off FAILED")) {
         status.cleanup = true;
+      }
+      if (!status.audit && !status.cleanup) {
+        const manifestMatch = detectAgentUiStatusFromManifests(
+          loadAgentUiDetectionManifests(agentUiManifestLoadOptions()),
+          "ralph",
+          content,
+        );
+        if (manifestMatch?.status === "audit") status.audit = true;
+        if (manifestMatch?.status === "cleanup") status.cleanup = true;
+        if (manifestMatch) status.detectionManifest = manifestMatch.diagnostics;
       }
     }
 

--- a/tests/unit/agent-ui-detection-manifest.test.ts
+++ b/tests/unit/agent-ui-detection-manifest.test.ts
@@ -1,0 +1,228 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  acceptAgentUiManifestUpdate,
+  AGENT_UI_MANIFEST_MAX_BYTES,
+  bundledAgentUiDetectionManifest,
+  detectAgentUiStatusFromManifests,
+  loadAgentUiDetectionManifests,
+  validateAgentUiDetectionManifest,
+} from "../../src/agent-ui-detection-manifest.js";
+import { parseRalphLog } from "../../src/server/ralph.js";
+import { startFakeRalph, stopFakeRalph, type FakeRalph } from "../helpers/fake-ralph-pid.js";
+
+let fakeRalph: FakeRalph | null = null;
+let fakeRalphPid = process.pid;
+let tmpDir: string;
+const originalUserManifest = process.env.WOLFPACK_AGENT_UI_MANIFEST;
+const originalCachedManifest = process.env.WOLFPACK_AGENT_UI_MANIFEST_CACHE;
+
+beforeAll(() => {
+  fakeRalph = startFakeRalph();
+  fakeRalphPid = fakeRalph.pid;
+});
+
+afterAll(() => {
+  if (fakeRalph) stopFakeRalph(fakeRalph);
+});
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "agent-ui-manifest-"));
+  delete process.env.WOLFPACK_AGENT_UI_MANIFEST;
+  delete process.env.WOLFPACK_AGENT_UI_MANIFEST_CACHE;
+});
+
+afterEach(() => {
+  if (originalUserManifest === undefined) delete process.env.WOLFPACK_AGENT_UI_MANIFEST;
+  else process.env.WOLFPACK_AGENT_UI_MANIFEST = originalUserManifest;
+  if (originalCachedManifest === undefined) delete process.env.WOLFPACK_AGENT_UI_MANIFEST_CACHE;
+  else process.env.WOLFPACK_AGENT_UI_MANIFEST_CACHE = originalCachedManifest;
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function manifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    manifestId: "test.ralph",
+    version: "2026.07.11",
+    generatedAt: "2026-07-11T00:00:00.000Z",
+    validUntil: "2027-07-11T00:00:00.000Z",
+    agents: [
+      {
+        id: "ralph",
+        versionConstraints: ["*"],
+        rules: [
+          {
+            id: "test.cleanup",
+            status: "cleanup",
+            confidence: 0.91,
+            contains: ["Custom Cleanup Started"],
+            notContains: ["Custom Cleanup Done"],
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function writeManifestFile(name: string, value: unknown): string {
+  const path = join(tmpDir, name);
+  writeFileSync(path, JSON.stringify(value));
+  return path;
+}
+
+function writeProjectLog(content: string): string {
+  const projectDir = join(tmpDir, "project");
+  rmSync(projectDir, { recursive: true, force: true });
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(join(projectDir, "PLAN.md"), "- [ ] task\n");
+  writeFileSync(join(projectDir, "progress.txt"), "");
+  writeFileSync(join(projectDir, ".ralph.log"), [
+    "🥋 ralph — 5 iterations",
+    "agent: claude",
+    "plan: PLAN.md",
+    "progress: progress.txt",
+    "phase_cleanup: on",
+    "phase_audit_fix: off",
+    `pid: ${fakeRalphPid}`,
+    "started: Mon Jan 01 2024 12:00:00",
+    "",
+    content,
+  ].join("\n"));
+  return projectDir;
+}
+
+function sha256(text: string | Buffer): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+describe("agent UI detection manifests", () => {
+  test("bundled manifest provides fallback detection below explicit hooks", () => {
+    const match = detectAgentUiStatusFromManifests(
+      [bundledAgentUiDetectionManifest()],
+      "ralph",
+      "worker says Wax Off is underway",
+    );
+
+    expect(match?.status).toBe("cleanup");
+    expect(match?.diagnostics.sourceKind).toBe("bundled");
+    expect(match?.diagnostics.matchedRule).toBe("ralph.cleanup.wax-off");
+  });
+
+  test("user manifests override cached and bundled manifests", () => {
+    const cachedPath = writeManifestFile("cached.json", manifest({
+      manifestId: "cached.ralph",
+      agents: [{ id: "ralph", rules: [{ id: "cached.audit", status: "audit", confidence: 0.5, contains: ["same token"] }] }],
+    }));
+    const userPath = writeManifestFile("user.json", manifest({
+      manifestId: "user.ralph",
+      agents: [{ id: "ralph", rules: [{ id: "user.cleanup", status: "cleanup", confidence: 0.5, contains: ["same token"] }] }],
+    }));
+
+    const loaded = loadAgentUiDetectionManifests({
+      cachedManifestPath: cachedPath,
+      userManifestPaths: [userPath],
+      now: new Date("2026-07-11T00:00:00.000Z"),
+    });
+    const match = detectAgentUiStatusFromManifests(loaded, "ralph", "same token");
+
+    expect(match?.status).toBe("cleanup");
+    expect(match?.diagnostics.sourceKind).toBe("user");
+    expect(match?.diagnostics.manifestId).toBe("user.ralph");
+  });
+
+  test("malformed and oversized local manifests fail closed to bundled defaults", () => {
+    const malformedPath = join(tmpDir, "bad.json");
+    writeFileSync(malformedPath, "{");
+    const oversizedPath = join(tmpDir, "oversized.json");
+    writeFileSync(oversizedPath, "x".repeat(AGENT_UI_MANIFEST_MAX_BYTES + 1));
+
+    const loaded = loadAgentUiDetectionManifests({
+      userManifestPaths: [malformedPath, oversizedPath],
+      now: new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    expect(loaded.map((entry) => entry.sourceKind)).toEqual(["bundled"]);
+  });
+
+  test("rejects executable-looking manifest fields", () => {
+    const result = validateAgentUiDetectionManifest(
+      manifest({ script: "rm -rf ." }),
+      new Date("2026-07-11T00:00:00.000Z"),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("manifest contains executable fields");
+  });
+
+  test("rejects stale manifests", () => {
+    const result = validateAgentUiDetectionManifest(
+      manifest({ validUntil: "2026-01-01T00:00:00.000Z" }),
+      new Date("2026-07-11T00:00:00.000Z"),
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("stale manifest");
+  });
+
+  test("accepts cached updates only with trusted content type and matching sha256", () => {
+    const body = JSON.stringify(manifest({ manifestId: "remote.ralph" }));
+    const cachePath = join(tmpDir, "cache", "agent-ui.json");
+    const rejectedType = acceptAgentUiManifestUpdate({
+      bytes: body,
+      expectedSha256: sha256(body),
+      contentType: "text/plain",
+      cachePath,
+      now: new Date("2026-07-11T00:00:00.000Z"),
+    });
+    const rejectedHash = acceptAgentUiManifestUpdate({
+      bytes: body,
+      expectedSha256: "0".repeat(64),
+      contentType: "application/json",
+      cachePath,
+      now: new Date("2026-07-11T00:00:00.000Z"),
+    });
+    const accepted = acceptAgentUiManifestUpdate({
+      bytes: body,
+      expectedSha256: sha256(body),
+      contentType: "application/json; charset=utf-8",
+      cachePath,
+      now: new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    expect(rejectedType).toEqual({ accepted: false, reason: "unsupported content type" });
+    expect(rejectedHash).toEqual({ accepted: false, reason: "sha256 mismatch" });
+    expect(accepted.accepted).toBe(true);
+    expect(existsSync(cachePath)).toBe(true);
+    expect(JSON.parse(readFileSync(cachePath, "utf-8")).manifestId).toBe("remote.ralph");
+  });
+
+  test("parseRalphLog uses manifests only when explicit phase markers do not match", () => {
+    const userPath = writeManifestFile("user.json", manifest());
+    process.env.WOLFPACK_AGENT_UI_MANIFEST = userPath;
+    const fallbackProject = writeProjectLog("Custom Cleanup Started\nworking");
+    const fallback = parseRalphLog(fallbackProject);
+
+    expect(fallback?.cleanup).toBe(true);
+    expect(fallback?.detectionManifest?.sourceKind).toBe("user");
+    expect(fallback?.detectionManifest?.matchedRule).toBe("test.cleanup");
+
+    const explicitProject = writeProjectLog("=== 🥋 Wax Inspect — starting audit+fix — now ===\nCustom Cleanup Started");
+    const explicit = parseRalphLog(explicitProject);
+
+    expect(explicit?.audit).toBe(true);
+    expect(explicit?.cleanup).toBe(false);
+    expect(explicit?.detectionManifest).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add local/updatable agent UI detection manifest support
- add docs-adjacent behavior and unit tests

Source plan: `.plans/i-updatable-agent-ui-detection-manifests.md`

## Verification
- cherry-picked Ralph task commit onto fresh branch from `main`
