### PR TITLE
docs: add a demo workflow call to action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ There is no Wolfpack-hosted relay or account; remote access is normally handled 
   <a href="docs/assets/wolfpack-usage-demo.mp4">Watch/download the MP4 demo</a>
 </p>
 
+**Try the workflow:** install Wolfpack on two machines, connect them to the same Tailscale tailnet, then open the phone QR from either host to control persistent agent sessions remotely. Start with the [Quickstart](#quickstart) and [First five minutes](#first-five-minutes).
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
The README already includes the usage demo, but the next action after watching it was implicit.

This adds a concise call to action that tells readers how to reproduce the demonstrated multi-machine workflow and links directly to Quickstart and First five minutes. No product behavior changes.