### PR TITLE
fix broker output forwarding under backpressure

### DIFF
--- a/.plans/take-control-output-lag-2026-07-22.md
+++ b/.plans/take-control-output-lag-2026-07-22.md
@@ -1,0 +1,49 @@
+# take-control output lag loop — 2026-07-22
+
+status: broker fix and stacked PR #196 client candidate deployed for manual verification
+branch: fix/take-control-output-lag
+base: PR #196 head 88f603d2d1da3cf9be05fc06e42bf3b6e79c1506
+
+## goal
+
+high-volume tui output during takeover must not overflow the broker subscription forwarder, trigger repeated `replay_truncated` reconnects, or expose a continuous redraw stream.
+
+## evidence
+
+- live server logs during repro repeatedly report `replay_truncated — forcing client reconnect for fresh snapshot`.
+- broker logs at matching timestamps report `subscription forwarder lagged broadcast`, dropping 203–1980 chunks per cycle.
+- `OutputBus` broadcast capacity is 256 chunks.
+- `forward_output` stops draining the broadcast receiver while awaiting a full per-connection writer queue, so a short high-volume burst can overflow even when total bytes are manageable.
+
+## success criteria
+
+- deterministic broker regression fills the writer queue, publishes beyond broadcast capacity, then receives every byte without `SubscriptionDropped`.
+- forwarder keeps draining during writer backpressure and coalesces contiguous chunks into bounded output frames.
+- seq watermark advances to the last coalesced chunk without gaps or duplication.
+- ordinary replay/live ordering remains intact.
+- broker/unit/integration/full suites pass.
+- broker restart requires explicit approval because active sessions are lost.
+
+## verification
+
+- focused regression red before fix: `SubscriptionDropped`, lagged 1 chunk in the deterministic backpressure case.
+- focused regression green after fix: 2,000 one-byte chunks arrive in one coalesced frame with seq 2,000 and no drop event.
+- full Rust broker suite: 174 passed, 0 failed (138 lib + 3 bin + 27 socket integration + 6 fixtures).
+- full Bun suite: 1,835 passed, 0 failed.
+- full Playwright run: 100 passed, 123 skipped, 2 failures in `broker-shell-reconnect`; the same `/tmp/marker.txt` → `/tmp/markerxt` mobile-proxy failure reproduces unchanged on pristine 921e46e and is unrelated to broker output forwarding.
+- relevant fixed-binary E2E passed: broker take-control A → B → A and broker TUI reconnect on both mobile projects.
+- clippy remains blocked by six pre-existing warnings in untouched files; no new clippy finding points at `broker/src/server.rs`.
+- full broker deploy completed: broker PID 34586 → 28214. No post-restart `subscription forwarder lagged broadcast` event has been logged.
+- residual risk: server logged broker request timeouts and one later `replay_truncated`; takeover must be manually rechecked before this draft is release-ready.
+- rebased onto PR #196 head and deployed server-only for keyboard testing: server PID 62749 → 68020; broker PID 28214 and all four session identities preserved.
+- live app hash: `b2f548b08b293a80be1932659da375c6f05b96b946d09ac8b95103cafd5b2521`.
+- live Ghostty hash: `20a5074d3ef7a4e8aa5555ffc7c2ac936227cd094bd5949a7be08a2711a68f57`; `insertReplacementText` present once and `preventScroll` twice.
+
+## status
+
+- [x] add and verify failing broker regression (`SubscriptionDropped`, lagged 1–2 chunks in the minimal case)
+- [x] implement bounded drain/coalescing
+- [x] verify focused broker test with a 2,000-chunk burst
+- [x] verify full broker and Bun suites; relevant takeover/TUI E2E passes
+- [x] review deployment tradeoff with user and perform approved broker restart
+- [ ] manually verify takeover stream and real Android/Gboard input

--- a/.plans/take-control-output-lag-2026-07-22.md
+++ b/.plans/take-control-output-lag-2026-07-22.md
@@ -1,6 +1,6 @@
 # take-control output lag loop — 2026-07-22
 
-status: review findings addressed locally; awaiting repeat sub-agent review
+status: second-review findings fixed and fully verified; awaiting final review
 branch: fix/take-control-output-lag
 base: PR #196 head 88f603d2d1da3cf9be05fc06e42bf3b6e79c1506
 
@@ -28,11 +28,12 @@ high-volume tui output during takeover must not overflow the broker subscription
 
 - focused regression red before fix: `SubscriptionDropped`, lagged 1 chunk in the deterministic backpressure case.
 - focused regression green after fix: 2,000 one-byte chunks arrive in one coalesced frame with seq 2,000 and no drop event.
-- full Rust broker suite after review fixes: 177 passed, 0 failed (141 lib + 3 bin + 27 socket integration + 6 fixtures).
-- full Bun suite on the stacked candidate: 1,827 passed, 0 failed.
+- full Rust broker suite after final ordering fix: 178 passed, 0 failed (142 lib + 3 bin + 27 socket integration + 6 fixtures).
+- full Bun suite on the final stacked candidate: 1,828 passed, 0 failed.
 - full Playwright run: 100 passed, 123 skipped, 2 failures in `broker-shell-reconnect`; the same `/tmp/marker.txt` → `/tmp/markerxt` mobile-proxy failure reproduces unchanged on pristine 921e46e and is unrelated to broker output forwarding.
 - real-browser multi-session redraw takeover is red against the old broker (four lagged subscriptions) and green 3/3 against the updated broker.
-- full Playwright after review fixes: 105 passed, 126 expected skips.
+- full Playwright after final fixes: 105 passed, 126 expected skips.
+- sidebar-hover test synchronization now waits for initial hydration opacity; reproduced red twice in full runs, then passed focused 5/5 and in the final full run.
 - clippy remains blocked by six pre-existing warnings in untouched files; no new clippy finding points at `broker/src/server.rs`.
 - full broker deploy completed: broker PID 34586 → 28214. No post-restart `subscription forwarder lagged broadcast` event has been logged.
 - initial deployed version still allowed output to fill the shared writer queue; server logged broker request timeouts and one later `replay_truncated`.
@@ -53,5 +54,11 @@ high-volume tui output during takeover must not overflow the broker subscription
 - [x] add sustained-output 8 MiB cap/lag-recovery coverage
 - [x] document coalesced frame seq and prioritized control ordering contracts
 - [x] preserve the writer queue's prior ~8 MiB output memory envelope
-- [ ] repeat all review passes on updated PR
+- [x] repeat all review passes on `3da0f12`; security approved, but output-priority race blocked shipping
+- [x] queue `subscription_dropped` behind accepted output as a per-connection ordering barrier
+- [x] add real socket-writer control-priority coverage
+- [x] add TS recovery coverage proving the barrier resumes from the last delivered chunk seq
+- [x] document `subscription_dropped` and remove remaining byte-offset comments
+- [x] run full Rust, Bun, Playwright, typecheck, formatting, and diff verification on the final head
+- [ ] repeat all review passes on the final head
 - [ ] manually verify real Android/Gboard input

--- a/.plans/take-control-output-lag-2026-07-22.md
+++ b/.plans/take-control-output-lag-2026-07-22.md
@@ -1,6 +1,6 @@
 # take-control output lag loop — 2026-07-22
 
-status: broker fix and stacked PR #196 client candidate deployed for manual verification
+status: review findings addressed locally; awaiting repeat sub-agent review
 branch: fix/take-control-output-lag
 base: PR #196 head 88f603d2d1da3cf9be05fc06e42bf3b6e79c1506
 
@@ -28,13 +28,15 @@ high-volume tui output during takeover must not overflow the broker subscription
 
 - focused regression red before fix: `SubscriptionDropped`, lagged 1 chunk in the deterministic backpressure case.
 - focused regression green after fix: 2,000 one-byte chunks arrive in one coalesced frame with seq 2,000 and no drop event.
-- full Rust broker suite: 174 passed, 0 failed (138 lib + 3 bin + 27 socket integration + 6 fixtures).
-- full Bun suite: 1,835 passed, 0 failed.
+- full Rust broker suite after review fixes: 177 passed, 0 failed (141 lib + 3 bin + 27 socket integration + 6 fixtures).
+- full Bun suite on the stacked candidate: 1,827 passed, 0 failed.
 - full Playwright run: 100 passed, 123 skipped, 2 failures in `broker-shell-reconnect`; the same `/tmp/marker.txt` → `/tmp/markerxt` mobile-proxy failure reproduces unchanged on pristine 921e46e and is unrelated to broker output forwarding.
-- relevant fixed-binary E2E passed: broker take-control A → B → A and broker TUI reconnect on both mobile projects.
+- real-browser multi-session redraw takeover is red against the old broker (four lagged subscriptions) and green 3/3 against the updated broker.
+- full Playwright after review fixes: 105 passed, 126 expected skips.
 - clippy remains blocked by six pre-existing warnings in untouched files; no new clippy finding points at `broker/src/server.rs`.
 - full broker deploy completed: broker PID 34586 → 28214. No post-restart `subscription forwarder lagged broadcast` event has been logged.
-- residual risk: server logged broker request timeouts and one later `replay_truncated`; takeover must be manually rechecked before this draft is release-ready.
+- initial deployed version still allowed output to fill the shared writer queue; server logged broker request timeouts and one later `replay_truncated`.
+- follow-up fix separates prioritized control/event traffic from bounded output traffic and restores the pre-coalescing 8 KiB frame limit.
 - rebased onto PR #196 head and deployed server-only for keyboard testing: server PID 62749 → 68020; broker PID 28214 and all four session identities preserved.
 - live app hash: `b2f548b08b293a80be1932659da375c6f05b96b946d09ac8b95103cafd5b2521`.
 - live Ghostty hash: `20a5074d3ef7a4e8aa5555ffc7c2ac936227cd094bd5949a7be08a2711a68f57`; `insertReplacementText` present once and `preventScroll` twice.
@@ -46,4 +48,10 @@ high-volume tui output during takeover must not overflow the broker subscription
 - [x] verify focused broker test with a 2,000-chunk burst
 - [x] verify full broker and Bun suites; relevant takeover/TUI E2E passes
 - [x] review deployment tradeoff with user and perform approved broker restart
-- [ ] manually verify takeover stream and real Android/Gboard input
+- [x] add real-browser/fixed-broker multi-session redraw takeover regression; old broker logs four subscription lags, fixed broker passes without lag or reconnect (3/3 repeat)
+- [x] add replay→live ordering/watermark coverage
+- [x] add sustained-output 8 MiB cap/lag-recovery coverage
+- [x] document coalesced frame seq and prioritized control ordering contracts
+- [x] preserve the writer queue's prior ~8 MiB output memory envelope
+- [ ] repeat all review passes on updated PR
+- [ ] manually verify real Android/Gboard input

--- a/broker/src/protocol.rs
+++ b/broker/src/protocol.rs
@@ -321,9 +321,10 @@ pub enum Event {
     SessionResized { session_id: Uuid, cols: u16, rows: u16 },
     SnapshotInvalidated { session_id: Uuid },
     /// Emitted directly to the connection that had its subscription dropped
-    /// due to broadcast lag. The client should re-snapshot to resync and then
-    /// re-subscribe. This event is NOT broadcast to all clients — it is sent
-    /// only on the writer channel of the affected connection.
+    /// due to broadcast lag. The client should re-subscribe from its last
+    /// delivered seq. This event is NOT broadcast to all clients: it is queued
+    /// on the affected connection's output stream after all accepted frames,
+    /// making it an ordering barrier for safe replay recovery.
     SubscriptionDropped { session_id: Uuid, lagged: u64 },
 }
 

--- a/broker/src/server.rs
+++ b/broker/src/server.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::{Path, PathBuf};
@@ -26,6 +26,13 @@ use crate::session::EventSender;
 /// it publishes through the broadcast channel; only this connection's
 /// fanout slows down.
 const WRITER_QUEUE_CAPACITY: usize = 1024;
+/// Merge adjacent PTY reads before crossing the broker socket. This keeps a
+/// redraw burst from consuming one writer-queue slot per tiny kernel read.
+const OUTPUT_FRAME_COALESCE_MAX_BYTES: usize = 128 * 1024;
+/// Keep draining live broadcast output while the socket writer is blocked,
+/// but bound per-subscription memory. At the cap we drain queued frames first;
+/// sustained producers then hit the existing broadcast-lag recovery contract.
+const OUTPUT_FORWARD_BUFFER_MAX_BYTES: usize = 8 * 1024 * 1024;
 
 pub struct ServerConfig {
     pub socket_path: PathBuf,
@@ -510,55 +517,112 @@ async fn handle_unsubscribe(
     .await
 }
 
-/// One forwarder task per (connection, session) subscription. Pushes
-/// replay first (chunks the ring still held at subscribe time), then
-/// pulls from the broadcast receiver until the bus closes or the writer
-/// queue dies. On `RecvError::Lagged(_)`, the forwarder logs and stops:
-/// the client must re-`subscribe` (or `snapshot`) to recover. Surfacing
-/// lag rather than silently swallowing it preserves the seq invariant.
+/// Queue one PTY read, merging contiguous seqs into a bounded socket frame.
+fn enqueue_output_chunk(
+    pending: &mut VecDeque<OutputFrame>,
+    pending_bytes: &mut usize,
+    session_id: Uuid,
+    chunk: OutputChunk,
+) {
+    *pending_bytes += chunk.data.len();
+    if let Some(last) = pending.back_mut() {
+        if last.seq.checked_add(1) == Some(chunk.seq)
+            && last.data.len() + chunk.data.len() <= OUTPUT_FRAME_COALESCE_MAX_BYTES
+        {
+            last.seq = chunk.seq;
+            last.data.extend_from_slice(&chunk.data);
+            return;
+        }
+    }
+    pending.push_back(chunk_to_frame(session_id, chunk));
+}
+
+async fn notify_subscription_lag(writer_tx: &mpsc::Sender<Frame>, session_id: Uuid, lagged: u64) {
+    warn!(
+        %session_id,
+        lagged,
+        "subscription forwarder lagged broadcast; notifying client to re-subscribe"
+    );
+    let _ = writer_tx
+        .send(Frame::Event(crate::protocol::Event::SubscriptionDropped {
+            session_id,
+            lagged,
+        }))
+        .await;
+}
+
+/// One forwarder task per (connection, session) subscription. Replay and live
+/// chunks share a bounded local queue. Crucially, this task continues draining
+/// the broadcast receiver while the per-connection writer is backpressured;
+/// otherwise 256 tiny PTY reads can overflow the broadcast channel before the
+/// Unix socket drains, forcing a replay-truncated reconnect loop.
 async fn forward_output(
     session_id: Uuid,
     replay: Vec<OutputChunk>,
     mut rx: tokio::sync::broadcast::Receiver<OutputChunk>,
     writer_tx: mpsc::Sender<Frame>,
 ) {
+    let mut pending = VecDeque::new();
+    let mut pending_bytes = 0;
     for chunk in replay {
-        if writer_tx
-            .send(Frame::OutputBinary(chunk_to_frame(session_id, chunk)))
-            .await
-            .is_err()
-        {
-            return;
-        }
+        enqueue_output_chunk(&mut pending, &mut pending_bytes, session_id, chunk);
     }
+    let mut receiver_closed = false;
+
     loop {
-        match rx.recv().await {
-            Ok(chunk) => {
-                if writer_tx
-                    .send(Frame::OutputBinary(chunk_to_frame(session_id, chunk)))
-                    .await
-                    .is_err()
-                {
+        if pending.is_empty() {
+            if receiver_closed {
+                return;
+            }
+            match rx.recv().await {
+                Ok(chunk) => {
+                    enqueue_output_chunk(&mut pending, &mut pending_bytes, session_id, chunk);
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    notify_subscription_lag(&writer_tx, session_id, n).await;
                     return;
                 }
             }
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                warn!(
-                    %session_id,
-                    lagged = n,
-                    "subscription forwarder lagged broadcast; notifying client to re-subscribe"
-                );
-                // Notify the client directly on its writer channel so it can
-                // re-snapshot and re-subscribe. This event is NOT broadcast to
-                // all clients — only this connection's writer sees it.
-                let _ = writer_tx
-                    .send(Frame::Event(crate::protocol::Event::SubscriptionDropped {
-                        session_id,
-                        lagged: n,
-                    }))
-                    .await;
+        }
+
+        // Once the local byte cap is reached, apply backpressure by draining a
+        // coalesced frame before accepting more. If the producer remains too
+        // fast, the broadcast channel surfaces an exact Lagged count as before.
+        if receiver_closed || pending_bytes >= OUTPUT_FORWARD_BUFFER_MAX_BYTES {
+            let Some(frame) = pending.pop_front() else {
+                continue;
+            };
+            pending_bytes -= frame.data.len();
+            if writer_tx.send(Frame::OutputBinary(frame)).await.is_err() {
                 return;
+            }
+            continue;
+        }
+
+        tokio::select! {
+            received = rx.recv() => match received {
+                Ok(chunk) => {
+                    enqueue_output_chunk(&mut pending, &mut pending_bytes, session_id, chunk);
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    receiver_closed = true;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    notify_subscription_lag(&writer_tx, session_id, n).await;
+                    return;
+                }
+            },
+            permit = writer_tx.reserve() => {
+                let Ok(permit) = permit else {
+                    return;
+                };
+                let Some(frame) = pending.pop_front() else {
+                    continue;
+                };
+                pending_bytes -= frame.data.len();
+                permit.send(Frame::OutputBinary(frame));
             }
         }
     }
@@ -596,9 +660,10 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn slow_output_forwarder_reports_lag_without_socket_timing() {
+    async fn slow_output_forwarder_preserves_burst_during_writer_backpressure() {
+        const CHUNK_COUNT: u64 = 2_000;
         let session_id = Uuid::new_v4();
-        let bus = crate::output_bus::OutputBus::new(8, 2);
+        let bus = crate::output_bus::OutputBus::new(CHUNK_COUNT as usize, 256);
         let subscription = bus.subscribe(None).expect("subscribe");
         let (writer_tx, mut writer_rx) = mpsc::channel(1);
 
@@ -615,40 +680,46 @@ mod tests {
             subscription.receiver,
             writer_tx,
         ));
+        tokio::task::yield_now().await;
 
-        for seq in 1..=4 {
+        for seq in 1..=CHUNK_COUNT {
             bus.publish(OutputChunk {
                 seq,
                 data: Arc::new(vec![b'x']),
             });
+            tokio::task::yield_now().await;
         }
+        bus.close();
 
         assert!(matches!(
             writer_rx.recv().await,
             Some(Frame::Event(Event::SnapshotInvalidated { .. }))
         ));
 
-        let mut lagged = None;
-        for _ in 0..3 {
+        let mut output = Vec::new();
+        let mut output_seqs = Vec::new();
+        while output.len() < CHUNK_COUNT as usize {
             let frame = tokio::time::timeout(std::time::Duration::from_secs(1), writer_rx.recv())
                 .await
                 .expect("forwarder response timeout")
                 .expect("writer queue closed");
-            if let Frame::Event(Event::SubscriptionDropped {
-                session_id: dropped_session,
-                lagged: dropped_count,
-            }) = frame
-            {
-                assert_eq!(dropped_session, session_id);
-                lagged = Some(dropped_count);
-                break;
+            match frame {
+                Frame::OutputBinary(frame) => {
+                    output.extend_from_slice(&frame.data);
+                    output_seqs.push(frame.seq);
+                }
+                Frame::Event(Event::SubscriptionDropped { lagged, .. }) => {
+                    panic!("buffered redraw burst was dropped: {lagged} chunks");
+                }
+                _ => {}
             }
         }
 
-        assert!(lagged.is_some_and(|count| count > 0));
+        assert_eq!(output, vec![b'x'; CHUNK_COUNT as usize]);
+        assert_eq!(output_seqs, [CHUNK_COUNT]);
         tokio::time::timeout(std::time::Duration::from_secs(1), forwarder)
             .await
-            .expect("forwarder did not stop after lag")
+            .expect("forwarder did not stop after bus close")
             .expect("forwarder task failed");
     }
 

--- a/broker/src/server.rs
+++ b/broker/src/server.rs
@@ -20,9 +20,9 @@ use crate::ring_buffer::OutputChunk;
 use crate::router::Router;
 use crate::session::EventSender;
 
-/// Per-connection queue depth. Control and output use separate queues so PTY
-/// traffic cannot starve request responses; the socket writer prioritises the
-/// control queue while preserving order within each queue.
+/// Per-connection queue depth. Control/global lifecycle and output use separate
+/// queues so PTY traffic cannot starve request responses; the socket writer
+/// prioritises control while preserving order within each queue.
 const WRITER_QUEUE_CAPACITY: usize = 1024;
 /// Merge adjacent PTY reads before crossing the broker socket without raising
 /// the writer queue's pre-coalescing memory envelope (1,024 × 8 KiB).
@@ -236,8 +236,8 @@ async fn handle_connection(
     debug!("broker connection opened");
     let (mut read_half, write_half) = stream.into_split();
 
-    // Control responses/events must not queue behind a PTY redraw burst. The
-    // dedicated socket writer prioritises this queue over live/replay output.
+    // Control responses/global lifecycle events must not queue behind a PTY
+    // redraw burst. The socket writer prioritises this queue over output.
     let (writer_tx, writer_rx) = mpsc::channel::<Frame>(writer_queue_cap);
     let (output_tx, output_rx) = mpsc::channel::<Frame>(writer_queue_cap);
     let writer_task = tokio::spawn(connection_writer(write_half, writer_rx, output_rx));
@@ -485,7 +485,6 @@ async fn handle_subscribe(
         sub.replay,
         sub.receiver,
         output_tx.clone(),
-        writer_tx.clone(),
     ));
     subs.insert(session_id, handle);
     true
@@ -549,13 +548,16 @@ fn enqueue_output_chunk(
     pending.push_back(chunk_to_frame(session_id, chunk));
 }
 
-async fn notify_subscription_lag(writer_tx: &mpsc::Sender<Frame>, session_id: Uuid, lagged: u64) {
+async fn notify_subscription_lag(output_tx: &mpsc::Sender<Frame>, session_id: Uuid, lagged: u64) {
     warn!(
         %session_id,
         lagged,
         "subscription forwarder lagged broadcast; notifying client to re-subscribe"
     );
-    let _ = writer_tx
+    // This event is an output-stream barrier: queue it behind every output
+    // frame already accepted for the connection. The client can then resume
+    // from its last delivered seq without older frames arriving afterward.
+    let _ = output_tx
         .send(Frame::Event(crate::protocol::Event::SubscriptionDropped {
             session_id,
             lagged,
@@ -573,7 +575,6 @@ async fn forward_output(
     replay: Vec<OutputChunk>,
     mut rx: tokio::sync::broadcast::Receiver<OutputChunk>,
     output_tx: mpsc::Sender<Frame>,
-    control_tx: mpsc::Sender<Frame>,
 ) {
     let mut pending = VecDeque::new();
     let mut pending_bytes = 0;
@@ -594,7 +595,7 @@ async fn forward_output(
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    notify_subscription_lag(&control_tx, session_id, n).await;
+                    notify_subscription_lag(&output_tx, session_id, n).await;
                     return;
                 }
             }
@@ -623,7 +624,7 @@ async fn forward_output(
                     receiver_closed = true;
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    notify_subscription_lag(&control_tx, session_id, n).await;
+                    notify_subscription_lag(&output_tx, session_id, n).await;
                     return;
                 }
             },
@@ -679,7 +680,6 @@ mod tests {
         let bus = crate::output_bus::OutputBus::new(CHUNK_COUNT as usize, 256);
         let subscription = bus.subscribe(None).expect("subscribe");
         let (output_tx, mut output_rx) = mpsc::channel(1);
-        let (control_tx, _control_rx) = mpsc::channel(1);
 
         output_tx
             .send(Frame::Event(Event::SnapshotInvalidated {
@@ -693,7 +693,6 @@ mod tests {
             subscription.replay,
             subscription.receiver,
             output_tx,
-            control_tx,
         ));
         tokio::task::yield_now().await;
 
@@ -750,7 +749,6 @@ mod tests {
         }
         let subscription = bus.subscribe(Some(0)).expect("subscribe");
         let (output_tx, mut output_rx) = mpsc::channel(1);
-        let (control_tx, _control_rx) = mpsc::channel(1);
         output_tx
             .send(Frame::Event(Event::SnapshotInvalidated {
                 session_id: Uuid::nil(),
@@ -763,7 +761,6 @@ mod tests {
             subscription.replay,
             subscription.receiver,
             output_tx,
-            control_tx,
         ));
         for (seq, byte) in [(3, b'c'), (4, b'd')] {
             bus.publish(OutputChunk {
@@ -806,7 +803,6 @@ mod tests {
         let bus = crate::output_bus::OutputBus::new(64, 64);
         let subscription = bus.subscribe(None).expect("subscribe");
         let (output_tx, mut output_rx) = mpsc::channel(1);
-        let (control_tx, mut control_rx) = mpsc::channel(1);
         output_tx
             .send(Frame::Event(Event::SnapshotInvalidated {
                 session_id: Uuid::nil(),
@@ -819,7 +815,6 @@ mod tests {
             subscription.replay,
             subscription.receiver,
             output_tx,
-            control_tx,
         ));
         for seq in 1..=CHUNKS_TO_CAP {
             bus.publish(OutputChunk {
@@ -839,10 +834,14 @@ mod tests {
             output_rx.recv().await,
             Some(Frame::Event(Event::SnapshotInvalidated { .. }))
         ));
-        let event = tokio::time::timeout(std::time::Duration::from_secs(1), control_rx.recv())
+        assert!(matches!(
+            output_rx.recv().await,
+            Some(Frame::OutputBinary(OutputFrame { seq: 1, .. }))
+        ));
+        let event = tokio::time::timeout(std::time::Duration::from_millis(100), output_rx.recv())
             .await
-            .expect("lag recovery event timeout")
-            .expect("control queue closed");
+            .expect("SubscriptionDropped overtook older queued output")
+            .expect("output queue closed");
         assert!(matches!(
             event,
             Frame::Event(Event::SubscriptionDropped {
@@ -854,6 +853,46 @@ mod tests {
             .await
             .expect("forwarder did not stop after lag recovery")
             .expect("forwarder task failed");
+    }
+
+    #[tokio::test]
+    async fn connection_writer_sends_control_before_queued_output() {
+        let session_id = Uuid::new_v4();
+        let (broker_stream, mut client_stream) = UnixStream::pair().expect("socket pair");
+        let (_read_half, write_half) = broker_stream.into_split();
+        let (control_tx, control_rx) = mpsc::channel(1);
+        let (output_tx, output_rx) = mpsc::channel(1);
+        output_tx
+            .send(Frame::OutputBinary(OutputFrame {
+                session_id,
+                seq: 1,
+                data: vec![b'x'],
+            }))
+            .await
+            .expect("queue output");
+        control_tx
+            .send(Frame::ControlResponse(unknown_session(7, Uuid::nil())))
+            .await
+            .expect("queue control response");
+        drop(control_tx);
+        drop(output_tx);
+
+        let writer = tokio::spawn(connection_writer(write_half, control_rx, output_rx));
+        assert!(matches!(
+            read_frame_async(&mut client_stream)
+                .await
+                .expect("read control response"),
+            Frame::ControlResponse(ControlResponse { id: 7, .. })
+        ));
+        assert!(matches!(
+            read_frame_async(&mut client_stream).await.expect("read output"),
+            Frame::OutputBinary(OutputFrame {
+                session_id: output_session,
+                seq: 1,
+                ..
+            }) if output_session == session_id
+        ));
+        writer.await.expect("writer task failed");
     }
 
     #[tokio::test]
@@ -870,7 +909,6 @@ mod tests {
             subscription.replay,
             subscription.receiver,
             output_tx,
-            control_tx.clone(),
         ));
         for seq in 1..=OUTPUT_CHUNKS {
             bus.publish(OutputChunk {

--- a/broker/src/server.rs
+++ b/broker/src/server.rs
@@ -20,15 +20,13 @@ use crate::ring_buffer::OutputChunk;
 use crate::router::Router;
 use crate::session::EventSender;
 
-/// Per-connection writer queue depth. Backpressure: if the writer falls
-/// behind by more than this many frames, the broadcast forwarder will
-/// block until the socket drains. The PTY itself is never blocked because
-/// it publishes through the broadcast channel; only this connection's
-/// fanout slows down.
+/// Per-connection queue depth. Control and output use separate queues so PTY
+/// traffic cannot starve request responses; the socket writer prioritises the
+/// control queue while preserving order within each queue.
 const WRITER_QUEUE_CAPACITY: usize = 1024;
-/// Merge adjacent PTY reads before crossing the broker socket. This keeps a
-/// redraw burst from consuming one writer-queue slot per tiny kernel read.
-const OUTPUT_FRAME_COALESCE_MAX_BYTES: usize = 128 * 1024;
+/// Merge adjacent PTY reads before crossing the broker socket without raising
+/// the writer queue's pre-coalescing memory envelope (1,024 × 8 KiB).
+const OUTPUT_FRAME_COALESCE_MAX_BYTES: usize = 8 * 1024;
 /// Keep draining live broadcast output while the socket writer is blocked,
 /// but bound per-subscription memory. At the cap we drain queued frames first;
 /// sustained producers then hit the existing broadcast-lag recovery contract.
@@ -49,9 +47,9 @@ pub struct ServerConfig {
     /// session's reaper, and by the router's resize path — see
     /// [`crate::session::EventSender`].
     pub events: EventSender,
-    /// Override the per-connection writer queue depth. `None` → use the
-    /// production default (1024). Only set this in tests that need a small
-    /// queue to trigger backpressure quickly.
+    /// Override each per-connection writer queue depth. `None` → use the
+    /// production default (1024). Only set this in tests that need small
+    /// control/output queues to trigger backpressure quickly.
     pub writer_queue_capacity: Option<usize>,
 }
 
@@ -238,12 +236,11 @@ async fn handle_connection(
     debug!("broker connection opened");
     let (mut read_half, write_half) = stream.into_split();
 
-    // Per-connection writer mpsc + dedicated writer task. Every outbound
-    // frame on this connection — control responses, output_binary live
-    // chunks, events — funnels through this queue so writes are
-    // serialised on the socket and ordering is preserved.
+    // Control responses/events must not queue behind a PTY redraw burst. The
+    // dedicated socket writer prioritises this queue over live/replay output.
     let (writer_tx, writer_rx) = mpsc::channel::<Frame>(writer_queue_cap);
-    let writer_task = tokio::spawn(connection_writer(write_half, writer_rx));
+    let (output_tx, output_rx) = mpsc::channel::<Frame>(writer_queue_cap);
+    let writer_task = tokio::spawn(connection_writer(write_half, writer_rx, output_rx));
 
     // Drain async lifecycle events into this connection's writer queue.
     // Started here (not inside `accept_loop`) so the receiver was already
@@ -272,6 +269,7 @@ async fn handle_connection(
                         router.as_ref(),
                         &registry,
                         &writer_tx,
+                        &output_tx,
                         &mut subs,
                     )
                     .await
@@ -300,12 +298,13 @@ async fn handle_connection(
     }
 
     // Cleanly tear down per-session forwarders, then the event forwarder,
-    // then drop the writer sender so the writer task observes EOF and exits.
+    // then drop both senders so the writer task observes EOF and exits.
     for (_, h) in subs.drain() {
         h.abort();
     }
     event_task.abort();
     drop(writer_tx);
+    drop(output_tx);
     if let Err(e) = writer_task.await {
         if !e.is_cancelled() {
             warn!(error = %e, "broker writer task join error");
@@ -335,11 +334,21 @@ async fn forward_events(mut rx: broadcast::Receiver<Event>, writer_tx: mpsc::Sen
     }
 }
 
-async fn connection_writer(mut w: tokio::net::unix::OwnedWriteHalf, mut rx: mpsc::Receiver<Frame>) {
-    while let Some(frame) = rx.recv().await {
+async fn connection_writer(
+    mut w: tokio::net::unix::OwnedWriteHalf,
+    mut control_rx: mpsc::Receiver<Frame>,
+    mut output_rx: mpsc::Receiver<Frame>,
+) {
+    loop {
+        let frame = tokio::select! {
+            biased;
+            Some(frame) = control_rx.recv() => frame,
+            Some(frame) = output_rx.recv() => frame,
+            else => return,
+        };
         if let Err(e) = write_frame_async(&mut w, &frame).await {
             warn!(error = %e, "broker writer failed; closing connection");
-            break;
+            return;
         }
     }
 }
@@ -351,11 +360,12 @@ async fn dispatch_frame(
     router: &dyn Router,
     registry: &Arc<Registry>,
     writer_tx: &mpsc::Sender<Frame>,
+    output_tx: &mpsc::Sender<Frame>,
     subs: &mut HashMap<Uuid, JoinHandle<()>>,
 ) -> bool {
     match frame {
         Frame::ControlRequest(req) => match req.method.as_str() {
-            methods::SUBSCRIBE => handle_subscribe(req, registry, writer_tx, subs).await,
+            methods::SUBSCRIBE => handle_subscribe(req, registry, writer_tx, output_tx, subs).await,
             methods::UNSUBSCRIBE => handle_unsubscribe(req, writer_tx, subs).await,
             _ => {
                 let resp = router.handle(req);
@@ -393,12 +403,14 @@ async fn dispatch_frame(
 ///      ring whose seq > since_seq);
 ///   3. then live `output_binary` frames as the drainer publishes them.
 ///
-/// The forwarder task below is spawned only after the response is queued
-/// so the writer mpsc preserves the (response, replay, live...) order.
+/// The forwarder task below is spawned only after the response enters the
+/// prioritised control queue, so it reaches the socket before replay/live
+/// frames from the separate output queue.
 async fn handle_subscribe(
     req: ControlRequest,
     registry: &Arc<Registry>,
     writer_tx: &mpsc::Sender<Frame>,
+    output_tx: &mpsc::Sender<Frame>,
     subs: &mut HashMap<Uuid, JoinHandle<()>>,
 ) -> bool {
     let id = req.id;
@@ -468,12 +480,12 @@ async fn handle_subscribe(
     }
 
     let session_id = params.session_id;
-    let writer_clone = writer_tx.clone();
     let handle = tokio::spawn(forward_output(
         session_id,
         sub.replay,
         sub.receiver,
-        writer_clone,
+        output_tx.clone(),
+        writer_tx.clone(),
     ));
     subs.insert(session_id, handle);
     true
@@ -560,7 +572,8 @@ async fn forward_output(
     session_id: Uuid,
     replay: Vec<OutputChunk>,
     mut rx: tokio::sync::broadcast::Receiver<OutputChunk>,
-    writer_tx: mpsc::Sender<Frame>,
+    output_tx: mpsc::Sender<Frame>,
+    control_tx: mpsc::Sender<Frame>,
 ) {
     let mut pending = VecDeque::new();
     let mut pending_bytes = 0;
@@ -581,7 +594,7 @@ async fn forward_output(
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => return,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    notify_subscription_lag(&writer_tx, session_id, n).await;
+                    notify_subscription_lag(&control_tx, session_id, n).await;
                     return;
                 }
             }
@@ -595,7 +608,7 @@ async fn forward_output(
                 continue;
             };
             pending_bytes -= frame.data.len();
-            if writer_tx.send(Frame::OutputBinary(frame)).await.is_err() {
+            if output_tx.send(Frame::OutputBinary(frame)).await.is_err() {
                 return;
             }
             continue;
@@ -610,11 +623,11 @@ async fn forward_output(
                     receiver_closed = true;
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    notify_subscription_lag(&writer_tx, session_id, n).await;
+                    notify_subscription_lag(&control_tx, session_id, n).await;
                     return;
                 }
             },
-            permit = writer_tx.reserve() => {
+            permit = output_tx.reserve() => {
                 let Ok(permit) = permit else {
                     return;
                 };
@@ -665,9 +678,10 @@ mod tests {
         let session_id = Uuid::new_v4();
         let bus = crate::output_bus::OutputBus::new(CHUNK_COUNT as usize, 256);
         let subscription = bus.subscribe(None).expect("subscribe");
-        let (writer_tx, mut writer_rx) = mpsc::channel(1);
+        let (output_tx, mut output_rx) = mpsc::channel(1);
+        let (control_tx, _control_rx) = mpsc::channel(1);
 
-        writer_tx
+        output_tx
             .send(Frame::Event(Event::SnapshotInvalidated {
                 session_id: Uuid::nil(),
             }))
@@ -678,7 +692,8 @@ mod tests {
             session_id,
             subscription.replay,
             subscription.receiver,
-            writer_tx,
+            output_tx,
+            control_tx,
         ));
         tokio::task::yield_now().await;
 
@@ -692,14 +707,14 @@ mod tests {
         bus.close();
 
         assert!(matches!(
-            writer_rx.recv().await,
+            output_rx.recv().await,
             Some(Frame::Event(Event::SnapshotInvalidated { .. }))
         ));
 
         let mut output = Vec::new();
         let mut output_seqs = Vec::new();
         while output.len() < CHUNK_COUNT as usize {
-            let frame = tokio::time::timeout(std::time::Duration::from_secs(1), writer_rx.recv())
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(1), output_rx.recv())
                 .await
                 .expect("forwarder response timeout")
                 .expect("writer queue closed");
@@ -721,6 +736,165 @@ mod tests {
             .await
             .expect("forwarder did not stop after bus close")
             .expect("forwarder task failed");
+    }
+
+    #[tokio::test]
+    async fn replay_precedes_live_output_when_coalesced_under_backpressure() {
+        let session_id = Uuid::new_v4();
+        let bus = crate::output_bus::OutputBus::new(8, 8);
+        for (seq, byte) in [(1, b'a'), (2, b'b')] {
+            bus.publish(OutputChunk {
+                seq,
+                data: Arc::new(vec![byte]),
+            });
+        }
+        let subscription = bus.subscribe(Some(0)).expect("subscribe");
+        let (output_tx, mut output_rx) = mpsc::channel(1);
+        let (control_tx, _control_rx) = mpsc::channel(1);
+        output_tx
+            .send(Frame::Event(Event::SnapshotInvalidated {
+                session_id: Uuid::nil(),
+            }))
+            .await
+            .expect("fill output queue");
+
+        let forwarder = tokio::spawn(forward_output(
+            session_id,
+            subscription.replay,
+            subscription.receiver,
+            output_tx,
+            control_tx,
+        ));
+        for (seq, byte) in [(3, b'c'), (4, b'd')] {
+            bus.publish(OutputChunk {
+                seq,
+                data: Arc::new(vec![byte]),
+            });
+        }
+        bus.close();
+
+        assert!(matches!(
+            output_rx.recv().await,
+            Some(Frame::Event(Event::SnapshotInvalidated { .. }))
+        ));
+        let mut output = Vec::new();
+        let mut output_seqs = Vec::new();
+        while output.len() < 4 {
+            let frame = tokio::time::timeout(std::time::Duration::from_secs(1), output_rx.recv())
+                .await
+                .expect("coalesced replay/live output timeout")
+                .expect("output queue closed");
+            if let Frame::OutputBinary(frame) = frame {
+                output.extend_from_slice(&frame.data);
+                output_seqs.push(frame.seq);
+            }
+        }
+        assert_eq!(output, b"abcd");
+        assert!(output_seqs.windows(2).all(|seqs| seqs[0] < seqs[1]));
+        assert_eq!(output_seqs.last(), Some(&4));
+        tokio::time::timeout(std::time::Duration::from_secs(1), forwarder)
+            .await
+            .expect("forwarder did not stop after bus close")
+            .expect("forwarder task failed");
+    }
+
+    #[tokio::test]
+    async fn sustained_output_beyond_local_cap_uses_lag_recovery() {
+        const CHUNK_BYTES: usize = 8 * 1024;
+        const CHUNKS_TO_CAP: u64 = (OUTPUT_FORWARD_BUFFER_MAX_BYTES / CHUNK_BYTES) as u64;
+        let session_id = Uuid::new_v4();
+        let bus = crate::output_bus::OutputBus::new(64, 64);
+        let subscription = bus.subscribe(None).expect("subscribe");
+        let (output_tx, mut output_rx) = mpsc::channel(1);
+        let (control_tx, mut control_rx) = mpsc::channel(1);
+        output_tx
+            .send(Frame::Event(Event::SnapshotInvalidated {
+                session_id: Uuid::nil(),
+            }))
+            .await
+            .expect("fill output queue");
+
+        let forwarder = tokio::spawn(forward_output(
+            session_id,
+            subscription.replay,
+            subscription.receiver,
+            output_tx,
+            control_tx,
+        ));
+        for seq in 1..=CHUNKS_TO_CAP {
+            bus.publish(OutputChunk {
+                seq,
+                data: Arc::new(vec![b'x'; CHUNK_BYTES]),
+            });
+            tokio::task::yield_now().await;
+        }
+        for seq in (CHUNKS_TO_CAP + 1)..=(CHUNKS_TO_CAP + 128) {
+            bus.publish(OutputChunk {
+                seq,
+                data: Arc::new(vec![b'y'; CHUNK_BYTES]),
+            });
+        }
+
+        assert!(matches!(
+            output_rx.recv().await,
+            Some(Frame::Event(Event::SnapshotInvalidated { .. }))
+        ));
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), control_rx.recv())
+            .await
+            .expect("lag recovery event timeout")
+            .expect("control queue closed");
+        assert!(matches!(
+            event,
+            Frame::Event(Event::SubscriptionDropped {
+                session_id: dropped_session,
+                lagged,
+            }) if dropped_session == session_id && lagged > 0
+        ));
+        tokio::time::timeout(std::time::Duration::from_secs(1), forwarder)
+            .await
+            .expect("forwarder did not stop after lag recovery")
+            .expect("forwarder task failed");
+    }
+
+    #[tokio::test]
+    async fn output_burst_leaves_writer_capacity_for_control_response() {
+        const OUTPUT_CHUNKS: u64 = 400;
+        let session_id = Uuid::new_v4();
+        let bus = crate::output_bus::OutputBus::new(512, 512);
+        let subscription = bus.subscribe(None).expect("subscribe");
+        let (output_tx, _output_rx) = mpsc::channel(18);
+        let (control_tx, mut control_rx) = mpsc::channel(18);
+
+        let forwarder = tokio::spawn(forward_output(
+            session_id,
+            subscription.replay,
+            subscription.receiver,
+            output_tx,
+            control_tx.clone(),
+        ));
+        for seq in 1..=OUTPUT_CHUNKS {
+            bus.publish(OutputChunk {
+                seq,
+                data: Arc::new(vec![b'x'; 8 * 1024]),
+            });
+        }
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+
+        tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            control_tx.send(Frame::ControlResponse(unknown_session(7, Uuid::nil()))),
+        )
+        .await
+        .expect("output saturated the writer queue and starved a control response")
+        .expect("control queue closed");
+        assert!(matches!(
+            control_rx.recv().await,
+            Some(Frame::ControlResponse(ControlResponse { id: 7, .. }))
+        ));
+
+        forwarder.abort();
     }
 
     #[test]

--- a/docs/broker-protocol.md
+++ b/docs/broker-protocol.md
@@ -232,11 +232,16 @@ Binary payload layout:
 ```
 
 - `session_id`: raw 16-byte UUID for the session this output belongs to.
-- `seq`: monotonic broker-assigned sequence over the session's output stream.
-  `seq` is the index of the **last** byte in this frame; `subscribe.since_seq`
-  uses the same numbering.
-- `raw PTY bytes`: exactly what the PTY emitted, no transformation. The client
-  must not interpret these as JSON.
+- `seq`: monotonic broker-assigned PTY-chunk watermark. Each PTY read receives
+  one sequence number. A frame may contain one chunk or several contiguous
+  chunks coalesced by the broker; `seq` is the final chunk covered by the frame.
+  `subscribe.since_seq` uses the same chunk numbering.
+- `raw PTY bytes`: exactly what the covered PTY chunks emitted, concatenated in
+  sequence order with no transformation. The client must not interpret these
+  as JSON.
+- Output frames remain ordered by `seq` within a session. Control responses and
+  lifecycle events use a prioritized queue and may overtake already-queued
+  output frames so PTY bursts cannot starve request handling.
 
 ### `input_binary` (kind `0x04`)
 
@@ -312,7 +317,7 @@ source.
 ```jsonc
 {
   "session_id":     "<uuid>",
-  "seq":            12345,           // last output byte covered by this snapshot
+  "seq":            12345,           // last PTY chunk covered by this snapshot
   "cols":           120,
   "rows":           30,
   "visible_screen": [StyledLine; rows],   // top-to-bottom, exactly `rows` entries

--- a/docs/broker-protocol.md
+++ b/docs/broker-protocol.md
@@ -280,10 +280,14 @@ are not tied to any request `id`.
 | `session_exited`      | `session_id, exit_code?, signal?`                |
 | `session_resized`     | `session_id, cols, rows`                         |
 | `snapshot_invalidated`| `session_id` — clients SHOULD re-`snapshot`      |
+| `subscription_dropped`| `session_id, lagged` — re-subscribe from the last delivered `seq` |
 
-Events are best-effort: a connection that did not subscribe to a session may
-still receive events for it (lifecycle events are global). The broker
-guarantees delivery order matches its own state-transition order.
+Lifecycle events are best-effort and global: a connection may receive them
+without subscribing to the affected session. They use the prioritized control
+queue and can overtake output. `subscription_dropped` is different: it is sent
+only to the affected connection through its output queue, after all previously
+accepted output frames. That ordering barrier makes replay from the client's
+last delivered `seq` safe.
 
 ---
 

--- a/src/broker/client.ts
+++ b/src/broker/client.ts
@@ -585,8 +585,8 @@ export class BrokerClient {
       }
       case FRAME_KIND_EVENT: {
         const ev = frame.value;
-        // subscription_dropped is a per-connection signal (not a global event):
-        // auto-resubscribe to get live output flowing again, then notify the caller.
+        // subscription_dropped is a per-connection output-stream barrier, queued
+        // after older output. Resume from the last delivered seq, then notify the caller.
         if (ev.event === "subscription_dropped" && typeof ev.session_id === "string") {
           const sessionId = ev.session_id as string;
           const lagged = typeof ev.lagged === "number" ? ev.lagged as number : 0;

--- a/src/broker/codec.ts
+++ b/src/broker/codec.ts
@@ -56,7 +56,7 @@ export interface EventBody {
 export interface OutputBinaryFrame {
   /** Canonical lowercase UUID string (8-4-4-4-12). */
   sessionId: string;
-  /** Monotonic per-session output seq, last byte index of this frame. */
+  /** Final per-session PTY-chunk seq covered by this possibly coalesced frame. */
   seq: bigint;
   /** Raw PTY bytes; receiver-owned (caller may retain). */
   data: Uint8Array;

--- a/src/server/backend.ts
+++ b/src/server/backend.ts
@@ -90,7 +90,7 @@ export type SessionLifecycleEvent =
 
 export interface SessionPrefill {
   data: Buffer;
-  /** Broker output-stream seq at snapshot time; undefined for non-broker backends. */
+  /** Final broker PTY-chunk seq covered by the snapshot; undefined for non-broker backends. */
   seq?: bigint;
 }
 

--- a/src/server/broker-backend.ts
+++ b/src/server/broker-backend.ts
@@ -138,7 +138,7 @@ interface StyledLine {
 interface SnapshotPayload extends SnapshotForRender {
   visible_screen: StyledLine[];
   scrollback?: StyledLine[];
-  /** Broker output-stream byte offset at capture time. Present on all broker snapshots. */
+  /** Final broker PTY-chunk seq covered at capture time. Present on all broker snapshots. */
   seq?: number;
 }
 
@@ -492,8 +492,8 @@ export class BrokerBackend implements SessionBackend, PtyBackendMethods {
    * Fetch a fresh broker snapshot and render it to ANSI bytes for WS prefill.
    * Returns `{ data: empty, seq: undefined }` when the session is unknown or
    * the broker rejects the snapshot - callers treat empty data as "no prefill".
-   * `seq` is the broker output-stream byte offset at snapshot capture time;
-   * pass it to `onSessionData` so the broker replays any bytes emitted between
+   * `seq` is the final broker PTY-chunk watermark covered by the snapshot;
+   * pass it to `onSessionData` so the broker replays chunks emitted between
    * snapshot and subscribe attach.
    */
   async getSessionPrefill(name: string, cols?: number, options?: SessionPrefillOptions): Promise<SessionPrefill> {

--- a/src/server/websocket.ts
+++ b/src/server/websocket.ts
@@ -843,12 +843,11 @@ function subscribeWithCoalescing(
   // (e.g. post-resize redraws) that arrived after the snapshot was taken.
   //
   // ── Adaptive coalescing ──
-  // Broker forwards every PTY-read chunk as a separate output frame.
-  // macOS PTY delivers ~1KB clusters during heavy TUI redraws (claude
-  // SIGWINCH repaint = 1500 chunks @ 1024 bytes). Without coalescing,
-  // each chunk = one ws.send = one browser macrotask = one ghostty parse
-  // pass; ghostty paints between chunks as rAF fires, so the user sees
-  // mid-redraw fragments scrolling/painting incrementally.
+  // Broker frames may already combine contiguous PTY reads up to 8 KiB, but a
+  // heavy TUI redraw still spans many broker frames. Without this second-stage
+  // time-based coalescing, each frame becomes one ws.send, one browser
+  // macrotask, and one ghostty parse pass; ghostty may paint between frames so
+  // the user sees mid-redraw fragments scrolling/painting incrementally.
   //
   // Strategy: append to a buffer + arm a flush timer for COALESCE_FLUSH_MS
   // (one rAF). Each new chunk resets the timer. Hard cap at

--- a/tests/e2e/broker-helpers.ts
+++ b/tests/e2e/broker-helpers.ts
@@ -20,6 +20,7 @@ export interface BrokerTestServer {
   port: number;
   baseUrl: string;
   socketPath: string;
+  brokerStderr(): string;
   teardown(): Promise<void>;
 }
 
@@ -185,5 +186,11 @@ export async function start(opts?: {
     }
   }
 
-  return { port, baseUrl: `http://127.0.0.1:${port}`, socketPath, teardown };
+  return {
+    port,
+    baseUrl: `http://127.0.0.1:${port}`,
+    socketPath,
+    brokerStderr: () => brokerStderr,
+    teardown,
+  };
 }

--- a/tests/e2e/broker-take-control.e2e.ts
+++ b/tests/e2e/broker-take-control.e2e.ts
@@ -19,12 +19,25 @@ import { test, expect } from "@playwright/test";
 import { mkdtempSync, mkdirSync, realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { start, skipIfNoBroker, type BrokerTestServer } from "./broker-helpers.ts";
+import { start, skipIfNoBroker } from "./broker-helpers.ts";
+import type { BrokerTestServer } from "./broker-helpers.ts";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const PROJECT_NAME = "wp-take-control";
 const SESSION_NAME = "tc-broker";
+const STRESS_SESSION_NAMES = [
+  "tc-broker-stress-1",
+  "tc-broker-stress-2",
+  "tc-broker-stress-3",
+  "tc-broker-stress-4",
+] as const;
+const STRESS_SESSION_NAME = STRESS_SESSION_NAMES[0];
+const STRESS_PAYLOAD_BYTES = 8_180;
+const STRESS_WRITES = 12_000;
+const STRESS_WRITE_DELAY_SECONDS = 0.0005;
+const STRESS_MIN_OUTPUT_BYTES = 64 * 1024;
+const STRESS_OBSERVE_MS = 6_000;
 const CLOSE_DISPLACED = 4002;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -70,6 +83,13 @@ function waitForClose(ws: WebSocket, timeoutMs = 5000): Promise<{ code: number; 
 function sendAttachAndTakeControl(ws: WebSocket, cols = 80, rows = 24): void {
   ws.send(JSON.stringify({ type: "attach", cols, rows }));
   ws.send(JSON.stringify({ type: "take_control" }));
+}
+
+function binaryMessageBytes(data: unknown): number {
+  if (data instanceof ArrayBuffer) return data.byteLength;
+  if (ArrayBuffer.isView(data)) return data.byteLength;
+  if (data instanceof Blob) return data.size;
+  return 0;
 }
 
 // ── Server lifecycle ──────────────────────────────────────────────────────────
@@ -144,4 +164,98 @@ test("broker take-control: A → B → A chain displaces correctly", async ({}, 
   // Cleanup
   wsA2.close();
   await wait(100);
+});
+
+test("broker take-control: redraw burst does not force browser reconnect", async ({ page }, testInfo) => {
+  test.skip(skipIfNoBroker.condition, skipIfNoBroker.reason);
+  test.skip(testInfo.project.name !== "iphone-se", "one real-browser viewport covers the broker path");
+
+  const activeViewers: WebSocket[] = [];
+  let activeOutputBytes = 0;
+  const redrawCommand = `python3 -c 'import os,time;[(os.write(1,(f"\\033[H{i:05d}"+("x"*${STRESS_PAYLOAD_BYTES})).encode()),time.sleep(${STRESS_WRITE_DELAY_SECONDS})) for i in range(${STRESS_WRITES})]'\n`;
+  for (const sessionName of STRESS_SESSION_NAMES) {
+    const createResp = await fetch(`${srv!.baseUrl}/api/create`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ project: PROJECT_NAME, cmd: "shell", sessionName }),
+    });
+    expect(createResp.ok, `POST /api/create ${sessionName}`).toBeTruthy();
+
+    const wsUrl = srv!.baseUrl.replace(/^http/, "ws")
+      + `/ws/pty?session=${encodeURIComponent(sessionName)}`;
+    const viewer = await openWs(wsUrl);
+    activeViewers.push(viewer);
+    viewer.send(JSON.stringify({ type: "attach", cols: 80, rows: 24 }));
+    await waitForJson(viewer, "attach_ack");
+    if (sessionName === STRESS_SESSION_NAME) {
+      viewer.addEventListener("message", (event) => {
+        if (typeof event.data !== "string") activeOutputBytes += binaryMessageBytes(event.data);
+      });
+    }
+    viewer.send(new TextEncoder().encode(redrawCommand));
+  }
+  const outputDeadline = Date.now() + 5000;
+  while (activeOutputBytes < STRESS_MIN_OUTPUT_BYTES && Date.now() < outputDeadline) await wait(25);
+  expect(activeOutputBytes, "stress redraw started before takeover").toBeGreaterThanOrEqual(STRESS_MIN_OUTPUT_BYTES);
+
+  let browserPtyConnections = 0;
+  page.on("websocket", (socket) => {
+    if (socket.url().includes("/ws/pty")) browserPtyConnections++;
+  });
+  await page.goto(srv!.baseUrl);
+  await page.locator(".card", { hasText: STRESS_SESSION_NAME }).first().click();
+  const conflict = page.locator("#desktop-conflict-overlay");
+  await expect(conflict).toBeVisible({ timeout: 5000 });
+
+  await page.evaluate(() => {
+    const target = document.getElementById("conn-status");
+    const state = window as unknown as {
+      __takeoverStatuses?: string[];
+      __takeoverCloses?: Array<{ readonly code: number; readonly reason: string }>;
+      state?: { readonly terminalController?: { readonly ptyClient?: { readonly ws?: WebSocket | null } } };
+    };
+    state.__takeoverStatuses = [];
+    state.__takeoverCloses = [];
+    state.state?.terminalController?.ptyClient?.ws?.addEventListener("close", (event) => {
+      state.__takeoverCloses?.push({ code: event.code, reason: event.reason });
+    });
+    if (!target) return;
+    const record = () => {
+      if (target.style.display !== "none") state.__takeoverStatuses?.push(target.textContent || "");
+    };
+    new MutationObserver(record).observe(target, { childList: true, subtree: true, attributes: true });
+    record();
+  });
+  await conflict.locator("button").click();
+  await expect(conflict).toBeHidden({ timeout: 5000 });
+  await page.waitForTimeout(STRESS_OBSERVE_MS);
+
+  const trace = await page.evaluate(() => {
+    const state = window as unknown as {
+      __takeoverStatuses?: string[];
+      __takeoverCloses?: Array<{ readonly code: number; readonly reason: string }>;
+    };
+    return {
+      statuses: state.__takeoverStatuses || [],
+      closes: state.__takeoverCloses || [],
+    };
+  });
+  expect(
+    browserPtyConnections,
+    `takeover stayed on the original browser websocket; closes=${JSON.stringify(trace.closes)}`,
+  ).toBe(1);
+  expect(trace.statuses.join("\n")).not.toMatch(/reconnecting/i);
+  expect(
+    srv!.brokerStderr(),
+    "broker subscription forwarders kept up with the multi-session redraw burst",
+  ).not.toContain("subscription forwarder lagged broadcast");
+
+  for (const viewer of activeViewers) viewer.close();
+  for (const session of STRESS_SESSION_NAMES) {
+    await fetch(`${srv!.baseUrl}/api/kill`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session }),
+    });
+  }
 });

--- a/tests/e2e/session-switch.e2e.ts
+++ b/tests/e2e/session-switch.e2e.ts
@@ -901,7 +901,11 @@ test("desktop sidebar hover does not put live terminal into loading state", asyn
     // @ts-ignore exposed by the browser bundle
     openSession("test-project", "");
   });
-  await expect(page.locator("#desktop-terminal-container")).toHaveAttribute("data-terminal-load-state", "live", { timeout: 5000 });
+  const terminalContainer = page.locator("#desktop-terminal-container");
+  await expect(terminalContainer).toHaveAttribute("data-terminal-load-state", "live", { timeout: 5000 });
+  await expect.poll(async () => terminalContainer.locator("canvas").evaluate((canvas) => getComputedStyle(canvas).opacity), {
+    timeout: 5000,
+  }).toBe("1");
 
   const hoverState = await page.evaluate(() => {
     const stateWindow = window as unknown as { state: { sidebarResizeDone: boolean; sidebarCollapsed: boolean; sidebarPinned: boolean; sessionsExpanded: boolean } };

--- a/tests/unit/broker-client.test.ts
+++ b/tests/unit/broker-client.test.ts
@@ -545,6 +545,33 @@ describe("BrokerClient: subscribe/unsubscribe RPC", () => {
     expect(captured!.since_seq).toBe(1234);
   });
 
+  test("subscription_dropped resumes after the last output delivered before the barrier", async () => {
+    const { server, client } = await bootClientToServer();
+    const sinceSeqs: Array<number | undefined> = [];
+    server.onRequest = (req, sock) => {
+      if (req.method === "subscribe") {
+        sinceSeqs.push((req.params as { since_seq?: number }).since_seq);
+      }
+      server.send(sock, {
+        kind: FRAME_KIND_CONTROL_RESPONSE,
+        value: { id: req.id, status: "ok", payload: { kind: req.method, ok: true, current_seq: 42 } },
+      });
+    };
+    await client.subscribe(SAMPLE_UUID);
+
+    server.broadcast({
+      kind: FRAME_KIND_OUTPUT_BINARY,
+      value: { sessionId: SAMPLE_UUID, seq: 42n, data: new Uint8Array([1]) },
+    });
+    server.broadcast({
+      kind: FRAME_KIND_EVENT,
+      value: { event: "subscription_dropped", session_id: SAMPLE_UUID, lagged: 7 },
+    });
+
+    await waitFor(() => sinceSeqs.length === 2);
+    expect(sinceSeqs).toEqual([undefined, 42]);
+  });
+
   test("subscribe clamps since_seq above Number.MAX_SAFE_INTEGER", async () => {
     const { server, client } = await bootClientToServer();
     let captured: Record<string, unknown> | null = null;


### PR DESCRIPTION
## stacked on

- base: #196 (`fix/mobile-keyboard-grid-polish`)
- merge #196 first; this PR contains the broker backpressure work and its review follow-ups.

## problem

During take-control on high-output TUIs, broker output forwarding can lag its 256-chunk broadcast receiver. The server then gets `SubscriptionDropped` / `replay_truncated`, reconnects the browser, and exposes redraw bytes as a visible character stream. The first implementation also allowed output to occupy the shared writer queue and starve control RPCs.

Live repros dropped 203–2,445 chunks per cycle.

## change

- continue draining live broadcast output while its output queue is backpressured
- use separate per-connection control/event and output queues
- prioritize control/event frames in the socket writer
- coalesce contiguous PTY chunks into frames capped at 8 KiB
- cap local per-subscription buffering at 8 MiB
- preserve the pre-coalescing ~8 MiB output-queue memory envelope
- retain existing lag recovery for sustained output beyond the local cap
- queue `subscription_dropped` behind accepted output as a replay-ordering barrier
- define `seq` as the final PTY-chunk watermark covered by a frame
- update broker protocol and client/server comments for coalescing and priority semantics

## regressions

- deterministic 2,000-chunk writer-backpressure test: all bytes arrive, no drop, final seq is preserved
- replay→live seam test: bytes remain ordered and frame watermarks increase through coalescing
- sustained-output test: crossing the 8 MiB local cap queues output before `subscription_dropped`
- real socket-writer test: queued control responses overtake queued output
- TS client recovery test: the barrier resubscribes from the last delivered chunk seq
- control-starvation test: saturated output cannot block a control response
- real-browser, real-broker takeover test with four concurrent high-volume sessions:
  - old broker: red with four `subscription forwarder lagged broadcast` warnings
  - updated broker: no lag, no reconnect banner, one browser websocket; green 3/3 repeated runs

## verification

- Rust broker: 178 passed, 0 failed
- Bun: 1,828 passed, 0 failed
- Playwright: 105 passed, 126 expected skips
- typecheck
- `rustfmt --check`
- `git diff --check`

## deployment status

The initial broker implementation was deployed as PID `28214`, and #196’s server candidate is live as PID `68020`. The latest review-fix commit `09c5625` is **not deployed**; it requires another approved broker restart.

Live #196 assets currently remain:

- app SHA-256: `b2f548b08b293a80be1932659da375c6f05b96b946d09ac8b95103cafd5b2521`
- Ghostty SHA-256: `20a5074d3ef7a4e8aa5555ffc7c2ac936227cd094bd5949a7be08a2711a68f57`

## release gates

This remains draft pending final repeat differential review and real Android/Gboard verification for #196.
