### PR TITLE
Improve live update handoff flow

### DIFF
--- a/docs/live-update-handoff.md
+++ b/docs/live-update-handoff.md
@@ -1,0 +1,52 @@
+# Live update handoff
+
+Wolfpack has two independently managed processes:
+
+- `wolfpack` server: HTTP, WebSocket, static UI, and broker client.
+- `wolfpack-broker`: PTY owner, child-process owner, replay ring, terminal snapshots, and output stream sequence numbers.
+
+## Current restart behavior
+
+Server-only restart is intended to be non-destructive. The server drops browser WebSockets and its broker client connection, then a fresh server reconnects to the same broker socket. Broker sessions, child PTYs, replay rings, and terminal snapshots remain owned by the still-running broker. Browser clients must reconnect and rehydrate from broker snapshots plus replay.
+
+Broker restart is destructive today. The broker owns the PTY file descriptors and child processes, and there is no implemented broker-to-broker fd/state transfer protocol. Stopping or restarting the broker terminates broker-owned sessions and invalidates active browser attachments. Any update flow that restarts the broker must report that blast radius before it proceeds.
+
+## Server-only update flow
+
+When the CLI replaces the stable `wolfpack` server binary while the service is already running, it must restart only the server. It must not route the update through full service install, because service install stages and bootstraps the broker before starting the server.
+
+The safe phase-1 flow is:
+
+1. copy the current `wolfpack` binary to `~/.wolfpack/bin/wolfpack`.
+2. read `/api/backend` when available to report active broker session count.
+3. stop the server service only.
+4. start the server service only, preserving the existing broker process and socket.
+5. let browser sessions reconnect and rehydrate from broker-owned state.
+
+If `/api/backend` is unavailable because the server is down, unreachable, or auth-protected, the CLI reports that the active broker session count is unavailable. The blast radius remains server-only: browser attachments disconnect briefly, but broker-owned PTYs should persist.
+
+## Broker handoff design gate
+
+Broker binary replacement remains design-first. Do not implement live broker handoff until tests prove that the platform can transfer every required ownership boundary without output gaps or duplication.
+
+A viable protocol needs:
+
+- versioned broker-to-broker handshake with explicit compatibility failure.
+- PTY fd and child-process ownership transfer, or a documented platform-specific equivalent.
+- terminal snapshot sequence at freeze time.
+- replay ring lower/upper sequence bounds.
+- subscriber set and reconnect policy.
+- resize/write handling while transfer is in flight.
+- rollback behavior when the new broker fails before it becomes authoritative.
+
+Initial non-goal: replacing the broker binary without PTY fd/state transfer. A stop/start broker update is still a destructive restart and must be labeled that way.
+
+## Failure modes to verify
+
+Required coverage for the current phase:
+
+- Rust broker tests continue to prove snapshot/replay sequencing and subscription behavior.
+- TS service lifecycle tests prove server binary updates choose server-only restart instead of full broker install.
+- Integration/e2e broker restart tests prove server restart preserves sessions and broker death does not leave stale session truth.
+
+Future broker handoff coverage must add output-during-transfer, subscriber reconnect, resize-in-flight, handshake downgrade, and rollback-failure cases before enabling broker handoff by default.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -89,6 +89,7 @@ wolfpack service restart --broker
 ## Sessions disappeared after broker restart
 
 The broker owns PTYs. Restarting the server preserves sessions; restarting/stopping the broker is destructive.
+See [`live-update-handoff.md`](live-update-handoff.md) for the current restart blast radius and broker handoff design gate.
 
 Use server-only lifecycle commands unless you intentionally want to kill all broker-owned sessions:
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,6 +46,15 @@ export function planServiceEnsureAction(
   return installed ? "start" : "install";
 }
 
+export function planBinaryUpdateAction(
+  binaryUpdated: boolean,
+  running: boolean,
+  installed: boolean,
+): "server-restart" | "noop" | "start" | "install" {
+  if (binaryUpdated && running) return "server-restart";
+  return planServiceEnsureAction(running, installed);
+}
+
 export function hasUninstallConfirmationFlag(argv: string[]): boolean {
   return argv.includes("--yes") || argv.includes("--force");
 }
@@ -90,14 +99,12 @@ async function start() {
   const binaryUpdated = updateStableBinary();
   const wasRunning = isServiceRunning();
   try {
-    if (binaryUpdated && wasRunning) {
-      // new binary on disk but old version still in memory — reinstall
-      serviceInstall();
-    } else {
-      const action = planServiceEnsureAction(wasRunning, isServiceInstalled());
-      if (action === "start") serviceStart();
-      else if (action === "install") serviceInstall();
-    }
+    const action = planBinaryUpdateAction(binaryUpdated, wasRunning, isServiceInstalled());
+    if (action === "server-restart") {
+      print(dim("  Updated server binary; restarting server only so broker sessions stay attached to the broker."));
+      serviceRestart({ broker: false, skipBrokerSessionWarning: true });
+    } else if (action === "start") serviceStart();
+    else if (action === "install") serviceInstall();
   } catch (e) {
     print(red(`  Service startup failed: ${e}`));
     print(dim("  Run 'wolfpack service install' to retry."));

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -304,21 +304,6 @@ export interface ServiceActionOptions {
   readonly skipBrokerSessionWarning?: boolean;
 }
 
-function describeBrokerSessionCount(activeBrokerSessions: number | null): string {
-  if (activeBrokerSessions === null) return "active broker session count unavailable";
-  const sessions = activeBrokerSessions === 1 ? "session" : "sessions";
-  return `${activeBrokerSessions} active broker ${sessions}`;
-}
-
-function printRestartBlastRadius(restartBroker: boolean, activeBrokerSessions: number | null): void {
-  const count = describeBrokerSessionCount(activeBrokerSessions);
-  if (restartBroker) {
-    print(yellow(`  Broker restart requested; ${count} may be terminated.`));
-  } else {
-    print(dim(`  Server-only restart; ${count} will remain broker-owned.`));
-  }
-}
-
 function launchdBootout() {
   try {
     execSync(`launchctl bootout ${LAUNCHD_TARGET} 2>/dev/null`);
@@ -719,7 +704,12 @@ export function serviceRestart(options: ServiceActionOptions = {}) {
   const restartBroker = options.broker ?? (
     ask(brokerRestartPrompt(activeBrokerSessions)).toLowerCase() === "y"
   );
-  printRestartBlastRadius(restartBroker, activeBrokerSessions);
+  const sessionCount = activeBrokerSessions === null
+    ? "active broker session count unavailable"
+    : `${activeBrokerSessions} active broker ${activeBrokerSessions === 1 ? "session" : "sessions"}`;
+  print(restartBroker
+    ? yellow(`  Broker restart requested; ${sessionCount} may be terminated.`)
+    : dim(`  Server-only restart; ${sessionCount} will remain broker-owned.`));
   const skipBrokerSessionWarning = options.skipBrokerSessionWarning ?? promptedForBroker;
   if (!serviceStop({ broker: restartBroker, skipBrokerSessionWarning })) return;
   serviceStart({ broker: restartBroker });

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -17,7 +17,7 @@ import { join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { xmlEsc, systemdEsc } from "../validation.js";
 import { createLogger, errMsg } from "../log.js";
-import { print, bold, green, red, dim } from "./formatting.js";
+import { print, bold, green, red, dim, yellow } from "./formatting.js";
 
 const log = createLogger("service");
 import {
@@ -302,6 +302,21 @@ const BROKER_LAUNCHD_TARGET = `${LAUNCHD_DOMAIN}/com.wolfpack.broker`;
 export interface ServiceActionOptions {
   readonly broker?: boolean;
   readonly skipBrokerSessionWarning?: boolean;
+}
+
+function describeBrokerSessionCount(activeBrokerSessions: number | null): string {
+  if (activeBrokerSessions === null) return "active broker session count unavailable";
+  const sessions = activeBrokerSessions === 1 ? "session" : "sessions";
+  return `${activeBrokerSessions} active broker ${sessions}`;
+}
+
+function printRestartBlastRadius(restartBroker: boolean, activeBrokerSessions: number | null): void {
+  const count = describeBrokerSessionCount(activeBrokerSessions);
+  if (restartBroker) {
+    print(yellow(`  Broker restart requested; ${count} may be terminated.`));
+  } else {
+    print(dim(`  Server-only restart; ${count} will remain broker-owned.`));
+  }
 }
 
 function launchdBootout() {
@@ -699,11 +714,14 @@ function brokerRestartPrompt(activeBrokerSessions: number | null): string {
 }
 
 export function serviceRestart(options: ServiceActionOptions = {}) {
+  const activeBrokerSessions = readBrokerSessionCount(loadConfig());
   const promptedForBroker = options.broker === undefined;
   const restartBroker = options.broker ?? (
-    ask(brokerRestartPrompt(readBrokerSessionCount(loadConfig()))).toLowerCase() === "y"
+    ask(brokerRestartPrompt(activeBrokerSessions)).toLowerCase() === "y"
   );
-  if (!serviceStop({ broker: restartBroker, skipBrokerSessionWarning: promptedForBroker })) return;
+  printRestartBlastRadius(restartBroker, activeBrokerSessions);
+  const skipBrokerSessionWarning = options.skipBrokerSessionWarning ?? promptedForBroker;
+  if (!serviceStop({ broker: restartBroker, skipBrokerSessionWarning })) return;
   serviceStart({ broker: restartBroker });
 }
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { remoteUrl, type Config } from "../../src/cli/config.ts";
-import { planServiceEnsureAction, hasUninstallConfirmationFlag, parseServiceCommand } from "../../src/cli/index.ts";
+import {
+  planBinaryUpdateAction,
+  planServiceEnsureAction,
+  hasUninstallConfirmationFlag,
+  parseServiceCommand,
+} from "../../src/cli/index.ts";
 
 describe("remoteUrl", () => {
   const base: Config = { devDir: "/home/dev", port: 18790 };
@@ -36,6 +41,22 @@ describe("planServiceEnsureAction", () => {
 
   test("installs the service when it is not yet installed", () => {
     expect(planServiceEnsureAction(false, false)).toBe("install");
+  });
+});
+
+describe("planBinaryUpdateAction", () => {
+  test("restarts only the running server after a binary update", () => {
+    expect(planBinaryUpdateAction(true, true, true)).toBe("server-restart");
+  });
+
+  test("falls back to normal service planning when no running binary was replaced", () => {
+    expect(planBinaryUpdateAction(false, true, true)).toBe("noop");
+    expect(planBinaryUpdateAction(false, false, true)).toBe("start");
+    expect(planBinaryUpdateAction(false, false, false)).toBe("install");
+  });
+
+  test("installs when an updated binary has no running service to restart", () => {
+    expect(planBinaryUpdateAction(true, false, false)).toBe("install");
   });
 });
 

--- a/tests/unit/service-lifecycle.test.ts
+++ b/tests/unit/service-lifecycle.test.ts
@@ -69,6 +69,18 @@ describe("serviceRestart", () => {
     ]);
     expect(execCommands).toContain("systemctl --user stop wolfpack-broker 2>/dev/null");
   });
+
+  test("server-only update restart does not prompt for or stop the broker", () => {
+    execCommands.length = 0;
+    askPrompts.length = 0;
+    curlBackendResponse = JSON.stringify({ counts: { broker: 2 } });
+
+    serviceRestart({ broker: false, skipBrokerSessionWarning: true });
+
+    expect(askPrompts).toEqual([]);
+    expect(execCommands).toContain("systemctl --user stop wolfpack");
+    expect(execCommands).not.toContain("systemctl --user stop wolfpack-broker 2>/dev/null");
+  });
 });
 `;
 


### PR DESCRIPTION
## Summary
- document live update handoff behavior
- improve server-only update/restart flow
- include Ralph cleanup simplification for the touched service path

Source plan: `.plans/j-live-update-handoff.md`

## Verification
- cherry-picked Ralph task commit(s) onto fresh branch from `main`
- removed runner-owned `progress.txt` from the PR branch
