### PR TITLE
Add terminal load perf summary output

### DIFF
--- a/.plans/perf-harness-summary-output-2026-07-20.md
+++ b/.plans/perf-harness-summary-output-2026-07-20.md
@@ -1,0 +1,37 @@
+# perf harness summary output — 2026-07-20
+
+status: pr open
+branch: perf-harness-summary-output
+base: main after #189
+
+## scope
+
+- add readable aggregate output for repeated terminal-load perf runs.
+- document supported perf harness env vars near the script.
+- keep measurement flow and terminal/browser behavior unchanged.
+
+## constraints
+
+- no terminal attach/reveal/hydration/socket timing changes.
+- env-driven harness stays; no cli parser unless needed later.
+- raw artifacts remain local/uncommitted.
+- TDD first for output formatting/docs helpers.
+
+## status
+
+- [x] red tests for readable summary/docs helpers
+- [x] implementation
+- [x] verification
+- [x] commit/push/pr — PR #190
+
+## verification log
+
+- red: `bun test tests/unit/terminal-load-perf.test.ts -t "perf run options"` failed on missing `formatPerfRunsSummary` export.
+- green: same narrow test passed, 4 tests.
+- green: `WOLFPACK_PERF_HELP=1 bun run scripts/terminal-load-perf.ts` printed env help without requiring broker/server startup.
+- green: `bun test tests/unit/terminal-load-perf.test.ts` passed, 10 tests.
+- green: `bun run typecheck` passed.
+- green: page-only repeated-run smoke with `WOLFPACK_PERF_RUNS=2` printed aggregate summary and parseable json, `summary.runs = 2`, console errors 0.
+- green: small full smoke with `WOLFPACK_PERF_GRID_CELLS=2` printed single/grid aggregate lines, parseable json, grid prewarm hits 2/2, no remaining `perf-*` sessions.
+- green: `git diff --check` passed.
+- green: full `bun test` with git commit signing disabled passed, 1820 tests.

--- a/scripts/terminal-load-perf.ts
+++ b/scripts/terminal-load-perf.ts
@@ -155,6 +155,14 @@ type ServerPhaseSummary = {
 const ROOT = join(import.meta.dirname, "..");
 const DEV_DIR = join(ROOT, ".wolfpack", "terminal-load-perf-dev");
 const DEFAULT_GRID_CELL_COUNTS = [2, 4, 6] as const;
+const PERF_HARNESS_ENV_HELP = [
+  "WOLFPACK_PERF_RUNS: positive integer repeated-run count (default: 1)",
+  "WOLFPACK_PERF_GRID_CELLS: comma-separated grid sizes 2-6 (default: 2,4,6)",
+  "WOLFPACK_PERF_USE_EXISTING_BROKER: set to 1 to use WOLFPACK_BROKER_SOCKET instead of spawning a broker",
+  "WOLFPACK_PERF_ONLY_PAGE_LOAD: set to 1 to skip single/grid terminal scenarios",
+  "WOLFPACK_PERF_PAGE_LOAD_WAIT_MS: extra post-load wait before page-load trace capture",
+  "WOLFPACK_PERF_SLOW_PREFILL_MS: inject server-side prefill delay for slow-path measurements",
+] as const;
 
 function resolveBrokerBin(): string | null {
   const fromEnv = process.env.WOLFPACK_BROKER_BIN;
@@ -684,6 +692,10 @@ function gridCellCounts(): number[] {
   return counts;
 }
 
+export function describePerfHarnessEnv(): readonly string[] {
+  return PERF_HARNESS_ENV_HELP;
+}
+
 export function parsePerfRunCount(raw: string | undefined): number {
   if (!raw) return 1;
   const count = Number(raw);
@@ -711,6 +723,29 @@ function metricStats(values: readonly number[]): MetricStats {
 
 function addMetric(target: number[], value: number | null): void {
   if (value !== null && Number.isFinite(value)) target.push(value);
+}
+
+function formatMetricPair(stats: MetricStats): string {
+  if (stats.p50 === null || stats.p95 === null) return "n/a (n=0)";
+  return `${stats.p50}/${stats.p95}ms (n=${stats.count})`;
+}
+
+export function formatPerfRunsSummary(summary: PerfRunsSummary): string {
+  return [
+    "aggregate summary",
+    `runs: ${summary.runs}`,
+    `page card visible p50/p95: ${formatMetricPair(summary.page.cardVisibleMs)}`,
+    `page second prewarm ready p50/p95: ${formatMetricPair(summary.page.secondPrewarmReadyMs)}`,
+    `page console errors: ${summary.pageConsoleErrorsTotal}`,
+    `single reveal p50/p95: ${formatMetricPair(summary.single.setupToRevealMs)}`,
+    `single ghostty create p50/p95: ${formatMetricPair(summary.single.ghosttyCreationMs)}`,
+    `single prewarm hits: ${summary.single.prewarmHits.hits}/${summary.single.prewarmHits.total}`,
+    `grid reveal p50/p95: ${formatMetricPair(summary.grid.setupToRevealMs)}`,
+    `grid ghostty create p50/p95: ${formatMetricPair(summary.grid.ghosttyCreationMs)}`,
+    `grid ws server p50/p95: ${formatMetricPair(summary.grid.wsServerMs)}`,
+    `grid prefill_done→reveal p50/p95: ${formatMetricPair(summary.grid.prefillDoneToRevealMs)}`,
+    `grid prewarm hits: ${summary.grid.prewarmHits.hits}/${summary.grid.prewarmHits.total}`,
+  ].join("\n");
 }
 
 export function summarizePerfRuns(runs: readonly PerfRunReport[]): PerfRunsSummary {
@@ -916,6 +951,12 @@ async function runPerfMeasurement(server: Awaited<ReturnType<typeof startServer>
 }
 
 async function main(): Promise<void> {
+  if (process.env.WOLFPACK_PERF_HELP === "1") {
+    console.log("terminal-load perf environment:");
+    for (const line of describePerfHarnessEnv()) console.log(`- ${line}`);
+    return;
+  }
+
   const brokerBin = resolveBrokerBin();
   const broker = existingBroker() || (brokerBin ? startBroker(brokerBin) : null);
   if (!broker) {
@@ -940,9 +981,11 @@ async function main(): Promise<void> {
       runs.push(await runPerfMeasurement(server, runIndex));
     }
 
+    const summary = summarizePerfRuns(runs);
     const report = runCount === 1
-      ? { generatedAt: new Date().toISOString(), ...runs[0], summary: summarizePerfRuns(runs) }
-      : { generatedAt: new Date().toISOString(), runs, summary: summarizePerfRuns(runs) };
+      ? { generatedAt: new Date().toISOString(), ...runs[0], summary }
+      : { generatedAt: new Date().toISOString(), runs, summary };
+    console.log(`\n${formatPerfRunsSummary(summary)}`);
     console.log("\njson:");
     console.log(JSON.stringify(report, null, 2));
   } finally {

--- a/tests/unit/terminal-load-perf.test.ts
+++ b/tests/unit/terminal-load-perf.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   cleanupCreatedSessions,
+  describePerfHarnessEnv,
+  formatPerfRunsSummary,
   parsePerfRunCount,
   serverTimingsFor,
   summarizeCell,
@@ -86,6 +88,25 @@ describe("terminal-load perf run options", () => {
         prewarmHits: { hits: 3, total: 4 },
       },
     });
+  });
+
+  test("formats a readable aggregate summary for terminal output", () => {
+    const summary = summarizePerfRuns([
+      perfRunReport([200, 210], [true, true]),
+      perfRunReport([190, 230], [true, false]),
+    ]);
+
+    expect(formatPerfRunsSummary(summary)).toContain("runs: 2");
+    expect(formatPerfRunsSummary(summary)).toContain("grid reveal p50/p95: 200/230ms (n=4)");
+    expect(formatPerfRunsSummary(summary)).toContain("grid prewarm hits: 3/4");
+  });
+
+  test("documents perf harness environment knobs in one helper", () => {
+    expect(describePerfHarnessEnv()).toEqual(expect.arrayContaining([
+      "WOLFPACK_PERF_RUNS: positive integer repeated-run count (default: 1)",
+      "WOLFPACK_PERF_GRID_CELLS: comma-separated grid sizes 2-6 (default: 2,4,6)",
+      "WOLFPACK_PERF_USE_EXISTING_BROKER: set to 1 to use WOLFPACK_BROKER_SOCKET instead of spawning a broker",
+    ]));
   });
 });
 


### PR DESCRIPTION
## Summary
- print a readable aggregate summary before the perf harness JSON block
- add `WOLFPACK_PERF_HELP=1` env help for supported perf knobs
- keep existing JSON report shape and measurement flow unchanged

## Verification
- red: new terminal-load perf unit contracts failed on missing `formatPerfRunsSummary`
- `bun test tests/unit/terminal-load-perf.test.ts` — 10 passed
- `bun run typecheck`
- `WOLFPACK_PERF_HELP=1 bun run scripts/terminal-load-perf.ts`
- page-only smoke: `WOLFPACK_PERF_RUNS=2 WOLFPACK_PERF_ONLY_PAGE_LOAD=1 ... bun run scripts/terminal-load-perf.ts`
  - aggregate summary printed
  - JSON parsed
  - `summary.runs = 2`
  - console errors 0
- small full smoke: `WOLFPACK_PERF_GRID_CELLS=2 WOLFPACK_PERF_RUNS=1 ... bun run scripts/terminal-load-perf.ts`
  - single/grid aggregate lines printed
  - JSON parsed
  - grid prewarm hits 2/2
  - remaining `perf-*` sessions 0
- `git diff --check`
- `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bun test` — 1820 passed

Note: commit signing is disabled for the full suite because this local shell otherwise triggers 1Password signing inside child git repos.
