### PR TITLE
feat: expose session target preflight status

### DIFF
--- a/.plans/issue-pi-task-target-preflight-2026-07-23.md
+++ b/.plans/issue-pi-task-target-preflight-2026-07-23.md
@@ -1,0 +1,231 @@
+# issue: expose wolfpack target liveness for pi-task dispatch preflight
+
+status: complete; parent-verified and independently reviewed
+created: 2026-07-23
+
+## implementation notes
+
+assumptions:
+
+1. extend `wolfpack session status <selector> --json` additively rather than adding `session preflight`; current status route is already the stable identity surface.
+2. broker/listed session plus backend liveness is authoritative; terminal snapshots/output remain unrelated and must not be called for status liveness.
+3. closed liveness enum for this phase is `ready | dead | unavailable`; Wolfpack cannot infer busy or stale, so it does not publish either state.
+4. exact Pi model/task semantics stay out of Wolfpack.
+
+red evidence:
+
+- `bun test tests/unit/session-control-fast-path.test.ts tests/integration/api.test.ts tests/unit/control-api-schema.test.ts` failed as expected for new contract tests: missing `selector/project/projectDir/terminal`, dead liveness returned 200 instead of structured failure, schema rejected new fields. Same run also hit existing unrelated `POST /api/ralph/start validation ordering` git commit timeout from local 1Password signing (`fatal: failed to write commit object`).
+
+progress:
+
+- [x] read repo instructions, plan, session-control docs, schema docs, relevant CLI/server/backend/session-selector modules, and git history for session control.
+- [x] added contract/regression tests before production code.
+- [x] implemented additive `session status --json` contract: `selector`, `project`, `projectDir`, and `terminal` liveness with closed enum; `projectPath`, `harness`, `session`, and `sessionId` remain preserved.
+- [x] dead listed sessions fail closed with HTTP 410 / CLI exit 3 and a structured `SESSION_DEAD` envelope; unknown/ambiguous/backend/auth failures keep bounded structured envelopes.
+- [x] generated `docs/generated/control-api.schema.json` and updated schema snapshot/docs.
+
+worker green evidence:
+
+- focused status/schema tests: `bun test tests/unit/session-control-fast-path.test.ts tests/integration/api.test.ts tests/unit/control-api-schema.test.ts tests/integration/control-api-schema-contract.test.ts --test-name-pattern 'status|session control API|control api schema'` — 25 pass, 0 fail.
+- schema contract: `bun test tests/integration/control-api-schema-contract.test.ts` — 1 pass, 0 fail.
+- typecheck after `bun install --frozen-lockfile`: `bun run typecheck` — pass.
+- full suite: `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false bun test` — 1821 pass, 21 skip, 0 fail. gpg signing was disabled only for the test process to avoid the local 1Password git signing failure observed in the red run.
+- diff check: `git diff --check` — pass.
+
+## parent takeover and review remediation — 2026-07-24
+
+The implementation worker session closed without publishing `agent_task_done`; the parent cancelled the stale task and continued from its uncommitted worktree.
+
+### contract hardening before review
+
+- red: a new schema test proved `selector`, `project`, `projectDir`, and `terminal` were documented but not required; a CLI test proved a nominal structured failure could reflect a 10,000-character server message.
+- change: added `src/session-status-contract.ts` as the closed-set owner, made all machine preflight fields required, normalized known status failures to fixed messages, bounded copied identities, and removed raw response prose from generic CLI failures.
+- green: focused schema/CLI tests passed; typecheck and diff checks passed.
+
+### independent review finding 1 — real broker dead state was unreachable
+
+- review reproduction: `BrokerBackend.list()` filters `alive:false` entries before active selector resolution, so the original HTTP 410 test exercised a mock-only state.
+- red: `BrokerBackend.inspectSession` regression failed because no broker-authoritative inspection primitive existed.
+- change: added optional backend inspection and a `BrokerBackend.inspectSession()` path that resolves name/stable-id ambiguity against the complete `list_sessions` table before active-list filtering. `alive:false` now reaches `SESSION_DEAD`; a reaped target honestly becomes `SESSION_NOT_FOUND`.
+- green: the real broker-adapter unit regression and focused route tests pass.
+
+### independent review finding 2 — direct HTTP failures were inconsistent
+
+- review evidence: status returned legacy `{ error, code }` or prose-only envelopes for missing, unknown, ambiguous, and backend-unavailable targets.
+- change: added one closed `SessionStatusFailure` envelope for 400/404/409/410/503, fixed messages, explicit unavailable liveness, generated schema coverage, and CLI sanitization for every known status failure.
+- green: focused API/schema/CLI suite passed with 30 tests, then the expanded touched-area suite passed with 23 status/schema tests after final schema-message bounding.
+
+### final independent re-review
+
+- verdict: ship; no actionable findings.
+- production reproduction: dead broker entry => HTTP 410 `SESSION_DEAD`; reaped target => 404 `SESSION_NOT_FOUND`; name/id collision => 409 `AMBIGUOUS_SELECTOR`.
+- CLI reproduction: arbitrary/oversized server prose is replaced by bounded closed messages.
+- confirmed status uses broker `list_sessions` inspection and never calls pane/snapshot output.
+
+### final parent verification
+
+- built the real Rust broker: `cargo build --manifest-path broker/Cargo.toml --bin wolfpack-broker`.
+- deterministic schema regeneration: schema SHA-256 `877c879c0aa4b55538eaaed458907061bb161efdbbc698052de91434b9a58eff`; snapshot SHA-256 `bf77e75e9f1c6412c61783d0fd6d9bc45db8c6e4ac4e367b57f375480ea862d5`.
+- `bun run typecheck`: passed.
+- full suite with real broker coverage: 1839 pass, 0 fail, 0 skip, 1 snapshot across 121 files.
+- `git diff --check`: passed.
+
+## summary
+
+`pi-tasks` needs a stable machine-readable Wolfpack target inspection surface so the Pi task communication layer can reject dead/stale/wrong-project targets before dispatching assignment text.
+
+Wolfpack should provide terminal/session facts only. Pi remains the authority for agent task state, active model requirements, issue metadata, context refs, and completion semantics.
+
+## background
+
+A recent multi-agent workflow wasted dispatches on dead or unsuitable target sessions. The task communication layer can avoid this, but only if the Wolfpack transport can ask Wolfpack for liveness/project/session facts before it calls the existing send/prompt path.
+
+Existing docs already describe:
+
+- `wolfpack list --json`
+- `wolfpack session status <session-or-id> --json`
+- stable `sessionId`
+- active state, project path, harness, parent identity
+- no terminal output scraping for automation
+
+This issue asks to make that surface sufficient and explicit for Pi task preflight.
+
+## ownership boundary
+
+Wolfpack owns and should expose:
+
+- selector resolution by name or stable session id
+- ambiguity failures
+- terminal/broker target existence
+- broker/pty liveness or stale/dead state
+- project path if known
+- harness/agent kind if known
+- stable session identity
+- bounded diagnostics and exit codes
+
+Wolfpack must not expose or decide:
+
+- active Pi model readiness
+- `agent_task_*` protocol semantics
+- phase/issue/role metadata
+- verification tiers
+- task completion status
+- whether a target has finished work based on terminal text
+
+## requested behavior
+
+### preferred minimal change
+
+Extend or stabilize:
+
+```bash
+wolfpack session status <session-or-id> --json
+```
+
+so it is sufficient for automated preflight.
+
+Expected success shape, exact names negotiable:
+
+```json
+{
+  "ok": true,
+  "session": "looper-ai-2-sub-agent",
+  "sessionId": "stable-id",
+  "selector": "looper-ai-2-sub-agent",
+  "project": "looper-ai",
+  "projectDir": "/Users/home/Dev/looper-ai",
+  "harness": "pi",
+  "terminal": {
+    "exists": true,
+    "alive": true,
+    "status": "ready"
+  }
+}
+```
+
+Allowed `terminal.status` values should be a closed enum, for example:
+
+```text
+ready | busy | stale | dead | unavailable
+```
+
+If Wolfpack cannot distinguish `ready` from `busy`, return `alive: true` and `status: "ready"` or `"unavailable"`; do not guess from terminal prose.
+
+### failure shape
+
+For unknown/dead/ambiguous/backend-unavailable targets:
+
+```json
+{
+  "ok": false,
+  "selector": "target",
+  "error": {
+    "code": "SESSION_NOT_FOUND",
+    "message": "session not found"
+  }
+}
+```
+
+Diagnostic text must be bounded and must not include terminal output.
+
+### optional explicit command
+
+If overloading `status` is undesirable, add:
+
+```bash
+wolfpack session preflight <session-or-id> --json [--project <path-or-name>] [--alive]
+```
+
+This command should be a thin machine-oriented wrapper around the same session identity/liveness facts. It should still not know Pi model or task semantics.
+
+## acceptance criteria
+
+- `wolfpack session status/preflight --json <stable-session-id>` succeeds for an alive target and returns stable `sessionId`.
+- The same command accepts an unambiguous session name and fails closed on ambiguous name/id selectors.
+- Unknown targets return nonzero with a bounded JSON error envelope.
+- Stale/dead targets are represented as structured liveness failure, not successful active sessions.
+- Project path/name is included when Wolfpack knows it, so Pi can compare required project before dispatch.
+- No terminal output is read or matched to determine task completion or readiness.
+- The command does not expose or require Pi model/task metadata.
+- Existing `session status --json` consumers remain compatible, or the change is added under the new `session preflight` command.
+- Docs in `docs/session-control.md` mention that Pi/agent task layers should use this only as terminal/session liveness evidence.
+
+## non-goals
+
+- no `agent_task_*` implementation in Wolfpack
+- no model inspection
+- no task board
+- no parsing terminal prose for readiness/completion
+- no per-session auth beyond Wolfpack's existing global admission/session-control trust model
+- no browser grid/layout state reconstruction
+
+## pi-tasks integration plan
+
+Once this exists, the Wolfpack transport in `pi-tasks` can implement optional transport preflight:
+
+```text
+agent_task_send
+→ pi-tasks validates task metadata/context refs/conflicting issue task
+→ wolfpack transport calls session status/preflight --json
+→ pi-tasks combines liveness/project result with Pi-owned model/task readiness
+→ dispatch only if required checks pass
+```
+
+If Wolfpack liveness is unavailable, `pi-tasks` should surface that as `unavailable`, not invent failure, unless the caller explicitly required reachable/alive target.
+
+## likely touched areas
+
+Implementation likely routes through:
+
+- `src/cli/session-control.ts` or adjacent CLI command parsing
+- server session-control/status route if JSON fields are missing there
+- broker-backed session adapter/client if liveness state is not currently surfaced
+- `docs/session-control.md`
+- control API schema/docs/tests if response shape changes
+
+Respect existing invariants:
+
+- broker owns PTY/session liveness
+- server/CLI are clients of broker/session state, not hidden PTY owners
+- selectors must fail closed on ambiguity
+- automation should retain/use stable `sessionId`

--- a/docs/generated/control-api.schema.json
+++ b/docs/generated/control-api.schema.json
@@ -583,10 +583,11 @@
         "$ref": "#/$defs/SessionStatus"
       },
       "errors": [
-        "400 ErrorEnvelope",
-        "404 ErrorEnvelope",
-        "409 ErrorEnvelope",
-        "503 ErrorEnvelope"
+        "400 SessionStatusFailure",
+        "404 SessionStatusFailure",
+        "409 SessionStatusFailure",
+        "410 SessionStatusFailure",
+        "503 SessionStatusFailure"
       ]
     },
     "readSession": {
@@ -2043,11 +2044,89 @@
       ],
       "additionalProperties": false
     },
+    "SessionTerminalStatus": {
+      "enum": [
+        "ready",
+        "dead",
+        "unavailable"
+      ]
+    },
+    "SessionTerminalLiveness": {
+      "type": "object",
+      "properties": {
+        "exists": {
+          "type": "boolean"
+        },
+        "alive": {
+          "type": "boolean"
+        },
+        "status": {
+          "$ref": "#/$defs/SessionTerminalStatus"
+        }
+      },
+      "required": [
+        "exists",
+        "alive",
+        "status"
+      ],
+      "additionalProperties": false
+    },
+    "SessionStatusFailure": {
+      "type": "object",
+      "properties": {
+        "ok": {
+          "const": false
+        },
+        "selector": {
+          "$ref": "#/$defs/SessionSelector"
+        },
+        "session": {
+          "$ref": "#/$defs/SessionName"
+        },
+        "sessionId": {
+          "$ref": "#/$defs/SessionId"
+        },
+        "terminal": {
+          "$ref": "#/$defs/SessionTerminalLiveness"
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "enum": [
+                "INVALID_REQUEST",
+                "SESSION_NOT_FOUND",
+                "AMBIGUOUS_SELECTOR",
+                "SESSION_DEAD",
+                "BACKEND_UNAVAILABLE"
+              ]
+            },
+            "message": {
+              "type": "string",
+              "maxLength": 160
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "ok",
+        "error"
+      ],
+      "additionalProperties": false
+    },
     "SessionStatus": {
       "type": "object",
       "properties": {
         "ok": {
           "const": true
+        },
+        "selector": {
+          "$ref": "#/$defs/SessionSelector"
         },
         "session": {
           "$ref": "#/$defs/SessionName"
@@ -2058,11 +2137,20 @@
         "state": {
           "const": "active"
         },
+        "project": {
+          "type": "string"
+        },
         "projectPath": {
+          "type": "string"
+        },
+        "projectDir": {
           "type": "string"
         },
         "harness": {
           "type": "string"
+        },
+        "terminal": {
+          "$ref": "#/$defs/SessionTerminalLiveness"
         },
         "parentSession": {
           "$ref": "#/$defs/SessionControlIdentity"
@@ -2070,11 +2158,15 @@
       },
       "required": [
         "ok",
+        "selector",
         "session",
         "sessionId",
         "state",
+        "project",
         "projectPath",
-        "harness"
+        "projectDir",
+        "harness",
+        "terminal"
       ],
       "additionalProperties": false
     },

--- a/docs/session-control.md
+++ b/docs/session-control.md
@@ -56,10 +56,11 @@ wolfpack session read <session-or-id> [--json]
 ```
 
 - `list --json` uses the lightweight `/api/session-control/list` route and returns active structured identities as one JSON envelope, without terminal previews.
-- `status` returns canonical name, stable ID, active state, project path, harness, and optional parent identity. It does not capture terminal output.
+- `status` returns canonical name, stable ID, active state, project path, `projectDir` alias, project name, harness, optional parent identity, and bounded `terminal` liveness (`ready | dead | unavailable`). Dead targets return `SESSION_DEAD`; unknown, ambiguous, and backend-unavailable targets use the same structured failure envelope. It does not capture terminal output.
 - `read` is the explicit full broker-snapshot operation.
 - names remain accepted for humans; automation should retain and use `sessionId` returned by create, spawn, list, or status.
 - selectors that ambiguously match a name and another session's ID fail closed.
+- Pi/agent task layers may use `session status <selector> --json` only as Wolfpack-owned target evidence: selector resolution, broker/session existence, stable identity, project path, harness, and terminal liveness. They must not infer Pi model readiness, task completion, or agent state from Wolfpack status.
 
 ## Send and wait
 

--- a/src/cli/session-control.ts
+++ b/src/cli/session-control.ts
@@ -13,6 +13,13 @@ import {
   SESSION_CREATE_ERROR,
 } from "../session-create-contract.js";
 import type { SessionCreateErrorCode } from "../session-create-contract.js";
+import {
+  isBoundedSessionStatusIdentity,
+  isSessionStatusErrorCode,
+  parseSessionTerminalLiveness,
+  SESSION_STATUS_ERROR_MESSAGE,
+} from "../session-status-contract.js";
+import type { SessionTerminalLiveness } from "../session-status-contract.js";
 import { MAX_INITIAL_PROMPT_LENGTH } from "../validation.js";
 import { call as callApi } from "./api.js";
 import { print, red, yellow } from "./formatting.js";
@@ -355,21 +362,54 @@ function shellQuote(value: string): string {
 }
 
 const SESSION_API_FAILURES: Readonly<Record<number, CliErrorDescriptor & { readonly code: string }>> = {
+  400: { code: "INVALID_REQUEST", message: "invalid request", exitCode: SESSION_EXIT.GENERAL },
   401: { code: "AUTH_REQUIRED", message: "auth required", exitCode: SESSION_EXIT.AUTH },
   404: { code: "SESSION_NOT_FOUND", message: "session not found", exitCode: SESSION_EXIT.NOT_FOUND },
   408: { code: "TIMEOUT", message: "timeout", exitCode: SESSION_EXIT.TIMEOUT },
   409: { code: "AMBIGUOUS_SELECTOR", message: "ambiguous session selector", exitCode: SESSION_EXIT.GENERAL },
+  410: { code: "SESSION_DEAD", message: "session is not alive", exitCode: SESSION_EXIT.NOT_FOUND },
   503: { code: "BACKEND_UNAVAILABLE", message: "backend unavailable", exitCode: SESSION_EXIT.BACKEND_UNAVAILABLE },
 };
+
+function parseStructuredFailure(
+  body: string | undefined,
+  failure: CliErrorDescriptor & { readonly code: string },
+): unknown {
+  if (!body) return undefined;
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+    const envelope = parsed as Record<string, unknown>;
+    if (envelope.ok !== false || !envelope.error || typeof envelope.error !== "object") return undefined;
+    const error = envelope.error as Record<string, unknown>;
+    if (!isSessionStatusErrorCode(error.code) || error.code !== failure.code) return undefined;
+    const terminal = parseSessionTerminalLiveness(envelope.terminal);
+    return {
+      ok: false,
+      ...(isBoundedSessionStatusIdentity(envelope.selector) && { selector: envelope.selector }),
+      ...(isBoundedSessionStatusIdentity(envelope.session) && { session: envelope.session }),
+      ...(isBoundedSessionStatusIdentity(envelope.sessionId) && { sessionId: envelope.sessionId }),
+      ...(terminal && { terminal }),
+      error: {
+        code: error.code,
+        message: SESSION_STATUS_ERROR_MESSAGE[error.code],
+      },
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 function mapApiError(e: unknown, output: OutputMode): number {
   const err = e as Partial<ApiError>;
   const failure = SESSION_API_FAILURES[err.status ?? 0] ?? {
     code: "SESSION_COMMAND_FAILED",
-    message: `session command failed: ${err.body ?? String(e)}`,
+    message: "session command failed",
     exitCode: SESSION_EXIT.GENERAL,
   };
-  if (output === "json") jsonOut({ ok: false, error: { code: failure.code, message: failure.message } });
+  const structured = output === "json" ? parseStructuredFailure(err.body, failure) : undefined;
+  if (structured !== undefined) jsonOut(structured);
+  else if (output === "json") jsonOut({ ok: false, error: { code: failure.code, message: failure.message } });
   else print((failure.exitCode === SESSION_EXIT.NOT_FOUND || failure.exitCode === SESSION_EXIT.TIMEOUT)
     ? yellow(failure.message)
     : red(failure.message));
@@ -386,11 +426,15 @@ interface SessionLaunchResponse {
 
 interface SessionStatusResponse {
   readonly ok: true;
+  readonly selector: string;
   readonly session: string;
   readonly sessionId: string;
   readonly state: "active";
+  readonly project: string;
   readonly projectPath: string;
+  readonly projectDir: string;
   readonly harness: string;
+  readonly terminal: SessionTerminalLiveness;
   readonly parentSession?: {
     readonly session: string;
     readonly sessionId: string;

--- a/src/control-api/schema.ts
+++ b/src/control-api/schema.ts
@@ -10,6 +10,11 @@ import {
   SESSION_OPEN_HTTP_STATUS,
 } from "../session-open-contract.ts";
 import type { SessionOpenErrorCode } from "../session-open-contract.ts";
+import {
+  SESSION_STATUS_ERROR,
+  SESSION_STATUS_ERROR_MESSAGE_MAX_CODE_POINTS,
+  SESSION_TERMINAL_STATUSES,
+} from "../session-status-contract.ts";
 import { MAX_INITIAL_PROMPT_LENGTH } from "../validation.ts";
 
 export const CONTROL_API_SCHEMA_VERSION = "1.0.0";
@@ -201,15 +206,50 @@ export const controlApiSource: ControlApiSource = {
       session: ref("SessionName"),
       sessionId: ref("SessionId"),
     }, ["session", "sessionId"]),
+    SessionTerminalStatus: { enum: [...SESSION_TERMINAL_STATUSES] },
+    SessionTerminalLiveness: object({
+      exists: boolean(),
+      alive: boolean(),
+      status: ref("SessionTerminalStatus"),
+    }, ["exists", "alive", "status"]),
+    SessionStatusFailure: object({
+      ok: { const: false },
+      selector: ref("SessionSelector"),
+      session: ref("SessionName"),
+      sessionId: ref("SessionId"),
+      terminal: ref("SessionTerminalLiveness"),
+      error: object({
+        code: { enum: Object.values(SESSION_STATUS_ERROR) },
+        message: {
+          type: "string",
+          maxLength: SESSION_STATUS_ERROR_MESSAGE_MAX_CODE_POINTS,
+        },
+      }, ["code", "message"]),
+    }, ["ok", "error"]),
     SessionStatus: object({
       ok: { const: true },
+      selector: ref("SessionSelector"),
       session: ref("SessionName"),
       sessionId: ref("SessionId"),
       state: { const: "active" },
+      project: string(),
       projectPath: string(),
+      projectDir: string(),
       harness: string(),
+      terminal: ref("SessionTerminalLiveness"),
       parentSession: ref("SessionControlIdentity"),
-    }, ["ok", "session", "sessionId", "state", "projectPath", "harness"]),
+    }, [
+      "ok",
+      "selector",
+      "session",
+      "sessionId",
+      "state",
+      "project",
+      "projectPath",
+      "projectDir",
+      "harness",
+      "terminal",
+    ]),
     Peer: object({
       name: string(),
       url: string(),
@@ -454,7 +494,13 @@ export const controlApiSource: ControlApiSource = {
       auth: "jwt-when-configured",
       request: object({ session: ref("SessionSelector") }, ["session"]),
       response: ref("SessionStatus"),
-      errors: ["400 ErrorEnvelope", "404 ErrorEnvelope", "409 ErrorEnvelope", "503 ErrorEnvelope"],
+      errors: [
+        "400 SessionStatusFailure",
+        "404 SessionStatusFailure",
+        "409 SessionStatusFailure",
+        "410 SessionStatusFailure",
+        "503 SessionStatusFailure",
+      ],
     },
     "GET /api/session-control/read": {
       operationId: "readSession",

--- a/src/server/backend.ts
+++ b/src/server/backend.ts
@@ -10,6 +10,7 @@ import { createLogger, errMsg } from "../log.js";
 import { defaultBrokerSocketPath } from "../broker/client.js";
 import type { BrokerBackend } from "./broker-backend.js";
 import type { EventBody } from "../broker/codec.js";
+import type { SessionInspectionResult } from "../session-status-contract.js";
 import type {
   AgentKind,
   CaptureSessionIdentityInput,
@@ -55,6 +56,7 @@ export interface SessionLaunchOptions {
 export interface SessionBackend {
   list(): Promise<string[]>;
   listIdentities?(): Promise<Record<string, PublicSessionIdentity>>;
+  inspectSession?(selector: string): Promise<SessionInspectionResult>;
   createSession(
     name: string,
     cwd: string,
@@ -389,6 +391,10 @@ export class BackendRouter implements SessionBackend {
   async listIdentities(): Promise<Record<string, PublicSessionIdentity>> {
     if (!this.broker) return {};
     return this.broker.listIdentities();
+  }
+
+  async inspectSession(selector: string): Promise<SessionInspectionResult> {
+    return this.requireBroker().inspectSession(selector);
   }
 
   async createSession(

--- a/src/server/broker-backend.ts
+++ b/src/server/broker-backend.ts
@@ -33,6 +33,7 @@ import type {
 } from "./backend.js";
 import type { BrokerClient, OutputSubscriber } from "../broker/client.js";
 import type { ControlResponse, EventBody } from "../broker/codec.js";
+import type { SessionInspectionResult } from "../session-status-contract.js";
 import {
   AGENT_KIND,
   detectAgentKindFromCommandArgs,
@@ -59,6 +60,7 @@ import type {
   ParentSessionIdentity,
   PublicSessionIdentity,
 } from "./session-identity.js";
+import { resolveSessionSelector } from "./session-selector.js";
 
 const log = createLogger("broker-backend");
 
@@ -207,9 +209,13 @@ export class BrokerBackend implements SessionBackend, PtyBackendMethods {
 
   // ── SessionBackend ──
 
-  async list(): Promise<string[]> {
+  private async brokerSessions(): Promise<BrokerSessionInfo[]> {
     const payload = unwrap(await this.client.request("list_sessions", {}));
-    const sessions = (payload.sessions as BrokerSessionInfo[] | undefined) ?? [];
+    return (payload.sessions as BrokerSessionInfo[] | undefined) ?? [];
+  }
+
+  async list(): Promise<string[]> {
+    const sessions = await this.brokerSessions();
     const identitySessions: Array<{
       wolfpackSessionId: string;
       wolfpackSessionName: string;
@@ -254,6 +260,44 @@ export class BrokerBackend implements SessionBackend, PtyBackendMethods {
       byName[identity.wolfpackSessionName] = toPublicSessionIdentity(identity);
     }
     return byName;
+  }
+
+  async inspectSession(selector: string): Promise<SessionInspectionResult> {
+    const sessions = await this.brokerSessions();
+    const observedAt = new Date(0).toISOString();
+    const identities: Record<string, PublicSessionIdentity> = {};
+    for (const session of sessions) {
+      const parentSession = extractParentSessionFromEnv(session.env);
+      identities[session.name] = {
+        wolfpackSessionId: session.id,
+        wolfpackSessionName: session.name,
+        projectPath: session.cwd,
+        agentKind: inferAgentKind(
+          envValue(session.env, "WOLFPACK_AGENT_KIND") || commandAgent(session.command),
+        ),
+        createdAt: observedAt,
+        updatedAt: observedAt,
+        ...(parentSession && { parentSession }),
+      };
+    }
+    const resolved = resolveSessionSelector(selector, sessions.map(session => session.name), identities);
+    if (!resolved.ok) return resolved;
+    const session = sessions.find(candidate => candidate.id === resolved.identity.wolfpackSessionId);
+    if (!session) return { ok: false, code: "NOT_FOUND" };
+    return {
+      ok: true,
+      session: session.name,
+      sessionId: session.id,
+      projectPath: session.cwd,
+      harness: resolved.identity.agentKind,
+      alive: session.alive,
+      ...(resolved.identity.parentSession && {
+        parentSession: {
+          session: resolved.identity.parentSession.wolfpackSessionName,
+          sessionId: resolved.identity.parentSession.wolfpackSessionId,
+        },
+      }),
+    };
   }
 
   async createSession(

--- a/src/server/mock-backend.ts
+++ b/src/server/mock-backend.ts
@@ -13,6 +13,8 @@ import type {
   ParentSessionIdentity,
   PublicSessionIdentity,
 } from "./session-identity.js";
+import type { SessionInspectionResult } from "../session-status-contract.js";
+import { resolveSessionSelector } from "./session-selector.js";
 
 export interface MockBackendOptions {
   sessions?: string[];
@@ -92,6 +94,26 @@ export class MockBackend implements SessionBackend {
       };
     }
     return out;
+  }
+
+  async inspectSession(selector: string): Promise<SessionInspectionResult> {
+    const identities = await this.listIdentities();
+    const resolved = resolveSessionSelector(selector, [...this._sessions], identities);
+    if (!resolved.ok) return resolved;
+    return {
+      ok: true,
+      session: resolved.name,
+      sessionId: resolved.identity.wolfpackSessionId,
+      projectPath: resolved.identity.projectPath,
+      harness: resolved.identity.agentKind,
+      alive: this.isSessionAlive(resolved.name),
+      ...(resolved.identity.parentSession && {
+        parentSession: {
+          session: resolved.identity.parentSession.wolfpackSessionName,
+          sessionId: resolved.identity.parentSession.wolfpackSessionId,
+        },
+      }),
+    };
   }
 
   /** Set hook called inside createSession before adding to set. */

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -14,7 +14,7 @@ import {
   readSync,
   closeSync,
 } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { hostname, homedir } from "node:os";
 import { execFile, execFileSync, spawn } from "node:child_process";
 import { promisify } from "node:util";
@@ -177,6 +177,17 @@ import {
 } from "../session-open-contract.js";
 import { openSubSession, SessionOpenError } from "./session-open.js";
 import { SESSION_CREATE_ERROR } from "../session-create-contract.js";
+import {
+  isBoundedSessionStatusIdentity,
+  SESSION_STATUS_ERROR,
+  SESSION_STATUS_ERROR_MESSAGE,
+  SESSION_TERMINAL_STATUS,
+} from "../session-status-contract.js";
+import type {
+  SessionInspectionResult,
+  SessionStatusErrorCode,
+  SessionTerminalLiveness,
+} from "../session-status-contract.js";
 import { createTopLevelSession } from "./session-create.js";
 import { resolveSessionSelector } from "./session-selector.js";
 import type { SessionSelectorResult } from "./session-selector.js";
@@ -311,7 +322,10 @@ async function resolveActiveSession(
     if (!resolved.ok) {
       json(
         res,
-        { error: resolved.code === "AMBIGUOUS" ? "ambiguous session selector" : "session not found" },
+        {
+          error: resolved.code === "AMBIGUOUS" ? "ambiguous session selector" : "session not found",
+          code: resolved.code === "AMBIGUOUS" ? "AMBIGUOUS_SELECTOR" : "SESSION_NOT_FOUND",
+        },
         resolved.code === "AMBIGUOUS" ? 409 : 404,
       );
       return null;
@@ -324,20 +338,76 @@ async function resolveActiveSession(
   }
 }
 
-function sessionStatusPayload(name: string, identity: PublicSessionIdentity) {
+function sessionTerminalLiveness(name: string): SessionTerminalLiveness {
+  const streaming = getRouter().getStreamingBackendForSession(name);
+  if (!streaming) {
+    return { exists: true, alive: false, status: SESSION_TERMINAL_STATUS.UNAVAILABLE };
+  }
+  const alive = streaming.isSessionAlive(name);
+  return {
+    exists: true,
+    alive,
+    status: alive ? SESSION_TERMINAL_STATUS.READY : SESSION_TERMINAL_STATUS.DEAD,
+  };
+}
+
+function sessionStatusPayload(name: string, identity: PublicSessionIdentity, selector: string = name) {
+  const terminal = sessionTerminalLiveness(name);
   return {
     ok: true as const,
+    selector,
     session: name,
     sessionId: identity.wolfpackSessionId,
     state: "active" as const,
+    project: basename(identity.projectPath),
     projectPath: identity.projectPath,
+    projectDir: identity.projectPath,
     harness: identity.agentKind,
+    terminal,
     ...(identity.parentSession && {
       parentSession: {
         session: identity.parentSession.wolfpackSessionName,
         sessionId: identity.parentSession.wolfpackSessionId,
       },
     }),
+  };
+}
+
+type SuccessfulSessionInspection = Extract<SessionInspectionResult, { readonly ok: true }>;
+
+function inspectedSessionStatusPayload(selector: string, inspection: SuccessfulSessionInspection) {
+  const terminal: SessionTerminalLiveness = {
+    exists: true,
+    alive: inspection.alive,
+    status: inspection.alive ? SESSION_TERMINAL_STATUS.READY : SESSION_TERMINAL_STATUS.DEAD,
+  };
+  return {
+    ok: true as const,
+    selector,
+    session: inspection.session,
+    sessionId: inspection.sessionId,
+    state: "active" as const,
+    project: basename(inspection.projectPath),
+    projectPath: inspection.projectPath,
+    projectDir: inspection.projectPath,
+    harness: inspection.harness,
+    terminal,
+    ...(inspection.parentSession && { parentSession: inspection.parentSession }),
+  };
+}
+
+function sessionStatusFailure(
+  selector: string | undefined,
+  code: SessionStatusErrorCode,
+  terminal?: SessionTerminalLiveness,
+  identity?: { readonly session: string; readonly sessionId: string },
+) {
+  return {
+    ok: false as const,
+    ...(isBoundedSessionStatusIdentity(selector) && { selector }),
+    ...(identity && { session: identity.session, sessionId: identity.sessionId }),
+    ...(terminal && { terminal }),
+    error: { code, message: SESSION_STATUS_ERROR_MESSAGE[code] },
   };
 }
 
@@ -972,11 +1042,63 @@ export const routes: Record<
 
   "GET /api/session-control/status": async (req, res) => {
     const url = new URL(req.url ?? "/", "http://localhost");
-    const selector = url.searchParams.get("session");
-    if (!selector) return json(res, { error: "missing session" }, 400);
-    const resolved = await resolveActiveSession(res, selector);
-    if (!resolved) return;
-    json(res, sessionStatusPayload(resolved.name, resolved.identity));
+    const selector = url.searchParams.get("session") ?? undefined;
+    if (!selector) {
+      return json(res, sessionStatusFailure(undefined, SESSION_STATUS_ERROR.INVALID_REQUEST), 400);
+    }
+    try {
+      const backend = getBackend();
+      const inspect = backend.inspectSession;
+      if (!inspect) {
+        return json(
+          res,
+          sessionStatusFailure(
+            selector,
+            SESSION_STATUS_ERROR.BACKEND_UNAVAILABLE,
+            { exists: false, alive: false, status: SESSION_TERMINAL_STATUS.UNAVAILABLE },
+          ),
+          503,
+        );
+      }
+      const inspection = await inspect.call(backend, selector);
+      if (!inspection.ok) {
+        const ambiguous = inspection.code === "AMBIGUOUS";
+        return json(
+          res,
+          sessionStatusFailure(
+            selector,
+            ambiguous ? SESSION_STATUS_ERROR.AMBIGUOUS : SESSION_STATUS_ERROR.NOT_FOUND,
+            { exists: false, alive: false, status: SESSION_TERMINAL_STATUS.UNAVAILABLE },
+          ),
+          ambiguous ? 409 : 404,
+        );
+      }
+      const status = inspectedSessionStatusPayload(selector, inspection);
+      if (!inspection.alive) {
+        return json(
+          res,
+          sessionStatusFailure(
+            selector,
+            SESSION_STATUS_ERROR.DEAD,
+            status.terminal,
+            { session: status.session, sessionId: status.sessionId },
+          ),
+          410,
+        );
+      }
+      return json(res, status);
+    } catch (error: unknown) {
+      log.warn("session status inspection failed", { error: errMsg(error) });
+      return json(
+        res,
+        sessionStatusFailure(
+          selector,
+          SESSION_STATUS_ERROR.BACKEND_UNAVAILABLE,
+          { exists: false, alive: false, status: SESSION_TERMINAL_STATUS.UNAVAILABLE },
+        ),
+        503,
+      );
+    }
   },
 
   "GET /api/session-control/read": async (req, res) => {

--- a/src/session-status-contract.ts
+++ b/src/session-status-contract.ts
@@ -1,0 +1,87 @@
+export const SESSION_TERMINAL_STATUS = {
+  READY: "ready",
+  DEAD: "dead",
+  UNAVAILABLE: "unavailable",
+} as const;
+
+export const SESSION_TERMINAL_STATUSES = [
+  SESSION_TERMINAL_STATUS.READY,
+  SESSION_TERMINAL_STATUS.DEAD,
+  SESSION_TERMINAL_STATUS.UNAVAILABLE,
+] as const;
+
+export type SessionTerminalStatus = typeof SESSION_TERMINAL_STATUSES[number];
+
+export interface SessionTerminalLiveness {
+  readonly exists: boolean;
+  readonly alive: boolean;
+  readonly status: SessionTerminalStatus;
+}
+
+export type SessionInspectionResult =
+  | {
+    readonly ok: true;
+    readonly session: string;
+    readonly sessionId: string;
+    readonly projectPath: string;
+    readonly harness: string;
+    readonly alive: boolean;
+    readonly parentSession?: {
+      readonly session: string;
+      readonly sessionId: string;
+    };
+  }
+  | {
+    readonly ok: false;
+    readonly code: "NOT_FOUND" | "AMBIGUOUS";
+  };
+
+export const SESSION_STATUS_ERROR = {
+  INVALID_REQUEST: "INVALID_REQUEST",
+  NOT_FOUND: "SESSION_NOT_FOUND",
+  AMBIGUOUS: "AMBIGUOUS_SELECTOR",
+  DEAD: "SESSION_DEAD",
+  BACKEND_UNAVAILABLE: "BACKEND_UNAVAILABLE",
+} as const;
+
+export type SessionStatusErrorCode = typeof SESSION_STATUS_ERROR[keyof typeof SESSION_STATUS_ERROR];
+
+export const SESSION_STATUS_ERROR_MESSAGE: Readonly<Record<SessionStatusErrorCode, string>> = {
+  [SESSION_STATUS_ERROR.INVALID_REQUEST]: "missing session selector",
+  [SESSION_STATUS_ERROR.NOT_FOUND]: "session not found",
+  [SESSION_STATUS_ERROR.AMBIGUOUS]: "ambiguous session selector",
+  [SESSION_STATUS_ERROR.DEAD]: "session is not alive",
+  [SESSION_STATUS_ERROR.BACKEND_UNAVAILABLE]: "backend unavailable",
+};
+
+export const SESSION_STATUS_IDENTITY_MAX_CODE_POINTS = 256;
+export const SESSION_STATUS_ERROR_MESSAGE_MAX_CODE_POINTS = 160;
+
+const SESSION_TERMINAL_STATUS_SET: ReadonlySet<string> = new Set(SESSION_TERMINAL_STATUSES);
+const SESSION_STATUS_ERROR_SET: ReadonlySet<string> = new Set(Object.values(SESSION_STATUS_ERROR));
+
+export function isSessionTerminalStatus(value: unknown): value is SessionTerminalStatus {
+  return typeof value === "string" && SESSION_TERMINAL_STATUS_SET.has(value);
+}
+
+export function isSessionStatusErrorCode(value: unknown): value is SessionStatusErrorCode {
+  return typeof value === "string" && SESSION_STATUS_ERROR_SET.has(value);
+}
+
+export function isBoundedSessionStatusIdentity(value: unknown): value is string {
+  return typeof value === "string"
+    && value.length > 0
+    && Array.from(value).length <= SESSION_STATUS_IDENTITY_MAX_CODE_POINTS;
+}
+
+export function parseSessionTerminalLiveness(value: unknown): SessionTerminalLiveness | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.exists !== "boolean" || typeof candidate.alive !== "boolean") return null;
+  if (!isSessionTerminalStatus(candidate.status)) return null;
+  return {
+    exists: candidate.exists,
+    alive: candidate.alive,
+    status: candidate.status,
+  };
+}

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -413,11 +413,15 @@ describe("agent-native top-level session control", () => {
     );
     expect(listed).toEqual({
       ok: true,
+      selector: "wolf-1",
       session: "wolf-1",
       sessionId: "mock:wolf-1",
       state: "active",
+      project: "",
       projectPath: "",
+      projectDir: "",
       harness: "unknown",
+      terminal: { exists: true, alive: true, status: "ready" },
     });
     expect(listed).not.toHaveProperty("lastLine");
 
@@ -425,11 +429,15 @@ describe("agent-native top-level session control", () => {
     expect(status.status).toBe(200);
     expect(await status.json()).toEqual({
       ok: true,
+      selector: "mock:wolf-1",
       session: "wolf-1",
       sessionId: "mock:wolf-1",
       state: "active",
+      project: "",
       projectPath: "",
+      projectDir: "",
       harness: "unknown",
+      terminal: { exists: true, alive: true, status: "ready" },
     });
 
     const read = await get(`/api/session-control/read?session=${selector}`);
@@ -1070,6 +1078,98 @@ describe("session control API", () => {
     mockBackend.setCapturePane(async (s: string) => `captured output for ${s}\n`);
     mockBackend.setOnAfterPrefill(null);
     mockBackend.lastSendArgs = null;
+  });
+
+  test("status exposes stable liveness/project facts by name without reading terminal output", async () => {
+    const originalListIdentities = mockBackend.listIdentities.bind(mockBackend);
+    mockBackend.listIdentities = async () => {
+      const identities = await originalListIdentities();
+      return {
+        ...identities,
+        "wolf-1": {
+          ...identities["wolf-1"]!,
+          projectPath: join(TEST_DEV_DIR, "my-app"),
+          agentKind: "pi",
+        },
+      };
+    };
+    mockBackend.setCapturePane(async () => {
+      throw new Error("status must not read terminal output");
+    });
+    try {
+      const res = await get("/api/session-control/status?session=wolf-1");
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        ok: true,
+        selector: "wolf-1",
+        session: "wolf-1",
+        sessionId: "mock:wolf-1",
+        state: "active",
+        project: "my-app",
+        projectPath: join(TEST_DEV_DIR, "my-app"),
+        projectDir: join(TEST_DEV_DIR, "my-app"),
+        harness: "pi",
+        terminal: { exists: true, alive: true, status: "ready" },
+      });
+    } finally {
+      mockBackend.listIdentities = originalListIdentities;
+    }
+  });
+
+  test("status resolves stable ids and fails closed for dead listed sessions", async () => {
+    mockBackend.setSessionAlive("wolf-2", false);
+    const res = await get("/api/session-control/status?session=mock%3Awolf-2");
+    mockBackend.setSessionAlive("wolf-2", null);
+
+    expect(res.status).toBe(410);
+    expect(await res.json()).toEqual({
+      ok: false,
+      selector: "mock:wolf-2",
+      session: "wolf-2",
+      sessionId: "mock:wolf-2",
+      terminal: { exists: true, alive: false, status: "dead" },
+      error: { code: "SESSION_DEAD", message: "session is not alive" },
+    });
+  });
+
+  test("status returns uniform bounded failures for missing, unknown, ambiguous, and unavailable targets", async () => {
+    const missing = await get("/api/session-control/status");
+    expect(missing.status).toBe(400);
+    expect(await missing.json()).toEqual({
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: "missing session selector" },
+    });
+
+    const unknown = await get("/api/session-control/status?session=missing-agent");
+    expect(unknown.status).toBe(404);
+    expect(await unknown.json()).toEqual({
+      ok: false,
+      selector: "missing-agent",
+      terminal: { exists: false, alive: false, status: "unavailable" },
+      error: { code: "SESSION_NOT_FOUND", message: "session not found" },
+    });
+
+    const originalInspectSession = mockBackend.inspectSession.bind(mockBackend);
+    mockBackend.inspectSession = async () => ({ ok: false, code: "AMBIGUOUS" });
+    const ambiguous = await get("/api/session-control/status?session=ambiguous-agent");
+    expect(ambiguous.status).toBe(409);
+    expect(await ambiguous.json()).toEqual({
+      ok: false,
+      selector: "ambiguous-agent",
+      terminal: { exists: false, alive: false, status: "unavailable" },
+      error: { code: "AMBIGUOUS_SELECTOR", message: "ambiguous session selector" },
+    });
+
+    mockBackend.inspectSession = async () => { throw new Error("transport details must stay private"); };
+    const unavailable = await get("/api/session-control/status?session=wolf-1");
+    mockBackend.inspectSession = originalInspectSession;
+    expect(unavailable.status).toBe(503);
+    expect(await unavailable.json()).toEqual({
+      ok: false,
+      selector: "wolf-1",
+      terminal: { exists: false, alive: false, status: "unavailable" },
+      error: { code: "BACKEND_UNAVAILABLE", message: "backend unavailable" },
+    });
   });
 
   test("reads current output from backend snapshot", async () => {

--- a/tests/unit/__snapshots__/control-api-schema.test.ts.snap
+++ b/tests/unit/__snapshots__/control-api-schema.test.ts.snap
@@ -586,10 +586,11 @@ exports[`control api schema generation schema source emits a stable snapshot 1`]
         "$ref": "#/$defs/SessionStatus"
       },
       "errors": [
-        "400 ErrorEnvelope",
-        "404 ErrorEnvelope",
-        "409 ErrorEnvelope",
-        "503 ErrorEnvelope"
+        "400 SessionStatusFailure",
+        "404 SessionStatusFailure",
+        "409 SessionStatusFailure",
+        "410 SessionStatusFailure",
+        "503 SessionStatusFailure"
       ]
     },
     "readSession": {
@@ -2046,11 +2047,89 @@ exports[`control api schema generation schema source emits a stable snapshot 1`]
       ],
       "additionalProperties": false
     },
+    "SessionTerminalStatus": {
+      "enum": [
+        "ready",
+        "dead",
+        "unavailable"
+      ]
+    },
+    "SessionTerminalLiveness": {
+      "type": "object",
+      "properties": {
+        "exists": {
+          "type": "boolean"
+        },
+        "alive": {
+          "type": "boolean"
+        },
+        "status": {
+          "$ref": "#/$defs/SessionTerminalStatus"
+        }
+      },
+      "required": [
+        "exists",
+        "alive",
+        "status"
+      ],
+      "additionalProperties": false
+    },
+    "SessionStatusFailure": {
+      "type": "object",
+      "properties": {
+        "ok": {
+          "const": false
+        },
+        "selector": {
+          "$ref": "#/$defs/SessionSelector"
+        },
+        "session": {
+          "$ref": "#/$defs/SessionName"
+        },
+        "sessionId": {
+          "$ref": "#/$defs/SessionId"
+        },
+        "terminal": {
+          "$ref": "#/$defs/SessionTerminalLiveness"
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "enum": [
+                "INVALID_REQUEST",
+                "SESSION_NOT_FOUND",
+                "AMBIGUOUS_SELECTOR",
+                "SESSION_DEAD",
+                "BACKEND_UNAVAILABLE"
+              ]
+            },
+            "message": {
+              "type": "string",
+              "maxLength": 160
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "ok",
+        "error"
+      ],
+      "additionalProperties": false
+    },
     "SessionStatus": {
       "type": "object",
       "properties": {
         "ok": {
           "const": true
+        },
+        "selector": {
+          "$ref": "#/$defs/SessionSelector"
         },
         "session": {
           "$ref": "#/$defs/SessionName"
@@ -2061,11 +2140,20 @@ exports[`control api schema generation schema source emits a stable snapshot 1`]
         "state": {
           "const": "active"
         },
+        "project": {
+          "type": "string"
+        },
         "projectPath": {
+          "type": "string"
+        },
+        "projectDir": {
           "type": "string"
         },
         "harness": {
           "type": "string"
+        },
+        "terminal": {
+          "$ref": "#/$defs/SessionTerminalLiveness"
         },
         "parentSession": {
           "$ref": "#/$defs/SessionControlIdentity"
@@ -2073,11 +2161,15 @@ exports[`control api schema generation schema source emits a stable snapshot 1`]
       },
       "required": [
         "ok",
+        "selector",
         "session",
         "sessionId",
         "state",
+        "project",
         "projectPath",
-        "harness"
+        "projectDir",
+        "harness",
+        "terminal"
       ],
       "additionalProperties": false
     },

--- a/tests/unit/broker-backend.test.ts
+++ b/tests/unit/broker-backend.test.ts
@@ -211,6 +211,29 @@ describe("BrokerBackend.list", () => {
   });
 });
 
+describe("BrokerBackend.inspectSession", () => {
+  test("resolves a dead session from the broker-authoritative table before active-list filtering", async () => {
+    client.setHandler("list_sessions", () => okResp({
+      sessions: [sessionInfo({
+        name: "dead-agent",
+        id: SESSION_UUID_1,
+        alive: false,
+        cwd: "/tmp/dead-project",
+        env: [["WOLFPACK_AGENT_KIND", "pi"]],
+      })],
+    }));
+
+    expect(await backend.inspectSession(SESSION_UUID_1)).toEqual({
+      ok: true,
+      session: "dead-agent",
+      sessionId: SESSION_UUID_1,
+      projectPath: "/tmp/dead-project",
+      harness: "pi",
+      alive: false,
+    });
+  });
+});
+
 describe("BrokerBackend.createSession", () => {
   test("issues create_session with shell command for 'shell' agent and caches id", async () => {
     client.setHandler("create_session", () => okResp({

--- a/tests/unit/control-api-schema.test.ts
+++ b/tests/unit/control-api-schema.test.ts
@@ -198,6 +198,41 @@ describe("control api schema compatibility samples", () => {
     }, artifact)).toEqual([]);
   });
 
+  test("session status requires machine-readable preflight fields", () => {
+    const response = httpResponse("getSessionStatus");
+
+    expect(validate(response, {
+      ok: true,
+      session: "wolf-1-sub-agent",
+      sessionId: "broker-child",
+      state: "active",
+      projectPath: "/repo/wolf-1",
+      harness: "pi",
+    }, artifact)).toEqual(expect.arrayContaining([
+      "$.selector is required",
+      "$.project is required",
+      "$.projectDir is required",
+      "$.terminal is required",
+    ]));
+  });
+
+  test("session status publishes one closed failure envelope", () => {
+    const failureSchema = { $ref: "#/$defs/SessionStatusFailure" };
+
+    expect(validate(failureSchema, {
+      ok: false,
+      selector: "dead-agent",
+      session: "dead-agent",
+      sessionId: "broker-dead",
+      terminal: { exists: true, alive: false, status: "dead" },
+      error: { code: "SESSION_DEAD", message: "session is not alive" },
+    }, artifact)).toEqual([]);
+    expect(validate(failureSchema, {
+      ok: false,
+      error: { code: "BROKER_SAID_SOMETHING", message: "unbounded prose" },
+    }, artifact)).not.toEqual([]);
+  });
+
   test("representative http responses satisfy generated schemas", () => {
     const samples: Array<[string, unknown]> = [
       ["getInfo", { name: "devbox", version: "1.6.6" }],
@@ -221,6 +256,18 @@ describe("control api schema compatibility samples", () => {
       ["getSettings", {
         settings: { agentCmd: "shell", cmds: [{ cmd: "shell", enabled: true }] },
         effective: { agentCmd: "shell", cmds: ["shell"], ralphAgents: [] },
+      }],
+      ["getSessionStatus", {
+        ok: true,
+        selector: "broker-child",
+        session: "wolf-1-sub-agent",
+        sessionId: "broker-child",
+        state: "active",
+        project: "wolf-1",
+        projectPath: "/repo/wolf-1",
+        projectDir: "/repo/wolf-1",
+        harness: "pi",
+        terminal: { exists: true, alive: true, status: "ready" },
       }],
       ["listRalphLoops", {
         loops: [{

--- a/tests/unit/session-control-fast-path.test.ts
+++ b/tests/unit/session-control-fast-path.test.ts
@@ -308,17 +308,21 @@ describe("session control fast-path requests", () => {
     });
   });
 
-  test("status preserves canonical name and id returned for an id selector", () => {
+  test("status preserves canonical name/id and exposes bounded terminal liveness facts for an id selector", () => {
     const script = `
       globalThis.fetch = async (url) => {
         if (!String(url).includes("/api/session-control/status?session=id-branchout")) process.exit(98);
         return Response.json({
           ok: true,
+          selector: "id-branchout",
           session: "branchout",
           sessionId: "id-branchout",
           state: "active",
+          project: "branchout",
           projectPath: "/tmp/branchout",
+          projectDir: "/tmp/branchout",
           harness: "pi",
+          terminal: { exists: true, alive: true, status: "ready" },
         });
       };
       const { runSessionCommand } = await import("./src/cli/session-control.ts");
@@ -332,10 +336,71 @@ describe("session control fast-path requests", () => {
     });
     expect(child.exitCode).toBe(SESSION_EXIT.OK);
     expect(JSON.parse(child.stdout.toString())).toMatchObject({
+      selector: "id-branchout",
       session: "branchout",
       sessionId: "id-branchout",
       state: "active",
+      project: "branchout",
+      projectDir: "/tmp/branchout",
       harness: "pi",
+      terminal: { exists: true, alive: true, status: "ready" },
     });
+  });
+
+  test("status maps structured dead-session liveness failures without terminal output", () => {
+    const script = `
+      globalThis.fetch = async () => Response.json({
+        ok: false,
+        selector: "id-dead",
+        session: "dead-session",
+        sessionId: "id-dead",
+        terminal: { exists: true, alive: false, status: "dead" },
+        error: { code: "SESSION_DEAD", message: "session is not alive" },
+      }, { status: 410 });
+      const { runSessionCommand } = await import("./src/cli/session-control.ts");
+      process.exit(await runSessionCommand(["status", "id-dead", "--json"]));
+    `;
+    const child = Bun.spawnSync([process.execPath, "-e", script], {
+      cwd: process.cwd(),
+      env: { ...process.env, NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(child.exitCode).toBe(SESSION_EXIT.NOT_FOUND);
+    expect(JSON.parse(child.stdout.toString())).toEqual({
+      ok: false,
+      selector: "id-dead",
+      session: "dead-session",
+      sessionId: "id-dead",
+      terminal: { exists: true, alive: false, status: "dead" },
+      error: { code: "SESSION_DEAD", message: "session is not alive" },
+    });
+  });
+
+  test("status bounds untrusted structured failure messages", () => {
+    const script = `
+      globalThis.fetch = async () => Response.json({
+        ok: false,
+        selector: "id-dead",
+        session: "dead-session",
+        sessionId: "id-dead",
+        terminal: { exists: true, alive: false, status: "dead" },
+        error: { code: "SESSION_DEAD", message: "x".repeat(10_000) },
+      }, { status: 410 });
+      const { runSessionCommand } = await import("./src/cli/session-control.ts");
+      process.exit(await runSessionCommand(["status", "id-dead", "--json"]));
+    `;
+    const child = Bun.spawnSync([process.execPath, "-e", script], {
+      cwd: process.cwd(),
+      env: { ...process.env, NO_COLOR: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(child.exitCode).toBe(SESSION_EXIT.NOT_FOUND);
+    expect(JSON.parse(child.stdout.toString())).toMatchObject({
+      ok: false,
+      error: { code: "SESSION_DEAD", message: "session is not alive" },
+    });
+    expect(child.stdout.length).toBeLessThan(1_000);
   });
 });


### PR DESCRIPTION
## summary

- make `wolfpack session status <selector> --json` sufficient for machine preflight
- resolve stable IDs/names against the broker-authoritative session table before active filtering
- expose bounded project, harness, identity, and `ready | dead | unavailable` terminal facts
- return one closed structured failure envelope for missing, unknown, ambiguous, dead, and backend-unavailable targets
- sanitize CLI failures without reading or reflecting terminal/server prose

## ownership boundary

Wolfpack reports only session identity, project, harness, and broker/PTTY liveness. Pi remains responsible for model readiness, task state, completion, and dispatch policy.

## verification

- independent differential re-review: ship, no actionable findings
- `cargo build --manifest-path broker/Cargo.toml --bin wolfpack-broker`
- `bun run typecheck`
- full suite: 1839 passed, 0 failed, 0 skipped
- deterministic control API schema generation
- `git diff --check`
