### PR TITLE
fix(broker): isolate alternate-screen snapshots

### DIFF
--- a/.plans/013-alt-screen-snapshot-isolation.md
+++ b/.plans/013-alt-screen-snapshot-isolation.md
@@ -1,0 +1,30 @@
+# alternate-screen snapshot isolation
+
+status: implementation and local verification complete; remote PR CI is the final gate
+branch: fix/alt-screen-snapshot-isolation
+base: main@ed009b3
+
+## goal
+
+Prevent broker snapshots taken while the alternate screen is active from exposing primary-screen scrollback.
+
+## evidence
+
+Deployed integration QA reproduced primary shell history in an alternate-screen reconnect snapshot on narrow viewports. `TerminalState::snapshot_with_reflow` selects the active visible buffer but always serializes `inner.scrollback`, which belongs to the primary screen.
+
+## steps
+
+- [completed] make the existing active-buffer snapshot test create primary scrollback and observe the leak.
+- [completed] suppress primary scrollback while `inner.on_alt` is true.
+- [completed] verify Rust (174), Bun (1,695 with local Git signing disabled to match CI), five consecutive iphone-se broker reconnect E2Es, release broker build, rustfmt, diff hygiene, and standalone security review approval.
+- [completed] prepare the clean branch for a separate PR against `main`.
+
+## remote gate
+
+- push `fix/alt-screen-snapshot-isolation` and open a PR against `main`.
+- require fresh CI to pass before merge.
+
+## boundaries
+
+- no session-open, session-control, mobile-scrolling, deployment, or integration-plan changes.
+- no merge or release.

--- a/broker/src/terminal_state.rs
+++ b/broker/src/terminal_state.rs
@@ -283,12 +283,17 @@ impl TerminalState {
         };
         let visible_screen = active.lines.iter().map(line_to_styled).collect();
 
-        // Truncate first (at raw-row granularity), then reflow.
-        let total = inner.scrollback.len();
-        let start = scrollback_limit
-            .map(|n| total.saturating_sub(n))
-            .unwrap_or(0);
-        let scrollback_rows: Vec<Row> = inner.scrollback.iter().skip(start).cloned().collect();
+        // The alternate screen is isolated from primary-screen history.
+        // Truncate primary scrollback first (at raw-row granularity), then reflow.
+        let scrollback_rows: Vec<Row> = if inner.on_alt {
+            Vec::new()
+        } else {
+            let total = inner.scrollback.len();
+            let start = scrollback_limit
+                .map(|n| total.saturating_sub(n))
+                .unwrap_or(0);
+            inner.scrollback.iter().skip(start).cloned().collect()
+        };
         let scrollback_rows = match target_cols {
             Some(tc) if tc > 0 => reflow_lines(&scrollback_rows, tc),
             _ => scrollback_rows,
@@ -1888,9 +1893,10 @@ mod tests {
     #[test]
     fn snapshot_visible_screen_follows_active_buffer() {
         // On alt screen the visible_screen must reflect the alt grid, and
-        // scrollback must stay empty (alt scrolls don't feed the ring).
+        // primary-screen scrollback must remain hidden.
         let mut t = TerminalState::new(4, 2);
-        t.feed(b"primary");
+        t.feed(b"one1\r\ntwo2\r\nthree");
+        assert!(!t.inner.scrollback.is_empty());
         t.feed(b"\x1b[?1049h"); // enter alt — cleared
         t.feed(b"alt!");
 


### PR DESCRIPTION
## summary

- suppress primary-screen scrollback when broker snapshots serialize the active alternate screen
- strengthen the active-buffer regression so primary history exists before entering alt-screen
- keep primary-screen snapshot and restoration behavior unchanged

## root cause

`snapshot_with_reflow` selected the alternate visible grid but unconditionally serialized `inner.scrollback`, which belongs to the primary screen. narrow viewports made the leak visible after reconnect because wrapped shell output had already entered primary scrollback.

## verification

- regression observed red before the fix and green after
- Rust: 174 passed
- Bun: 1,695 passed with local Git signing disabled to match CI
- broker release build passed
- iphone-se broker TUI reconnect: 5/5 passed
- rustfmt and `git diff --check` passed
- standalone security review: approve, no findings

## scope

independent of PR #180 and PR #183. no auth, protocol, PTY ownership, replay sequencing, or browser behavior changes.
