### PR TITLE
Fix tagged Ghostty source builds

### DIFF
--- a/.plans/007-tagged-ghostty-release-recovery.md
+++ b/.plans/007-tagged-ghostty-release-recovery.md
@@ -1,0 +1,33 @@
+# tagged ghostty build release recovery
+
+## goal
+
+ship v1.6.10 from main, including pr #246, without mutating the failed v1.6.9 tag. prevent extracted ghostty source builds from observing wolfpack's enclosing git tag.
+
+## constraints
+
+- preserve the existing remote v1.6.9 tag and failed workflow history.
+- fix the source-build boundary instead of hardcoding a ghostty release version.
+- merge the regression fix to main before creating the v1.6.10 release commit and tag.
+- do not publish until focused, full, and main-ci verification pass.
+
+## non-goals
+
+- changing the pinned ghostty revision, patches, zig version, or broker behavior.
+- changing release assets or npm package layout.
+
+## 1. reproduce tagged-build metadata leakage
+
+add a deterministic regression test using a real temporary git repository and exact tag. prove the current build environment exposes the enclosing wolfpack repository to extracted ghostty source.
+
+## 2. isolate the ghostty source build
+
+set the git discovery ceiling for the zig source-build subprocess so the authenticated extracted source cannot discover enclosing wolfpack repository metadata.
+
+## 3. verify and merge the fix
+
+run focused tests, the full bun suite, typecheck, and relevant build reproduction. push a fix pr, pass ci, and merge it to main.
+
+## 4. release v1.6.10
+
+create a clean release branch from updated main, bump all package versions to 1.6.10, verify, commit, tag, and monitor github/npm publication.

--- a/.plans/007-tagged-ghostty-release-recovery.status.md
+++ b/.plans/007-tagged-ghostty-release-recovery.status.md
@@ -1,0 +1,33 @@
+# tagged ghostty build release recovery status
+
+- plan: `.plans/007-tagged-ghostty-release-recovery.md`
+- plan sha256: `c0c40201b79f8b9c8cddc9119762dfd880f852b225387f813d35bf7d1e6bbabf`
+- overall: `in_progress`
+- current phase: `3`
+
+## task state
+
+- 1 reproduce tagged-build metadata leakage: `accepted`
+- 2 isolate the ghostty source build: `accepted`
+- 3 verify and merge the fix: `in_progress`
+- 4 release v1.6.10: `not_started`
+
+## decisions
+
+- preserve failed remote tag v1.6.9; advance package release to v1.6.10.
+- source fix will prevent enclosing git discovery rather than inject a magic ghostty version.
+
+## evidence
+
+- failed release run: https://github.com/almogdepaz/wolfpack/actions/runs/30553762081
+- both broker jobs panicked in ghostty `Config.zig` because wolfpack tag `v1.6.9` was detected as ghostty's own tag.
+- red: focused test failed because `runGhosttySourceBuild` did not exist.
+- green: `bun test tests/unit/build-ghostty-vt.test.ts` — 16 pass, 0 fail; real git command cannot discover the enclosing exact tag.
+- tagged reproduction: exact temporary outer tag plus `bun run scripts/build-ghostty-vt.ts --target aarch64-apple-darwin` completed and staged the authenticated archive.
+- `bun run typecheck` passed.
+- `bun test` passed: 1464 pass, 0 fail.
+- `cargo test --locked --manifest-path broker/Cargo.toml --all` passed: 153 tests across broker targets, 0 fail.
+
+## next action
+
+commit, push, open the fix pr, and require main ci before release.

--- a/scripts/build-ghostty-vt.ts
+++ b/scripts/build-ghostty-vt.ts
@@ -53,9 +53,18 @@ export type GhosttyBundleManifest = {
   symbols: { noHostMemsetOverride: true };
 };
 
-function run(cmd: string, args: string[], cwd = ROOT): string {
+function run(cmd: string, args: readonly string[], cwd = ROOT, env = process.env): string {
   console.log(`$ ${cmd} ${args.join(" ")}`);
-  return execFileSync(cmd, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
+  return execFileSync(cmd, args, { cwd, env, encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
+}
+
+export function runGhosttySourceBuild(
+  cmd: string,
+  args: readonly string[],
+  cwd: string,
+  repositoryRoot = ROOT,
+): string {
+  return run(cmd, args, cwd, { ...process.env, GIT_CEILING_DIRECTORIES: repositoryRoot });
 }
 
 function sha256Bytes(bytes: Buffer | string): string {
@@ -232,7 +241,7 @@ function buildTarget(cargoTriple: string, sourceDir: string, lock: GhosttyLock) 
   rmSync(prefix, { recursive: true, force: true });
   mkdirSync(prefix, { recursive: true });
 
-  run("zig", ghosttyBuildArgs(cargoTriple, prefix, lock), sourceDir);
+  runGhosttySourceBuild("zig", ghosttyBuildArgs(cargoTriple, prefix, lock), sourceDir);
 
   const targetOut = join(OUT_ROOT, cargoTriple);
   rmSync(targetOut, { recursive: true, force: true });

--- a/tests/unit/build-ghostty-vt.test.ts
+++ b/tests/unit/build-ghostty-vt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -11,6 +12,7 @@ import {
   ghosttyBuildArgs,
   ghosttyPatchArgs,
   readGhosttyLock,
+  runGhosttySourceBuild,
   verifyBundleManifest,
 } from "../../scripts/build-ghostty-vt.ts";
 
@@ -47,6 +49,35 @@ describe("libghostty-vt prebuild arguments", () => {
 
   test("Linux archive builds use the matching Zig target", () => {
     expect(ghosttyBuildArgs("x86_64-unknown-linux-gnu", "/tmp/prefix")).toContain("-Dtarget=x86_64-linux-gnu");
+  });
+
+  test("source builds cannot discover an enclosing Wolfpack release tag", () => {
+    const repositoryRoot = mkdtempSync(join(tmpdir(), "ghostty-vt-tagged-repo-"));
+    try {
+      execFileSync("git", ["init", "-q"], { cwd: repositoryRoot });
+      execFileSync("git", ["config", "user.email", "wolfpack-test@example.invalid"], { cwd: repositoryRoot });
+      execFileSync("git", ["config", "user.name", "Wolfpack Test"], { cwd: repositoryRoot });
+      writeFileSync(join(repositoryRoot, "tracked"), "release\n");
+      execFileSync("git", ["add", "tracked"], { cwd: repositoryRoot });
+      execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-q", "-m", "release"], { cwd: repositoryRoot });
+      execFileSync("git", ["tag", "v1.6.10"], { cwd: repositoryRoot });
+
+      const sourceDir = join(repositoryRoot, ".cache", "ghostty-vt", "source");
+      mkdirSync(sourceDir, { recursive: true });
+      expect(execFileSync("git", ["describe", "--tags", "--exact-match"], {
+        cwd: sourceDir,
+        encoding: "utf8",
+      }).trim()).toBe("v1.6.10");
+
+      expect(() => runGhosttySourceBuild(
+        "git",
+        ["describe", "--tags", "--exact-match"],
+        sourceDir,
+        repositoryRoot,
+      )).toThrow();
+    } finally {
+      rmSync(repositoryRoot, { recursive: true, force: true });
+    }
   });
 
   test("source preparation applies tracked Ghostty patches with zero fuzz", () => {


### PR DESCRIPTION
## summary
- isolate extracted Ghostty source builds from enclosing Wolfpack git metadata
- add a real-git regression test for exact release tags
- record immutable v1.6.10 release recovery plan

## verification
- bun test tests/unit/build-ghostty-vt.test.ts
- exact-tag pinned Ghostty aarch64 build
- bun run typecheck
- bun test
- cargo test --locked --manifest-path broker/Cargo.toml --all

## context
Fixes the pre-publish failure in release run 30553762081. The failed v1.6.9 tag remains immutable; successful publication will advance to v1.6.10.