### PR TITLE
Add opt-in Pi integration setup

### DIFF
--- a/.plans/pi-extension-skills-setup.md
+++ b/.plans/pi-extension-skills-setup.md
@@ -1,0 +1,66 @@
+# pi extension and skills setup
+
+status: implemented — verification complete
+base: main @ ed49315
+
+**goal**
+
+when setup detects pi on `PATH`, offer one explicit opt-in that installs wolfpack session-control skills plus structured pi task delegation. users without pi must not see the offer.
+
+**assumptions**
+
+- one default-no prompt covers the complete pi subagent integration
+- acceptance invokes pi's package manager in dependency order:
+  1. `pi install npm:wolfpack-bridge` for wolfpack-owned skills
+  2. `pi install npm:@sgtbeatdown/pi-tasks` for `agent_task_*` and `wolfpack-pi-task-delegation`
+- the second install runs only if the first succeeds
+- non-interactive setup installs nothing and prints the commands only when pi exists
+- wolfpack does not edit pi settings or copy skill files directly
+
+**success criteria**
+
+- [x] non-pi users receive no pi integration prompt or guidance
+- [x] pi users receive a concise ownership explanation and default-no install prompt
+- [x] acceptance invokes both canonical package installs in order
+- [x] decline changes nothing
+- [x] first-package failure prevents extension installation
+- [x] failures show the exact retry command without aborting core setup
+- [x] README and `docs/agent-skills.md` explain the extension/skill roles and opt-in behavior
+- [x] focused tests, typecheck, full tests, package dry-run, and diff checks pass
+
+## ~~1. Add pi integration behavior tests~~
+
+add focused tests for PATH detection, interactive/non-interactive offer selection, ordered real subprocess arguments, and fail-closed sequencing.
+
+## ~~2. Implement and wire the opt-in setup flow~~
+
+add a small cli helper around canonical argv-based `pi install`, then call it from setup only when pi is detected.
+
+## ~~3. Document extension and skill ownership~~
+
+update README and `docs/agent-skills.md` with the exact package commands, ownership boundaries, opt-in behavior, and manual audited alternative.
+
+## ~~4. Verify the complete change~~
+
+run focused tests, typecheck, full `bun test`, `npm pack --dry-run --json`, and `git diff --check`; record fresh evidence here.
+
+**out of scope**
+
+- pi installation
+- direct pi settings mutation
+- non-pi harness skill installation
+- pi package uninstall/update management
+
+**status log**
+
+- 2026-07-26: switched to clean main after stashing prior `dev_new` work as `stash@{0}`.
+- 2026-07-26: inspected main setup, skill docs/tests, pi package/skill documentation, and the `@sgtbeatdown/pi-tasks` manifest.
+- 2026-07-26 red: `bun test tests/unit/pi-integration-setup.test.ts` failed because `src/cli/pi-integration.ts` did not exist.
+- 2026-07-26 green: focused setup/docs suite passed, 14 tests and 109 assertions.
+- 2026-07-26 typecheck: `bun run typecheck` passed.
+- 2026-07-26 full suite: `bun test` passed, 1922 tests across 127 files, 0 failures after rebasing onto current main.
+- 2026-07-26 package: `npm pack --dry-run --json` included all three Wolfpack skill files and updated docs.
+- 2026-07-26 real Pi package smoke: isolated temporary HOME installed both npm sources successfully; `pi list` showed both packages and filesystem checks found `wolfpack-tailnet-control`, the Pi Tasks extension, and `wolfpack-pi-task-delegation`.
+- 2026-07-26 hygiene: `git diff --check` passed.
+- 2026-07-26: fast-forwarded/rebased onto current `origin/main` at `ed49315` and branched as `feat/pi-integration-setup`.
+- 2026-07-26 post-rebase verification: full suite, typecheck, package dry-run, and diff hygiene all passed.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,37 @@ Wolfpack exposes repository-local agent skills in `skills/`:
 - `wolfpack-ralph` — Ralph loop response contract, notifications, and sandbox/socket caveats.
 - `wolfpack-tailnet-control` — discover, inspect, and control Wolfpack terminal sessions across Tailscale hosts.
 
+### Pi subagent integration
+
+When setup detects `pi` on `PATH`, it offers one default-no, opt-in installation.
+Accepting uses Pi's package manager to install the complete integration:
+
+```bash
+pi install npm:wolfpack-bridge
+pi install npm:@sgtbeatdown/pi-tasks
+```
+
+The pieces have separate jobs:
+
+| Owner | Resource | Responsibility |
+| --- | --- | --- |
+| Wolfpack | `wolfpack-tailnet-control` | Creates, selects, inspects, and closes visible Wolfpack sessions. |
+| Pi Tasks extension | `agent_task_*` | Sends assignments and records durable structured status/results; it does not create sessions. |
+| Pi Tasks skill | `wolfpack-pi-task-delegation` | Teaches Pi to combine Wolfpack session control with the task tools and completion protocol. |
+
+The first package exposes Wolfpack's bundled skills to Pi. The second package
+contains both the Pi Tasks extension and its matching delegation skill. Every
+participating Pi session needs Pi Tasks loaded; its default filesystem store
+also requires parent and child sessions to use the same project directory.
+Declining the setup prompt changes nothing. Non-interactive setup never installs
+Pi packages and prints the commands instead.
+
+Skills and extensions can execute commands with your user permissions. Review
+the packages before accepting. Start a fresh Pi session afterward, or run
+`/reload` in an existing session.
+
+### Manual skill installation
+
 Skills are executable agent instructions, so install only the ones you have audited. Clone or update `https://github.com/almogdepaz/wolfpack`, review the requested file (for example `skills/wolfpack-tailnet-control/SKILL.md`), then symlink that skill directory into one supported root:
 
 - Pi global: `~/.pi/agent/skills/`
@@ -220,7 +251,7 @@ wolfpack session create <project> --harness pi --plan .plans/000-task.md --json
 wolfpack agent spawn <project> --plan .plans/000-task.md --notify-parent --json
 ```
 
-Platform binaries do not install skills. This is intentional: the cloned repository remains the auditable source of truth.
+Platform binaries do not contain skills. The setup wizard only asks Pi's package manager to install them after explicit opt-in; the cloned repository remains the auditable source for manual installation.
 
 ## Contributing
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -12,6 +12,37 @@ Bundled skills:
 - `wolfpack-tailnet-control` - top-level session creation, same-harness child
   spawning, and safe local/Tailscale session inspection/control workflows.
 
+## Pi opt-in setup
+
+`wolfpack setup` checks for `pi` on `PATH`. Pi users receive one default-no,
+opt-in offer for the complete subagent integration; users without Pi receive no
+offer. Accepting runs Pi's package manager with these commands in order:
+
+```bash
+pi install npm:wolfpack-bridge
+pi install npm:@sgtbeatdown/pi-tasks
+```
+
+The packages and resources have distinct ownership:
+
+| Owner | Resource | Responsibility |
+| --- | --- | --- |
+| Wolfpack | `wolfpack-tailnet-control` | Creates and controls visible Wolfpack sessions through the canonical CLI. |
+| Pi Tasks extension | `agent_task_*` | Delivers assignments and stores structured task status/results; it does not spawn sessions. |
+| Pi Tasks skill | `wolfpack-pi-task-delegation` | Teaches Pi how to combine the session-control skill with task dispatch, completion, and parent-owned cleanup. |
+
+`npm:wolfpack-bridge` exposes the bundled Wolfpack skills to Pi.
+`npm:@sgtbeatdown/pi-tasks` contains both the extension and its matching
+delegation skill, so those two stay version-aligned. Every participating Pi
+session needs Pi Tasks loaded. Its default filesystem task store also requires
+parent and child sessions to use the same project directory; cross-repository or
+multi-host task state needs a shared store.
+
+Declining changes nothing. Non-interactive setup installs nothing and prints the
+two commands only when Pi is detected. Package extensions and skills can execute
+commands with the user's permissions, so review them before opting in. Start a
+fresh agent context afterward, or run `/reload` in an existing Pi session.
+
 ## Clone or update the auditable source
 
 Use a dedicated clone. Updating is fast-forward-only so this workflow does not
@@ -116,8 +147,8 @@ contracts.
 ## Distribution boundary
 
 The npm package includes `skills/` so users inspecting that package can read the
-same repository files. Platform binary packages only contain executables, and
-platform binaries do not install skills. This is intentional: there is no
-binary-embedded skill payload, skill installer, network download, or automatic
-overwrite of a user's skill directories. The cloned repository remains the
-auditable source of truth.
+same repository files. Platform binary packages only contain executables;
+platform binaries do not contain skills. After explicit opt-in, the setup wizard
+delegates package installation to Pi instead of embedding skill payloads,
+editing Pi settings, or overwriting skill directories. The cloned repository
+remains the auditable source of truth for manual installation.

--- a/src/cli/pi-integration.ts
+++ b/src/cli/pi-integration.ts
@@ -9,6 +9,16 @@ export const PI_INTEGRATION_PACKAGES = [
 
 export type PiIntegrationSetupMode = "hidden" | "prompt" | "guidance";
 
+export function piIntegrationDisclosureLines(): readonly string[] {
+  return [
+    "  - Wolfpack skill: creates and controls visible agent sessions.",
+    "  - Pi Tasks: adds agent_task_* tools and their delegation skill.",
+    "  Commands Pi will run:",
+    ...PI_INTEGRATION_PACKAGES.map((source) => `    pi install ${source}`),
+    "  Skills and extensions can execute commands with your user permissions. Review before accepting.",
+  ];
+}
+
 export interface PiIntegrationInstallOptions {
   readonly pathValue: string | undefined;
   readonly env?: Readonly<Record<string, string | undefined>>;

--- a/src/cli/pi-integration.ts
+++ b/src/cli/pi-integration.ts
@@ -1,0 +1,72 @@
+import { execFileSync } from "node:child_process";
+import { AGENT_KIND } from "../agent-kind.js";
+import { detectInstalledProviderCommands } from "../provider-readiness.js";
+
+export const PI_INTEGRATION_PACKAGES = [
+  "npm:wolfpack-bridge",
+  "npm:@sgtbeatdown/pi-tasks",
+] as const;
+
+export type PiIntegrationSetupMode = "hidden" | "prompt" | "guidance";
+
+export interface PiIntegrationInstallOptions {
+  readonly pathValue: string | undefined;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+}
+
+export interface InstalledPiIntegration {
+  readonly status: "installed";
+  readonly installedSources: readonly string[];
+}
+
+export interface FailedPiIntegrationInstall {
+  readonly status: "failed";
+  readonly installedSources: readonly string[];
+  readonly failedSource: string;
+  readonly retryCommand: string;
+}
+
+export type PiIntegrationInstallResult = InstalledPiIntegration | FailedPiIntegrationInstall;
+
+export function planPiIntegrationSetup(
+  pathValue: string | undefined,
+  interactive: boolean,
+): PiIntegrationSetupMode {
+  const hasPi = detectInstalledProviderCommands(pathValue).includes(AGENT_KIND.PI);
+  if (!hasPi) return "hidden";
+  return interactive ? "prompt" : "guidance";
+}
+
+export function acceptsPiIntegrationInstall(answer: string): boolean {
+  return answer.toLowerCase() === "y";
+}
+
+export function installPiIntegration(
+  options: PiIntegrationInstallOptions,
+): PiIntegrationInstallResult {
+  const installedSources: string[] = [];
+  const env = {
+    ...process.env,
+    ...options.env,
+    PATH: options.pathValue,
+  };
+
+  for (const source of PI_INTEGRATION_PACKAGES) {
+    try {
+      execFileSync("pi", ["install", source], {
+        env,
+        stdio: "inherit",
+      });
+      installedSources.push(source);
+    } catch {
+      return {
+        status: "failed",
+        installedSources,
+        failedSource: source,
+        retryCommand: `pi install ${source}`,
+      };
+    }
+  }
+
+  return { status: "installed", installedSources };
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -36,6 +36,7 @@ import {
   PI_INTEGRATION_PACKAGES,
   acceptsPiIntegrationInstall,
   installPiIntegration,
+  piIntegrationDisclosureLines,
   planPiIntegrationSetup,
 } from "./pi-integration.js";
 
@@ -270,8 +271,9 @@ export async function setup() {
   if (piIntegrationMode === "prompt") {
     print("");
     print(bold("  Optional Pi subagent integration:"));
-    print(dim("  - Wolfpack skill: creates and controls visible agent sessions."));
-    print(dim("  - Pi Tasks: adds agent_task_* tools and their delegation skill."));
+    for (const line of piIntegrationDisclosureLines()) {
+      print(dim(line));
+    }
     const installPi = ask("  Install the Pi extension and Wolfpack skills? [y/N] ");
     if (acceptsPiIntegrationInstall(installPi)) {
       const installResult = installPiIntegration({ pathValue: process.env.PATH });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -32,6 +32,12 @@ import {
 import { serviceInstall } from "./service.js";
 import { createLogger } from "../log.js";
 import { initializeProviderSettingsFile } from "../initial-provider-settings.js";
+import {
+  PI_INTEGRATION_PACKAGES,
+  acceptsPiIntegrationInstall,
+  installPiIntegration,
+  planPiIntegrationSetup,
+} from "./pi-integration.js";
 
 const log = createLogger("setup");
 
@@ -258,6 +264,35 @@ export async function setup() {
       ? `Enabled detected providers: ${detectedProviders.join(", ")}`
       : "No coding-agent providers detected; enabled shell only";
     print(dim(`  ${readinessSummary}.`));
+  }
+
+  const piIntegrationMode = planPiIntegrationSetup(process.env.PATH, interactive);
+  if (piIntegrationMode === "prompt") {
+    print("");
+    print(bold("  Optional Pi subagent integration:"));
+    print(dim("  - Wolfpack skill: creates and controls visible agent sessions."));
+    print(dim("  - Pi Tasks: adds agent_task_* tools and their delegation skill."));
+    const installPi = ask("  Install the Pi extension and Wolfpack skills? [y/N] ");
+    if (acceptsPiIntegrationInstall(installPi)) {
+      const installResult = installPiIntegration({ pathValue: process.env.PATH });
+      if (installResult.status === "installed") {
+        print(green("  Installed Pi task delegation and Wolfpack skills."));
+        print(dim("  Start a fresh Pi session, or run /reload in an existing session."));
+      } else {
+        print(red(`  Pi integration install stopped at ${installResult.failedSource}.`));
+        print(dim(`  Retry: ${installResult.retryCommand}`));
+        print(dim("  Then run 'wolfpack setup' again to finish the integration."));
+      }
+    } else {
+      print(dim("  Skipped optional Pi integration."));
+    }
+  } else if (piIntegrationMode === "guidance") {
+    print("");
+    print(dim("  Pi detected; non-interactive mode skipped the optional subagent integration."));
+    print(dim("  Install it explicitly:"));
+    for (const source of PI_INTEGRATION_PACKAGES) {
+      print(dim(`    pi install ${source}`));
+    }
   }
 
   print("");

--- a/tests/unit/agent-skills.test.ts
+++ b/tests/unit/agent-skills.test.ts
@@ -133,7 +133,7 @@ describe("agent skills", () => {
       expect(content).toContain("fresh agent context");
       expect(content).toContain("wolfpack session create <project>");
       expect(content).toContain("wolfpack agent spawn <project>");
-      expect(content.toLowerCase()).toContain("platform binaries do not install skills");
+      expect(content.toLowerCase()).toContain("platform binaries do not contain skills");
     }
 
     expect(docs).toContain("[ ! -e \"$DEST\" ]");
@@ -141,6 +141,20 @@ describe("agent skills", () => {
     expect(docs).toContain("must be refreshed manually");
     expect(docs).not.toContain("rm -rf");
     expect(docs).not.toContain("ln -sf");
+  });
+
+  test("documents the opt-in Pi extension and skill ownership", () => {
+    const readme = readRepoFile("README.md");
+    const docs = readRepoFile("docs/agent-skills.md");
+
+    for (const content of [readme, docs]) {
+      expect(content).toContain("pi install npm:wolfpack-bridge");
+      expect(content).toContain("pi install npm:@sgtbeatdown/pi-tasks");
+      expect(content).toContain("`wolfpack-tailnet-control`");
+      expect(content).toContain("`wolfpack-pi-task-delegation`");
+      expect(content).toContain("`agent_task_*`");
+      expect(content.toLowerCase()).toContain("opt-in");
+    }
   });
 
   test("standalone install fences succeed once and fail closed on rerun or missing source", () => {

--- a/tests/unit/pi-integration-setup.test.ts
+++ b/tests/unit/pi-integration-setup.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  PI_INTEGRATION_PACKAGES,
+  acceptsPiIntegrationInstall,
+  installPiIntegration,
+  planPiIntegrationSetup,
+} from "../../src/cli/pi-integration.ts";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const directory = mkdtempSync(join(tmpdir(), "wolfpack-pi-integration-"));
+  tempDirs.push(directory);
+  return directory;
+}
+
+function fakePi(): { readonly pathValue: string; readonly callLog: string } {
+  const directory = tempDir();
+  const executable = join(directory, "pi");
+  const callLog = join(directory, "calls.log");
+  writeFileSync(executable, `#!/bin/sh
+printf '%s\\n' "$*" >> "$CALL_LOG"
+if [ "\${FAIL_SOURCE:-}" = "$2" ]; then
+  exit 42
+fi
+`);
+  chmodSync(executable, 0o755);
+  return { pathValue: directory, callLog };
+}
+
+afterEach(() => {
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Pi integration setup", () => {
+  test("hides the integration for users without Pi", () => {
+    expect(planPiIntegrationSetup(tempDir(), true)).toBe("hidden");
+    expect(planPiIntegrationSetup(undefined, false)).toBe("hidden");
+  });
+
+  test("prompts interactive Pi users and only prints guidance without a TTY", () => {
+    const pi = fakePi();
+
+    expect(planPiIntegrationSetup(pi.pathValue, true)).toBe("prompt");
+    expect(planPiIntegrationSetup(pi.pathValue, false)).toBe("guidance");
+  });
+
+  test("keeps the integration default-no", () => {
+    expect(acceptsPiIntegrationInstall("y")).toBe(true);
+    expect(acceptsPiIntegrationInstall("Y")).toBe(true);
+    expect(acceptsPiIntegrationInstall("")).toBe(false);
+    expect(acceptsPiIntegrationInstall("n")).toBe(false);
+    expect(acceptsPiIntegrationInstall("yes")).toBe(false);
+  });
+
+  test("installs Wolfpack skills before the Pi task extension", () => {
+    const pi = fakePi();
+    const result = installPiIntegration({
+      pathValue: pi.pathValue,
+      env: { CALL_LOG: pi.callLog },
+    });
+
+    expect(result).toEqual({
+      status: "installed",
+      installedSources: PI_INTEGRATION_PACKAGES,
+    });
+    expect(readFileSync(pi.callLog, "utf8")).toBe(
+      "install npm:wolfpack-bridge\ninstall npm:@sgtbeatdown/pi-tasks\n",
+    );
+  });
+
+  test("stops before installing the extension when Wolfpack skill installation fails", () => {
+    const pi = fakePi();
+    const result = installPiIntegration({
+      pathValue: pi.pathValue,
+      env: {
+        CALL_LOG: pi.callLog,
+        FAIL_SOURCE: "npm:wolfpack-bridge",
+      },
+    });
+
+    expect(result).toEqual({
+      status: "failed",
+      installedSources: [],
+      failedSource: "npm:wolfpack-bridge",
+      retryCommand: "pi install npm:wolfpack-bridge",
+    });
+    expect(readFileSync(pi.callLog, "utf8")).toBe("install npm:wolfpack-bridge\n");
+  });
+
+  test("reports a retry command when the task extension installation fails", () => {
+    const pi = fakePi();
+    const result = installPiIntegration({
+      pathValue: pi.pathValue,
+      env: {
+        CALL_LOG: pi.callLog,
+        FAIL_SOURCE: "npm:@sgtbeatdown/pi-tasks",
+      },
+    });
+
+    expect(result).toEqual({
+      status: "failed",
+      installedSources: ["npm:wolfpack-bridge"],
+      failedSource: "npm:@sgtbeatdown/pi-tasks",
+      retryCommand: "pi install npm:@sgtbeatdown/pi-tasks",
+    });
+    expect(readFileSync(pi.callLog, "utf8")).toBe(
+      "install npm:wolfpack-bridge\ninstall npm:@sgtbeatdown/pi-tasks\n",
+    );
+  });
+});

--- a/tests/unit/pi-integration-setup.test.ts
+++ b/tests/unit/pi-integration-setup.test.ts
@@ -6,6 +6,7 @@ import {
   PI_INTEGRATION_PACKAGES,
   acceptsPiIntegrationInstall,
   installPiIntegration,
+  piIntegrationDisclosureLines,
   planPiIntegrationSetup,
 } from "../../src/cli/pi-integration.ts";
 
@@ -48,6 +49,15 @@ describe("Pi integration setup", () => {
 
     expect(planPiIntegrationSetup(pi.pathValue, true)).toBe("prompt");
     expect(planPiIntegrationSetup(pi.pathValue, false)).toBe("guidance");
+  });
+
+  test("discloses exact package commands and user-permission risk before prompting", () => {
+    const disclosure = piIntegrationDisclosureLines().join("\n");
+
+    expect(disclosure).toContain("pi install npm:wolfpack-bridge");
+    expect(disclosure).toContain("pi install npm:@sgtbeatdown/pi-tasks");
+    expect(disclosure).toContain("user permissions");
+    expect(disclosure).toContain("Review");
   });
 
   test("keeps the integration default-no", () => {


### PR DESCRIPTION
## summary

- offer Pi users a default-no setup prompt for Wolfpack session skills and structured task delegation
- install `wolfpack-bridge` and `@sgtbeatdown/pi-tasks` through canonical argv-based `pi install` calls
- keep noninteractive and non-Pi setup paths mutation-free
- document package ownership, trust boundaries, reload guidance, and manual alternatives

## verification

- `bun test` — 1922 pass, 0 fail
- `bun run typecheck`
- `npm pack --dry-run --json`
- isolated temporary-HOME smoke install of both Pi packages
- EDC differential security review — APPROVE, no security findings
- `git diff --check`