### PR TITLE
fix: derive activity from rendered terminal output

### DIFF
--- a/src/server/agent-status.ts
+++ b/src/server/agent-status.ts
@@ -342,10 +342,10 @@ function fallbackRuntimeSource(input: AgentRuntimeStateInput): AgentStatusSource
     authority: AGENT_STATUS_AUTHORITY.FALLBACK,
     freshness: AGENT_STATUS_FRESHNESS.FRESH,
     source: AGENT_STATUS_SOURCE.SCREEN_FALLBACK,
-    label: input.fallback.rawOutputChanged ? "raw output activity" : "bounded activity idle",
+    label: input.fallback.rawOutputChanged ? "rendered output activity" : "bounded activity idle",
     stale: false,
     observedAt: input.fallback.observedAt,
-    message: "derived only from broker-owned pty byte activity",
+    message: "derived only from broker-rendered terminal changes",
   });
 }
 

--- a/src/server/backend.ts
+++ b/src/server/backend.ts
@@ -65,6 +65,11 @@ export interface SessionListFact {
   readonly identity?: PublicSessionIdentity;
 }
 
+export interface CapturePaneOptions {
+  /** Maximum broker scrollback rows to include; zero captures only the visible screen. */
+  readonly scrollbackLines?: number;
+}
+
 export interface SessionBackend {
   /** Live-only session names for terminal attach/control consumers. */
   list(): Promise<string[]>;
@@ -81,7 +86,7 @@ export interface SessionBackend {
   ): Promise<PublicSessionIdentity>;
   killSession(name: string): Promise<void>;
   hasSession(name: string): Promise<boolean>;
-  capturePane(name: string): Promise<string>;
+  capturePane(name: string, options?: CapturePaneOptions): Promise<string>;
   resize(name: string, cols: number, rows: number): Promise<void>;
   send(name: string, text: string, noEnter?: boolean): Promise<void>;
   sendKey(name: string, key: string): Promise<void>;
@@ -457,8 +462,8 @@ export class BackendRouter implements SessionBackend {
     return this.requireBroker().hasSession(name);
   }
 
-  async capturePane(name: string): Promise<string> {
-    return this.requireBroker().capturePane(name);
+  async capturePane(name: string, options?: CapturePaneOptions): Promise<string> {
+    return this.requireBroker().capturePane(name, options);
   }
 
   async resize(name: string, cols: number, rows: number): Promise<void> {

--- a/src/server/broker-backend.ts
+++ b/src/server/broker-backend.ts
@@ -24,6 +24,7 @@
  */
 import { DuplicateSessionError, UnsupportedTerminalKeyError } from "./backend.js";
 import type {
+  CapturePaneOptions,
   PtyBackendMethods,
   SessionBackend,
   SessionLaunchOptions,
@@ -445,10 +446,10 @@ export class BrokerBackend implements SessionBackend, PtyBackendMethods, Session
     return this.idToInfo.get(id)?.alive ?? false;
   }
 
-  async capturePane(name: string): Promise<string> {
+  async capturePane(name: string, options?: CapturePaneOptions): Promise<string> {
     const id = await this.resolveId(name);
     if (!id) return "";
-    const snap = await this.fetchSnapshot(id, name, "capturePane");
+    const snap = await this.fetchSnapshot(id, name, "capturePane", undefined, options?.scrollbackLines);
     if (!snap) return "";
     return renderSnapshot(snap);
   }

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -452,19 +452,16 @@ function settingsPath(): string {
   return process.env.WOLFPACK_SETTINGS_PATH || join(homedir(), ".wolfpack", "bridge-settings.json");
 }
 
-/** Number of trailing rendered lines used to detect generic visible output. */
-const ACTIVITY_FINGERPRINT_LINE_COUNT = 3;
-
 /** Previous rendered terminal fingerprint per durable session identity. */
 const prevRenderedActivityFingerprints = new Map<string, string>();
 
 function renderedActivityFingerprint(pane: string): string | undefined {
-  const nonEmptyLines = pane
+  const normalized = pane
     .split("\n")
     .map((line) => line.trimEnd())
-    .filter((line) => line.trim().length > 0);
-  const tail = nonEmptyLines.slice(-ACTIVITY_FINGERPRINT_LINE_COUNT);
-  return tail.length > 0 ? tail.join("\n") : undefined;
+    .join("\n")
+    .trimEnd();
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 interface KnownSessionSummary {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -28,7 +28,7 @@ import {
 
 import { assets } from "../public-assets.js";
 import type { TriageStatus } from "../triage.js";
-import { brokerOutputAdvanced, brokerOutputSequence } from "../broker-output-sequence.js";
+import { brokerOutputSequence } from "../broker-output-sequence.js";
 import {
   collectAgentStatusSources,
   getAgentRuntimeStateStore,
@@ -452,8 +452,20 @@ function settingsPath(): string {
   return process.env.WOLFPACK_SETTINGS_PATH || join(homedir(), ".wolfpack", "bridge-settings.json");
 }
 
-/** Previous broker output watermark per durable session identity. */
-const prevOutputSequences = new Map<string, string>();
+/** Number of trailing rendered lines used to detect generic visible output. */
+const ACTIVITY_FINGERPRINT_LINE_COUNT = 3;
+
+/** Previous rendered terminal fingerprint per durable session identity. */
+const prevRenderedActivityFingerprints = new Map<string, string>();
+
+function renderedActivityFingerprint(pane: string): string | undefined {
+  const nonEmptyLines = pane
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0);
+  const tail = nonEmptyLines.slice(-ACTIVITY_FINGERPRINT_LINE_COUNT);
+  return tail.length > 0 ? tail.join("\n") : undefined;
+}
 
 interface KnownSessionSummary {
   readonly name: string;
@@ -465,7 +477,7 @@ const knownSessionSummaries = new Map<string, KnownSessionSummary>();
 
 export function __resetSessionObservationForTests(): void {
   if (!process.env.WOLFPACK_TEST) throw new Error("__resetSessionObservationForTests is test-only");
-  prevOutputSequences.clear();
+  prevRenderedActivityFingerprints.clear();
   knownSessionSummaries.clear();
 }
 
@@ -643,57 +655,64 @@ export const routes: Record<
 
     const activeNames = new Set<string>();
     const activeSessionKeys = new Set<string>();
-    const results = sessionFacts.map((fact) => {
-      const name = fact.name;
-      activeNames.add(name);
-      const brokerState = fact.alive ? "alive" : "dead";
-      const identity = fact.identity;
-      const sessionKey = identity?.wolfpackSessionId ?? name;
-      activeSessionKeys.add(sessionKey);
+    const results = await Promise.all(
+      sessionFacts.map(async (fact) => {
+        const name = fact.name;
+        activeNames.add(name);
+        const brokerState = fact.alive ? "alive" : "dead";
+        const identity = fact.identity;
+        const sessionKey = identity?.wolfpackSessionId ?? name;
+        activeSessionKeys.add(sessionKey);
 
-      const outputSequence = brokerOutputSequence(fact.outputSequence);
-      const previousOutputSequence = prevOutputSequences.get(sessionKey);
-      const rawOutputChanged = brokerState === "alive"
-        && brokerOutputAdvanced(previousOutputSequence, outputSequence);
-      const outputSequenceIsCurrent = previousOutputSequence === undefined
-        || previousOutputSequence === outputSequence
-        || brokerOutputAdvanced(previousOutputSequence, outputSequence);
-      if (brokerState === "alive" && outputSequence !== undefined && outputSequenceIsCurrent) {
-        prevOutputSequences.set(sessionKey, outputSequence);
-      }
-      const triage: TriageStatus = rawOutputChanged ? "running" : "idle";
-      const lastLine = "";
-      const observedAt = new Date().toISOString();
-      const runtimeState = getAgentRuntimeStateStore().reduce({
-        sessionKey,
-        broker: { state: brokerState, observedAt },
-        sources: identity?.projectPath ? collectAgentStatusSources(identity.projectPath, {
-          state: rawOutputChanged ? AGENT_STATUS_STATE.OUTPUT : AGENT_STATUS_STATE.IDLE,
-          stale: false,
-          observedAt,
-        }) : [],
-        fallback: { rawOutputChanged, observedAt, preview: lastLine },
-        currentRun: {
-          runId: identity?.wolfpackSessionId,
-          runOrder: identity?.createdAt ? Date.parse(identity.createdAt) : undefined,
-        },
-      });
+        let activityFingerprint: string | undefined;
+        if (brokerState === "alive") {
+          try {
+            activityFingerprint = renderedActivityFingerprint(await backend.capturePane(name, { scrollbackLines: 0 }));
+          } catch {
+            activityFingerprint = undefined;
+          }
+        }
+        const previousFingerprint = prevRenderedActivityFingerprints.get(sessionKey);
+        const rawOutputChanged = activityFingerprint !== undefined
+          && previousFingerprint !== undefined
+          && activityFingerprint !== previousFingerprint;
+        if (activityFingerprint !== undefined) prevRenderedActivityFingerprints.set(sessionKey, activityFingerprint);
 
-      const summary = {
-        name,
-        lastLine,
-        triage,
-        runtimeState,
-        ...(outputSequence !== undefined && { outputSequence }),
-        ...(identity && { identity }),
-      };
-      knownSessionSummaries.set(name, { name, lastLine, ...(identity && { identity }) });
-      return summary;
-    });
+        const outputSequence = brokerOutputSequence(fact.outputSequence);
+        const triage: TriageStatus = rawOutputChanged ? "running" : "idle";
+        const lastLine = "";
+        const observedAt = new Date().toISOString();
+        const runtimeState = getAgentRuntimeStateStore().reduce({
+          sessionKey,
+          broker: { state: brokerState, observedAt },
+          sources: identity?.projectPath ? collectAgentStatusSources(identity.projectPath, {
+            state: rawOutputChanged ? AGENT_STATUS_STATE.OUTPUT : AGENT_STATUS_STATE.IDLE,
+            stale: false,
+            observedAt,
+          }) : [],
+          fallback: { rawOutputChanged, observedAt, preview: lastLine },
+          currentRun: {
+            runId: identity?.wolfpackSessionId,
+            runOrder: identity?.createdAt ? Date.parse(identity.createdAt) : undefined,
+          },
+        });
+
+        const summary = {
+          name,
+          lastLine,
+          triage,
+          runtimeState,
+          ...(outputSequence !== undefined && { outputSequence }),
+          ...(identity && { identity }),
+        };
+        knownSessionSummaries.set(name, { name, lastLine, ...(identity && { identity }) });
+        return summary;
+      }),
+    );
     results.sort((a, b) => a.name.localeCompare(b.name));
     // Prune observations for sessions omitted from authoritative broker truth.
-    for (const key of prevOutputSequences.keys()) {
-      if (!activeSessionKeys.has(key)) prevOutputSequences.delete(key);
+    for (const key of prevRenderedActivityFingerprints.keys()) {
+      if (!activeSessionKeys.has(key)) prevRenderedActivityFingerprints.delete(key);
     }
     for (const key of knownSessionSummaries.keys()) {
       if (!activeNames.has(key)) knownSessionSummaries.delete(key);
@@ -1072,8 +1091,8 @@ export const routes: Record<
     if (!resolved) return;
     // Clean up any associated desktop PTY session (wp_*) before killing
     teardownPty(resolved.name);
-    prevOutputSequences.delete(resolved.identity.wolfpackSessionId);
-    prevOutputSequences.delete(resolved.name);
+    prevRenderedActivityFingerprints.delete(resolved.identity.wolfpackSessionId);
+    prevRenderedActivityFingerprints.delete(resolved.name);
     await getBackend().killSession(resolved.name);
     json(res, {
       ok: true,

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -284,12 +284,12 @@ describe("GET /api/sessions", () => {
     expect(data.sessions[0].runtimeState).toMatchObject({ state: "idle" });
   });
 
-  test("classifies running when rendered content changes despite a stable raw sequence", async () => {
-    mockBackend.setCapturePane(async () => "step one\n");
+  test("classifies running when rendered content changes above a stable three-line footer", async () => {
+    mockBackend.setCapturePane(async () => "step one\nseparator\nstatus\nagents\n");
     mockBackend.setOutputSequence("wolf-1", "1");
     await get("/api/sessions");
 
-    mockBackend.setCapturePane(async () => "step two\n");
+    mockBackend.setCapturePane(async () => "step two\nseparator\nstatus\nagents\n");
     const data = await (await get("/api/sessions")).json();
 
     expect(data.sessions[0].triage).toBe("running");

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -272,13 +272,39 @@ describe("GET /api/sessions", () => {
     expect(data.sessions).toHaveLength(0);
   });
 
-  test("classifies running when broker output sequence advances", async () => {
+  test("classifies idle when raw PTY output advances but rendered content is unchanged", async () => {
+    mockBackend.setCapturePane(async () => "static rendered tui\n");
     mockBackend.setOutputSequence("wolf-1", "1");
     await get("/api/sessions");
+
     mockBackend.setOutputSequence("wolf-1", "2");
-    const res = await get("/api/sessions");
-    const data = await res.json();
+    const data = await (await get("/api/sessions")).json();
+
+    expect(data.sessions[0].triage).toBe("idle");
+    expect(data.sessions[0].runtimeState).toMatchObject({ state: "idle" });
+  });
+
+  test("classifies running when rendered content changes despite a stable raw sequence", async () => {
+    mockBackend.setCapturePane(async () => "step one\n");
+    mockBackend.setOutputSequence("wolf-1", "1");
+    await get("/api/sessions");
+
+    mockBackend.setCapturePane(async () => "step two\n");
+    const data = await (await get("/api/sessions")).json();
+
     expect(data.sessions[0].triage).toBe("running");
+    expect(data.sessions[0].runtimeState).toMatchObject({ state: "output" });
+  });
+
+  test("classifies idle when the rendered snapshot is unavailable", async () => {
+    mockBackend.setCapturePane(async () => "last rendered output\n");
+    await get("/api/sessions");
+
+    mockBackend.setCapturePane(async () => { throw new Error("snapshot unavailable"); });
+    const data = await (await get("/api/sessions")).json();
+
+    expect(data.sessions[0].triage).toBe("idle");
+    expect(data.sessions[0].runtimeState).toMatchObject({ state: "idle" });
   });
 
   test("classifies idle when output sequence is stable despite prompt prose", async () => {
@@ -309,9 +335,9 @@ describe("GET /api/sessions", () => {
 
   test("sorts sessions by triage priority", async () => {
     mockBackend.setSessions(["idle-sess", "running-sess", "input-sess"]);
+    mockBackend.setCapturePane(async (session: string) => session === "running-sess" ? "step one\n" : "quiet\n");
     await get("/api/sessions");
-    // Second call — only running-sess advances its broker output watermark.
-    mockBackend.setOutputSequence("running-sess", "1");
+    mockBackend.setCapturePane(async (session: string) => session === "running-sess" ? "step two\n" : "quiet\n");
     const res = await get("/api/sessions");
     const data = await res.json();
     // Sessions sorted alphabetically (5cf260d), triage is per-session metadata
@@ -335,7 +361,7 @@ describe("GET /api/sessions", () => {
       unseen: true,
     });
 
-    mockBackend.setOutputSequence("wolf-1", "1");
+    mockBackend.setCapturePane(async () => "compiling step 2...\n");
     const second = await (await get("/api/sessions")).json();
     expect(second.sessions[0].triage).toBe("running");
     expect(second.sessions[0].runtimeState).toMatchObject({
@@ -345,13 +371,13 @@ describe("GET /api/sessions", () => {
     });
   });
 
-  test("uses output sequence changes for activity without snapshotting dashboard sessions", async () => {
-    const sessionName = "sequence-activity";
-    const sessionId = "sequence-activity-id";
+  test("uses rendered pane changes for activity while preserving the output sequence", async () => {
+    const sessionName = "rendered-activity";
+    const sessionId = "rendered-activity-id";
     const factBackend = new FactBackend([
       { name: sessionName, alive: true, outputSequence: "41", identity: testIdentity(sessionName, sessionId) },
     ]);
-    factBackend.setPane(sessionName, "must not be captured\n");
+    factBackend.setPane(sessionName, "stable rendered tui\n");
     __setTestBackend(factBackend);
     try {
       const initial = await (await get("/api/sessions")).json();
@@ -366,42 +392,33 @@ describe("GET /api/sessions", () => {
       factBackend.setFacts([
         { name: sessionName, alive: true, outputSequence: "42", identity: testIdentity(sessionName, sessionId) },
       ]);
-      const advanced = await (await get("/api/sessions")).json();
-      expect(advanced.sessions[0]).toMatchObject({
-        name: sessionName,
-        lastLine: "",
-        triage: "running",
+      const redraw = await (await get("/api/sessions")).json();
+      expect(redraw.sessions[0]).toMatchObject({
+        triage: "idle",
         outputSequence: "42",
-        runtimeState: { state: "output" },
+        runtimeState: { state: "idle" },
       });
 
-      factBackend.setFacts([
-        { name: sessionName, alive: true, outputSequence: "40", identity: testIdentity(sessionName, sessionId) },
-      ]);
-      const regressed = await (await get("/api/sessions")).json();
-      expect(regressed.sessions[0]).toMatchObject({ triage: "idle", runtimeState: { state: "idle" } });
-
-      factBackend.setFacts([
-        { name: sessionName, alive: true, outputSequence: "41", identity: testIdentity(sessionName, sessionId) },
-      ]);
-      const belowWatermark = await (await get("/api/sessions")).json();
-      expect(belowWatermark.sessions[0]).toMatchObject({ triage: "idle", runtimeState: { state: "idle" } });
-
-      factBackend.setFacts([
-        { name: sessionName, alive: true, identity: testIdentity(sessionName, sessionId) },
-      ]);
-      const legacy = await (await get("/api/sessions")).json();
-      expect(legacy.sessions[0]).toMatchObject({ triage: "idle", runtimeState: { state: "idle" } });
-      expect(legacy.sessions[0]).not.toHaveProperty("outputSequence");
-      expect(factBackend.capturePaneCalls).toBe(0);
+      factBackend.setPane(sessionName, "updated rendered tui\n");
+      const renderedOutput = await (await get("/api/sessions")).json();
+      expect(renderedOutput.sessions[0]).toMatchObject({
+        triage: "running",
+        outputSequence: "42",
+        runtimeState: {
+          state: "output",
+          label: "rendered output activity",
+          message: "derived only from broker-rendered terminal changes",
+        },
+      });
+      expect(factBackend.capturePaneCalls).toBe(3);
     } finally {
       __setTestBackend(mockBackend);
     }
   });
 
-  test("first output sequence initializes baseline without reporting recent output", async () => {
+  test("first rendered fingerprint initializes baseline without reporting recent output", async () => {
     mockBackend.setSessions(["fresh-baseline"]);
-    mockBackend.setOutputSequence("fresh-baseline", "99");
+    mockBackend.setCapturePane(async () => "quiet existing screen\n");
 
     const data = await (await get("/api/sessions")).json();
 
@@ -415,9 +432,9 @@ describe("GET /api/sessions", () => {
     });
   });
 
-  test("restored acknowledged state stays seen on first sequence sample after restart", async () => {
+  test("restored acknowledged state stays seen on first rendered sample after restart", async () => {
     mockBackend.setSessions(["restored-baseline"]);
-    mockBackend.setOutputSequence("restored-baseline", "99");
+    mockBackend.setCapturePane(async () => "quiet existing screen\n");
     const sessionKey = "mock:restored-baseline";
     const store = new AgentRuntimeStateStore(process.env.WOLFPACK_AGENT_RUNTIME_STATE_PATH!);
     const idle = store.reduce({
@@ -666,7 +683,7 @@ describe("GET /api/sessions", () => {
     expect(acked.runtimeState.unseen).toBe(false);
     expect(acked.runtimeState.acknowledgedSequence).toBe(runtimeState.transitionSequence);
 
-    mockBackend.setOutputSequence("wolf-1", "1");
+    mockBackend.setCapturePane(async () => "new output\n");
     const next = await (await get("/api/sessions")).json();
     expect(next.sessions[0].runtimeState.transitionSequence).toBeGreaterThan(runtimeState.transitionSequence);
     expect(next.sessions[0].runtimeState.unseen).toBe(true);

--- a/tests/unit/broker-backend.test.ts
+++ b/tests/unit/broker-backend.test.ts
@@ -517,6 +517,21 @@ describe("BrokerBackend.capturePane", () => {
     expect(text).toBe("older\nhello\nworld");
   });
 
+  test("can limit a snapshot to the visible screen", async () => {
+    client.setHandler("list_sessions", () => okResp({
+      sessions: [sessionInfo({ name: "tui", id: SESSION_UUID_1 })],
+    }));
+    await backend.list();
+    client.setHandler("snapshot", () => okResp(styledSnapshot(["visible"], ["older"])));
+
+    await backend.capturePane("tui", { scrollbackLines: 0 });
+
+    expect(client.requests.at(-1)).toEqual({
+      method: "snapshot",
+      params: { session_id: SESSION_UUID_1, scrollback_lines: 0 },
+    });
+  });
+
   test("returns empty string when broker fails", async () => {
     client.setHandler("list_sessions", () => okResp({
       sessions: [sessionInfo({ name: "tui", id: SESSION_UUID_1 })],


### PR DESCRIPTION
## summary
- classify dashboard activity from changes in the complete broker-rendered visible screen instead of raw PTY byte sequence changes
- normalize terminal cell padding while preserving visible layout, so unchanged redraw traffic remains idle and working content above stable TUI footers reports output
- keep `outputSequence` unchanged for websocket replay and recovery
- request zero scrollback rows for bounded dashboard snapshots

## regression coverage
- advancing raw PTY output with an unchanged rendered screen stays idle
- changed rendered content above a stable three-line footer reports output even with a stable raw sequence
- unavailable rendered snapshots fail quiet as idle
- activity capture requests only the visible screen

## verification
- `bun test` — 1496 pass
- `bun run typecheck`
- `git diff --check`
- local server-only deploy via `scripts/deploy-local.sh --broker=no`
  - server restarted successfully
  - broker PID unchanged
  - 6 existing sessions preserved
  - `/api/info` reports `1.6.14`
  - live `wolfpack-3` sampling reports `running/output` while its working spinner/progress changes above a static footer

## release
- no additional version bump
- no tag created; tag `v1.6.14` after merge