### PR TITLE
feat: improve discovery and activation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,10 +18,14 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      # v4.2.2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      # v5.0.0
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+      # v3.0.1
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
         with:
           path: site
       - id: deployment
-        uses: actions/deploy-pages@v4
+        # v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Wolfpack is a self-hosted browser terminal dashboard for AI coding agents: Claud
 It runs on your own macOS/Linux machine — laptop, workstation, or cloud VM — and gives you a PWA command center for long-running agent terminal sessions across your Tailscale tailnet.
 
 Sessions live in a Rust PTY broker, not the web server, so server restarts and redeploys do not kill your agents.
-There is no Wolfpack-hosted relay or account; remote access is normally handled by [Tailscale](https://tailscale.com/).
+There is no Wolfpack-hosted relay or account; remote access is normally handled by [Tailscale](https://tailscale.com/). Visit the [Wolfpack homepage](https://get-wolfpack.netlify.app/) for the product overview.
 
 <p align="center">
   <img src="docs/assets/wolfpack-desktop-grid.png" width="700" alt="Desktop — multi-terminal grid" />
@@ -25,7 +25,7 @@ There is no Wolfpack-hosted relay or account; remote access is normally handled 
   <a href="docs/assets/wolfpack-usage-demo.mp4">Watch/download the MP4 demo</a>
 </p>
 
-**Try the workflow:** install Wolfpack on two machines, connect them to the same Tailscale tailnet, then open the phone QR from either host to control persistent agent sessions remotely. Start with the [Quickstart](#quickstart) and [First five minutes](#first-five-minutes).
+**Try the workflow:** install Wolfpack on two machines, connect them to the same Tailscale tailnet, then open the phone QR from either host to control persistent agent sessions remotely. Start with the [Quickstart](#quickstart) and [First five minutes](#first-five-minutes). If you are trialing this workflow, use the [multi-machine feedback template](docs/multi-machine-trial-feedback.md).
 
 ## Quickstart
 

--- a/docs/multi-machine-trial-feedback.md
+++ b/docs/multi-machine-trial-feedback.md
@@ -1,0 +1,35 @@
+# multi-machine trial feedback
+
+use this template after a real Wolfpack trial on at least two machines. post it in the tester discussion or an issue only after removing identifying machine and network details.
+
+Do not include terminal output, project names, Tailscale URLs, or credentials.
+
+## Participant context
+
+- operating systems and architectures:
+- Tailscale already installed on each machine: yes/no
+- local-only, remote Tailnet, or both:
+
+## Setup timeline
+
+- time from installer start to a usable first host:
+- time from installer start to a verified remote URL:
+- commands or steps that were unclear:
+
+## First remote session
+
+- second machine or phone used to connect:
+- could you read output and send input: yes/no
+- time from opening the URL to the first usable remote session:
+- what required assistance, if anything:
+
+## Failure points
+
+- first failure on macOS, Linux, local-only, or Tailnet remote flow:
+- exact user-visible error or failed step (redact sensitive values):
+- workaround or recovery:
+
+## Follow-up
+
+- would you use this workflow again: yes/no/unsure
+- one change that would make setup clearer:

--- a/llms.txt
+++ b/llms.txt
@@ -6,6 +6,7 @@ Wolfpack is a PWA and CLI for controlling long-running terminal sessions from a 
 
 ## Primary links
 
+- Canonical homepage: https://get-wolfpack.netlify.app/
 - Repository and README: https://github.com/almogdepaz/wolfpack
 - Install script: https://raw.githubusercontent.com/almogdepaz/wolfpack/main/install.sh
 - npm package: https://www.npmjs.com/package/wolfpack-bridge

--- a/site/index.html
+++ b/site/index.html
@@ -5,6 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#07100e">
   <meta name="description" content="Wolfpack is a private, self-hosted control room for persistent coding-agent sessions across your machines.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://get-wolfpack.netlify.app/">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://get-wolfpack.netlify.app/">
+  <meta property="og:title" content="Wolfpack — your agents. your machines. your tailnet.">
+  <meta property="og:description" content="A self-hosted control room for persistent coding-agent sessions across your machines, connected through your Tailscale tailnet.">
+  <meta property="og:image" content="https://get-wolfpack.netlify.app/assets/desktop-sessions.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Wolfpack — your agents. your machines. your tailnet.">
+  <meta name="twitter:description" content="Self-hosted, multi-machine control for Claude Code, Codex, Gemini, and shell sessions.">
+  <meta name="twitter:image" content="https://get-wolfpack.netlify.app/assets/desktop-sessions.png">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "Wolfpack",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "macOS, Linux",
+      "description": "A self-hosted browser control room for persistent coding-agent terminal sessions across your machines.",
+      "url": "https://get-wolfpack.netlify.app/",
+      "downloadUrl": "https://github.com/almogdepaz/wolfpack",
+      "license": "https://github.com/almogdepaz/wolfpack/blob/main/LICENSE"
+    }
+  </script>
   <title>Wolfpack — your agents. your machines. your tailnet.</title>
   <link rel="icon" href="assets/wolfpack-icon.svg" type="image/svg+xml">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://get-wolfpack.netlify.app/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://get-wolfpack.netlify.app/</loc>
+  </url>
+</urlset>

--- a/tests/unit/discovery-assets.test.ts
+++ b/tests/unit/discovery-assets.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const CANONICAL_URL = "https://get-wolfpack.netlify.app/";
+
+function readRepoFile(path: string): string {
+  return readFileSync(path, "utf-8");
+}
+
+function jsonLdFrom(html: string): Record<string, unknown> {
+  const match = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+  if (!match?.[1]) throw new Error("homepage JSON-LD is missing");
+  return JSON.parse(match[1]);
+}
+
+describe("discovery assets", () => {
+  test("publishes the canonical homepage metadata", () => {
+    const homepage = readRepoFile("site/index.html");
+
+    expect(homepage).toContain(`<link rel="canonical" href="${CANONICAL_URL}">`);
+    expect(homepage).toContain(`<meta property="og:url" content="${CANONICAL_URL}">`);
+    expect(homepage).toContain("<meta name=\"twitter:card\" content=\"summary_large_image\">");
+
+    const jsonLd = jsonLdFrom(homepage);
+    expect(jsonLd["@type"]).toBe("SoftwareApplication");
+    expect(jsonLd.url).toBe(CANONICAL_URL);
+  });
+
+  test("ships crawler assets for the canonical homepage", () => {
+    const robots = readRepoFile("site/robots.txt");
+    const sitemap = readRepoFile("site/sitemap.xml");
+
+    expect(robots).toContain(`Sitemap: ${CANONICAL_URL}sitemap.xml`);
+    expect(sitemap).toContain(`<loc>${CANONICAL_URL}</loc>`);
+  });
+
+  test("links machine-readable and README discovery to the canonical homepage", () => {
+    expect(readRepoFile("README.md")).toContain(CANONICAL_URL);
+    expect(readRepoFile("llms.txt")).toContain(CANONICAL_URL);
+  });
+
+  test("provides a privacy-respecting feedback template for multi-machine trials", () => {
+    const template = readRepoFile("docs/multi-machine-trial-feedback.md");
+
+    expect(template).toContain("## Setup timeline");
+    expect(template).toContain("## First remote session");
+    expect(template).toContain("Do not include terminal output, project names, Tailscale URLs, or credentials.");
+  });
+
+  test("pins the privileged Pages deployment actions", () => {
+    const workflow = readRepoFile(".github/workflows/pages.yml");
+
+    expect(workflow).toContain("actions/checkout@11d5960a326750d5838078e36cf38b85af677262");
+    expect(workflow).toContain("actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b");
+    expect(workflow).toContain("actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa");
+    expect(workflow).toContain("actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e");
+  });
+});


### PR DESCRIPTION
## summary
- add canonical, social, JSON-LD, robots, and sitemap discovery assets
- link the canonical homepage and document two-machine trial feedback
- pin privileged GitHub Pages actions

## validation
- bun test
- bun run typecheck
- local static artifact check

closes #268