### PR TITLE
Add agent discovery metadata and homepage indexing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 Wolfpack is a self-hosted browser terminal dashboard for AI coding agents: Claude Code, Codex, Gemini, shell commands, and custom agent wrappers.
 It runs on your own macOS/Linux machine — laptop, workstation, or cloud VM — and gives you a PWA command center for long-running agent terminal sessions across your Tailscale tailnet.
 
+**Homepage:** [get-wolfpack.netlify.app](https://get-wolfpack.netlify.app/) · **Agent-readable overview:** [llms.txt](https://get-wolfpack.netlify.app/llms.txt)
+
 Sessions live in a Rust PTY broker, not the web server, so server restarts and redeploys do not kill your agents.
 There is no Wolfpack-hosted relay or account; remote access is normally handled by [Tailscale](https://tailscale.com/). Visit the [Wolfpack homepage](https://get-wolfpack.netlify.app/) for the product overview.
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -1,0 +1,32 @@
+# Wolfpack — agent-readable overview
+
+## Summary
+Wolfpack is a self-hosted browser terminal manager and multi-machine control room for AI coding agents. It runs on the machines the operator controls and exposes persistent terminal sessions through a browser/PWA. The intended network path for remote use is a private Tailscale tailnet.
+
+## Activation use case
+Install Wolfpack on two machines, connect both to the same tailnet, start an agent session on one machine, and open Wolfpack from another machine or phone. The operator can inspect output, send input, and continue long-running work without juggling SSH windows or tmux panes.
+
+## Supported environments
+- macOS arm64 and x64
+- Linux x64 and arm64
+- Claude Code, Codex CLI, Gemini CLI, shell, Cursor, Pi, and custom commands when installed on PATH
+
+## Install
+```bash
+curl -fsSL https://raw.githubusercontent.com/almogdepaz/wolfpack/main/install.sh | bash
+```
+
+Then run `wolfpack`, complete setup, and use `wolfpack doctor` for diagnostics. The installer provides matching prebuilt `wolfpack` and `wolfpack-broker` binaries.
+
+## Architecture
+The local Rust broker owns PTY sessions, so browser-server restarts do not kill agents. Wolfpack is not a hosted orchestration service. It does not require a Wolfpack account, and there is no Wolfpack-hosted relay or prompt-upload service. Tailscale provides the private route for normal remote access.
+
+## Security
+Treat the generated local or tailnet URL as sensitive. Use a trusted tailnet and follow the repository's security model before exposing Wolfpack beyond that boundary. JWT authentication is not assumed by the Tailscale-first setup; review current security guidance before public exposure.
+
+## Links
+- Homepage: https://get-wolfpack.netlify.app/
+- Repository: https://github.com/almogdepaz/wolfpack
+- README: https://github.com/almogdepaz/wolfpack#readme
+- Security model: https://github.com/almogdepaz/wolfpack#trust-and-security-model
+- Tester discussion: https://github.com/almogdepaz/wolfpack/discussions/262

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,0 +1,21 @@
+# Wolfpack
+
+> Wolfpack is a self-hosted control room for persistent coding-agent terminal sessions across your machines.
+
+## What it does
+- Runs beside coding agents on macOS or Linux.
+- Provides browser/PWA access to persistent PTY sessions from a laptop, workstation, or phone.
+- Lets developers view and control sessions across machines on a Tailscale tailnet.
+- Supports Claude Code, Codex CLI, Gemini CLI, shell commands, and custom wrappers.
+
+## Privacy and architecture
+- Open source under the MIT license.
+- No Wolfpack account is required.
+- No Wolfpack-hosted relay or prompt-upload service is used; remote access normally travels over the operator's Tailscale network.
+- Sessions are owned by a local Rust PTY broker and survive web-server restarts.
+
+## Start here
+- Homepage: https://get-wolfpack.netlify.app/
+- Source and documentation: https://github.com/almogdepaz/wolfpack
+- Quickstart: https://github.com/almogdepaz/wolfpack#quickstart
+- Full agent-readable summary: https://get-wolfpack.netlify.app/llms-full.txt


### PR DESCRIPTION
## Summary
- add canonical, OpenGraph, Twitter, and JSON-LD metadata to the homepage
- add robots.txt, sitemap.xml, llms.txt, and llms-full.txt
- link the public homepage and agent-readable overview from the README

## Validation
- Netlify homepage and discovery files return HTTP 200
- sitemap XML parses successfully

Homepage: https://get-wolfpack.netlify.app/