### PR TITLE
fix: stop installing wolfpack app through Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It is an AI agent terminal orchestrator for developers who need persistent brows
 - **PWA UX** — install on your home screen, reconnect on drops, receive notifications when sessions need attention.
 - **Agent-agnostic** — use built-in commands or add your own shell command in Settings → Agents.
 - **Provider readiness** — First-run setup enables detected supported CLIs; Settings → Agents shows path/version and login guidance and lets you add providers installed later.
-- **Pi integration** — manually install the Wolfpack control skill, then optionally add Pi Tasks for durable subagent task delegation; see [Pi integration and agent skills](#pi-integration-and-agent-skills).
+- **Agent skills** — `wolfpack-tailnet-control` works with all agent harnesses that support Agent Skills; optionally add Pi Tasks for durable Pi subagent delegation. See [Agent skills](#agent-skills).
 
 ## Agent recipes
 
@@ -198,13 +198,15 @@ Optional: `WOLFPACK_JWT_AUDIENCE`, `WOLFPACK_JWT_ISSUER`, `WOLFPACK_JWT_CLOCK_TO
 
 Per-server agent settings live in `~/.wolfpack/bridge-settings.json`.
 
-## Pi integration and agent skills
+## Agent skills
 
-Wolfpack exposes one repository-local agent skill in `skills/`:
+### Wolfpack control skill
 
-- `wolfpack-tailnet-control` — discover, inspect, and control Wolfpack terminal sessions across Tailscale hosts.
+`wolfpack-tailnet-control` is for all agent harnesses that support Agent Skills,
+not just Pi. It discovers, inspects, and controls visible Wolfpack terminal
+sessions across Tailscale hosts.
 
-### Install the Pi integration
+### Optional Pi task delegation
 
 Install Wolfpack's control skill manually from this repository; setup does not add
 the full Wolfpack app to Pi just to deliver that skill. Then, when setup detects
@@ -234,7 +236,7 @@ Skills and extensions can execute commands with your user permissions. Review
 the packages before accepting. Start a fresh Pi session afterward, or run
 `/reload` in an existing session.
 
-### Manual skill installation
+### Install the Wolfpack control skill
 
 Skills are executable agent instructions, so install only the ones you have audited. Clone or update `https://github.com/almogdepaz/wolfpack`, review the requested file (for example `skills/wolfpack-tailnet-control/SKILL.md`), then symlink that skill directory into one supported root:
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It is an AI agent terminal orchestrator for developers who need persistent brows
 - **PWA UX** — install on your home screen, reconnect on drops, receive notifications when sessions need attention.
 - **Agent-agnostic** — use built-in commands or add your own shell command in Settings → Agents.
 - **Provider readiness** — First-run setup enables detected supported CLIs; Settings → Agents shows path/version and login guidance and lets you add providers installed later.
-- **Pi integration** — optionally install Pi packages for Wolfpack session control and durable subagent task delegation; see [Pi integration and agent skills](#pi-integration-and-agent-skills).
+- **Pi integration** — manually install the Wolfpack control skill, then optionally add Pi Tasks for durable subagent task delegation; see [Pi integration and agent skills](#pi-integration-and-agent-skills).
 
 ## Agent recipes
 
@@ -206,15 +206,13 @@ Wolfpack exposes one repository-local agent skill in `skills/`:
 
 ### Install the Pi integration
 
-When setup detects `pi` on `PATH`, it offers this default-no, opt-in installation. You can also install the packages directly from their npm pages:
+Install Wolfpack's control skill manually from this repository; setup does not add
+the full Wolfpack app to Pi just to deliver that skill. Then, when setup detects
+`pi` on `PATH`, it offers this default-no, opt-in installation:
 
-- [`wolfpack-bridge`](https://www.npmjs.com/package/wolfpack-bridge) — Wolfpack's Pi-installable skills, including `wolfpack-tailnet-control`.
 - [`@sgtbeatdown/pi-tasks`](https://www.npmjs.com/package/@sgtbeatdown/pi-tasks) — the Pi Tasks extension and `wolfpack-pi-task-delegation` skill.
 
-Install both with Pi's package manager:
-
 ```bash
-pi install npm:wolfpack-bridge
 pi install npm:@sgtbeatdown/pi-tasks
 ```
 
@@ -226,12 +224,11 @@ The pieces have separate jobs:
 | Pi Tasks extension | `agent_task_*` | Sends assignments and records durable structured status/results; it does not create sessions. |
 | Pi Tasks skill | `wolfpack-pi-task-delegation` | Teaches Pi to combine Wolfpack session control with the task tools and completion protocol. |
 
-The first package exposes Wolfpack's bundled skills to Pi. The second package
-contains both the Pi Tasks extension and its matching delegation skill. Every
+Pi Tasks contains both the extension and its matching delegation skill. Every
 participating Pi session needs Pi Tasks loaded; its default filesystem store
 also requires parent and child sessions to use the same project directory.
 Declining the setup prompt changes nothing. Non-interactive setup never installs
-Pi packages and prints the commands instead.
+Pi packages and prints the Pi Tasks command instead.
 
 Skills and extensions can execute commands with your user permissions. Review
 the packages before accepting. Start a fresh Pi session afterward, or run
@@ -254,7 +251,7 @@ wolfpack session create <project> --harness pi --plan .plans/000-task.md --json
 wolfpack agent spawn <project> --plan .plans/000-task.md --notify-parent --json
 ```
 
-Platform binaries do not contain skills. The setup wizard only asks Pi's package manager to install them after explicit opt-in; the cloned repository remains the auditable source for manual installation.
+Platform binaries do not contain skills. The setup wizard only asks Pi's package manager to install Pi Tasks after explicit opt-in; the cloned repository remains the auditable source for manual skill installation.
 
 ## Contributing
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -12,13 +12,16 @@ Bundled skill:
 ## Pi opt-in setup
 
 `wolfpack setup` checks for `pi` on `PATH`. Pi users receive one default-no,
-opt-in offer for the complete subagent integration; users without Pi receive no
-offer. Accepting runs Pi's package manager with these commands in order:
+opt-in offer for Pi Tasks; users without Pi receive no offer. Accepting runs
+Pi's package manager with this command:
 
 ```bash
-pi install npm:wolfpack-bridge
 pi install npm:@sgtbeatdown/pi-tasks
 ```
+
+Install `wolfpack-tailnet-control` manually from the reviewed repository source
+below. Wolfpack does not install the full `wolfpack-bridge` app inside Pi just
+to obtain that skill.
 
 The packages and resources have distinct ownership:
 
@@ -28,7 +31,6 @@ The packages and resources have distinct ownership:
 | Pi Tasks extension | `agent_task_*` | Delivers assignments and stores structured task status/results; it does not spawn sessions. |
 | Pi Tasks skill | `wolfpack-pi-task-delegation` | Teaches Pi how to combine the session-control skill with task dispatch, completion, and parent-owned cleanup. |
 
-`npm:wolfpack-bridge` exposes the bundled Wolfpack skills to Pi.
 `npm:@sgtbeatdown/pi-tasks` contains both the extension and its matching
 delegation skill, so those two stay version-aligned. Every participating Pi
 session needs Pi Tasks loaded. Its default filesystem task store also requires
@@ -36,9 +38,9 @@ parent and child sessions to use the same project directory; cross-repository or
 multi-host task state needs a shared store.
 
 Declining changes nothing. Non-interactive setup installs nothing and prints the
-two commands only when Pi is detected. Package extensions and skills can execute
-commands with the user's permissions, so review them before opting in. Start a
-fresh agent context afterward, or run `/reload` in an existing Pi session.
+Pi Tasks command only when Pi is detected. Package extensions and skills can
+execute commands with the user's permissions, so review them before opting in.
+Start a fresh agent context afterward, or run `/reload` in an existing Pi session.
 
 ## Clone or update the auditable source
 
@@ -143,9 +145,9 @@ contracts.
 
 ## Distribution boundary
 
-The npm package includes `skills/` so users inspecting that package can read the
-same repository files. Platform binary packages only contain executables;
-platform binaries do not contain skills. After explicit opt-in, the setup wizard
-delegates package installation to Pi instead of embedding skill payloads,
-editing Pi settings, or overwriting skill directories. The cloned repository
-remains the auditable source of truth for manual installation.
+The npm package includes `skills/` for inspection, but it is the Wolfpack
+application package and Wolfpack does not install it inside Pi. Platform binary
+packages only contain executables; platform binaries do not contain skills. After
+explicit opt-in, the setup wizard installs Pi Tasks without embedding skill
+payloads, editing Pi settings, or overwriting skill directories. The cloned
+repository remains the auditable source of truth for manual installation.

--- a/src/cli/pi-integration.ts
+++ b/src/cli/pi-integration.ts
@@ -2,18 +2,15 @@ import { execFileSync } from "node:child_process";
 import { AGENT_KIND } from "../agent-kind.js";
 import { detectInstalledProviderCommands } from "../provider-readiness.js";
 
-export const PI_INTEGRATION_PACKAGES = [
-  "npm:wolfpack-bridge",
-  "npm:@sgtbeatdown/pi-tasks",
-] as const;
+export const PI_INTEGRATION_PACKAGES = ["npm:@sgtbeatdown/pi-tasks"] as const;
 
 export type PiIntegrationSetupMode = "hidden" | "prompt" | "guidance";
 
 export function piIntegrationDisclosureLines(): readonly string[] {
   return [
-    "  - Wolfpack skill: creates and controls visible agent sessions.",
+    "  - Wolfpack skill: Install wolfpack-tailnet-control manually from the Wolfpack repository.",
     "  - Pi Tasks: adds agent_task_* tools and their delegation skill.",
-    "  Commands Pi will run:",
+    "  Command Pi will run:",
     ...PI_INTEGRATION_PACKAGES.map((source) => `    pi install ${source}`),
     "  Skills and extensions can execute commands with your user permissions. Review before accepting.",
   ];

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -232,15 +232,16 @@ export async function setup() {
   const piIntegrationMode = planPiIntegrationSetup(process.env.PATH, interactive);
   if (piIntegrationMode === "prompt") {
     print("");
-    print(bold("  Optional Pi subagent integration:"));
+    print(bold("  Optional Pi Tasks integration:"));
     for (const line of piIntegrationDisclosureLines()) {
       print(dim(line));
     }
-    const installPi = ask("  Install the Pi extension and Wolfpack skills? [y/N] ");
+    const installPi = ask("  Install Pi Tasks delegation tools? [y/N] ");
     if (acceptsPiIntegrationInstall(installPi)) {
       const installResult = installPiIntegration({ pathValue: process.env.PATH });
       if (installResult.status === "installed") {
-        print(green("  Installed Pi task delegation and Wolfpack skills."));
+        print(green("  Installed Pi Tasks delegation tools."));
+        print(dim("  Install wolfpack-tailnet-control manually from the Wolfpack repository."));
         print(dim("  Start a fresh Pi session, or run /reload in an existing session."));
       } else {
         print(red(`  Pi integration install stopped at ${installResult.failedSource}.`));
@@ -252,11 +253,12 @@ export async function setup() {
     }
   } else if (piIntegrationMode === "guidance") {
     print("");
-    print(dim("  Pi detected; non-interactive mode skipped the optional subagent integration."));
-    print(dim("  Install it explicitly:"));
+    print(dim("  Pi detected; non-interactive mode skipped the optional Pi Tasks integration."));
+    print(dim("  Install Pi Tasks explicitly:"));
     for (const source of PI_INTEGRATION_PACKAGES) {
       print(dim(`    pi install ${source}`));
     }
+    print(dim("  Install wolfpack-tailnet-control manually from the Wolfpack repository."));
   }
 
   print("");

--- a/tests/unit/agent-skills.test.ts
+++ b/tests/unit/agent-skills.test.ts
@@ -147,11 +147,12 @@ describe("agent skills", () => {
     const docs = readRepoFile("docs/agent-skills.md");
 
     for (const content of [readme, docs]) {
-      expect(content).toContain("pi install npm:wolfpack-bridge");
+      expect(content).not.toContain("pi install npm:wolfpack-bridge");
       expect(content).toContain("pi install npm:@sgtbeatdown/pi-tasks");
       expect(content).toContain("`wolfpack-tailnet-control`");
       expect(content).toContain("`wolfpack-pi-task-delegation`");
       expect(content).toContain("`agent_task_*`");
+      expect(content).toContain("manually");
       expect(content.toLowerCase()).toContain("opt-in");
     }
   });

--- a/tests/unit/agent-skills.test.ts
+++ b/tests/unit/agent-skills.test.ts
@@ -115,6 +115,7 @@ describe("agent skills", () => {
     expect(pkg.files).toContain("skills");
     expect(pkg.files).toContain("docs/agent-skills.md");
     expect(readme).toContain("docs/agent-skills.md");
+    expect(readme).toContain("all agent harnesses");
     expect(docs).toContain("The npm package includes `skills/`");
     expect(docs).toContain("prefer symlinking each desired Wolfpack skill");
   });

--- a/tests/unit/pi-integration-setup.test.ts
+++ b/tests/unit/pi-integration-setup.test.ts
@@ -51,11 +51,12 @@ describe("Pi integration setup", () => {
     expect(planPiIntegrationSetup(pi.pathValue, false)).toBe("guidance");
   });
 
-  test("discloses exact package commands and user-permission risk before prompting", () => {
+  test("installs only Pi Tasks and directs Wolfpack skill installation to the repository", () => {
     const disclosure = piIntegrationDisclosureLines().join("\n");
 
-    expect(disclosure).toContain("pi install npm:wolfpack-bridge");
     expect(disclosure).toContain("pi install npm:@sgtbeatdown/pi-tasks");
+    expect(disclosure).not.toContain("npm:wolfpack-bridge");
+    expect(disclosure).toContain("Install wolfpack-tailnet-control manually");
     expect(disclosure).toContain("user permissions");
     expect(disclosure).toContain("Review");
   });
@@ -68,7 +69,7 @@ describe("Pi integration setup", () => {
     expect(acceptsPiIntegrationInstall("yes")).toBe(false);
   });
 
-  test("installs Wolfpack skills before the Pi task extension", () => {
+  test("installs only the Pi Tasks extension", () => {
     const pi = fakePi();
     const result = installPiIntegration({
       pathValue: pi.pathValue,
@@ -79,31 +80,10 @@ describe("Pi integration setup", () => {
       status: "installed",
       installedSources: PI_INTEGRATION_PACKAGES,
     });
-    expect(readFileSync(pi.callLog, "utf8")).toBe(
-      "install npm:wolfpack-bridge\ninstall npm:@sgtbeatdown/pi-tasks\n",
-    );
+    expect(readFileSync(pi.callLog, "utf8")).toBe("install npm:@sgtbeatdown/pi-tasks\n");
   });
 
-  test("stops before installing the extension when Wolfpack skill installation fails", () => {
-    const pi = fakePi();
-    const result = installPiIntegration({
-      pathValue: pi.pathValue,
-      env: {
-        CALL_LOG: pi.callLog,
-        FAIL_SOURCE: "npm:wolfpack-bridge",
-      },
-    });
-
-    expect(result).toEqual({
-      status: "failed",
-      installedSources: [],
-      failedSource: "npm:wolfpack-bridge",
-      retryCommand: "pi install npm:wolfpack-bridge",
-    });
-    expect(readFileSync(pi.callLog, "utf8")).toBe("install npm:wolfpack-bridge\n");
-  });
-
-  test("reports a retry command when the task extension installation fails", () => {
+  test("reports a retry command when Pi Tasks installation fails", () => {
     const pi = fakePi();
     const result = installPiIntegration({
       pathValue: pi.pathValue,
@@ -115,12 +95,10 @@ describe("Pi integration setup", () => {
 
     expect(result).toEqual({
       status: "failed",
-      installedSources: ["npm:wolfpack-bridge"],
+      installedSources: [],
       failedSource: "npm:@sgtbeatdown/pi-tasks",
       retryCommand: "pi install npm:@sgtbeatdown/pi-tasks",
     });
-    expect(readFileSync(pi.callLog, "utf8")).toBe(
-      "install npm:wolfpack-bridge\ninstall npm:@sgtbeatdown/pi-tasks\n",
-    );
+    expect(readFileSync(pi.callLog, "utf8")).toBe("install npm:@sgtbeatdown/pi-tasks\n");
   });
 });


### PR DESCRIPTION
## summary
- remove the full Wolfpack app from Pi package installation
- retain opt-in Pi Tasks installation and direct users to the audited manual control-skill workflow
- cover the package boundary in setup and documentation tests

## verification
- bun test
- bun run typecheck