### PR TITLE
docs: improve README onboarding and install parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,41 +5,30 @@
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey.svg)]()
 [![Version](https://img.shields.io/github/v/release/almogdepaz/wolfpack?label=version)](https://get-wolfpack.netlify.app/)
 
-Wolfpack is a self-hosted browser terminal dashboard for AI coding agents: Claude Code, Codex, Gemini, shell commands, and custom agent wrappers.
-It runs on your own macOS/Linux machine — laptop, workstation, or cloud VM — and gives you a PWA command center for long-running agent terminal sessions across your Tailscale tailnet.
+Run Claude Code, Codex, Gemini, and shell sessions on machines you control. Reach them from a browser or phone over Tailscale, without a Wolfpack-hosted relay or account.
+
+Sessions live in a Rust PTY broker, not the web server, so server restarts and upgrades do not kill your agents.
 
 **Homepage:** [get-wolfpack.netlify.app](https://get-wolfpack.netlify.app/) · **Agent-readable overview:** [llms.txt](https://get-wolfpack.netlify.app/llms.txt)
 
-Sessions live in a Rust PTY broker, not the web server, so server restarts and redeploys do not kill your agents.
-There is no Wolfpack-hosted relay or account; remote access is normally handled by [Tailscale](https://tailscale.com/). Visit the [Wolfpack homepage](https://get-wolfpack.netlify.app/) for the product overview.
-
 <p align="center">
-  <img src="docs/assets/wolfpack-desktop-grid.png" width="700" alt="Desktop — multi-terminal grid" />
-</p>
-<p align="center">
-  <img src="docs/assets/wolfpack-mobile-menu.jpeg" width="250" alt="Mobile — session menu" />
-  <img src="docs/assets/wolfpack-mobile-terminal.jpeg" width="250" alt="Mobile — terminal session" />
-</p>
-<p align="center">
-  <img src="docs/assets/wolfpack-usage-demo.gif" width="700" alt="Wolfpack usage demo showing real broker-backed terminal sessions" />
-</p>
-<p align="center">
-  <a href="docs/assets/wolfpack-usage-demo.mp4">Watch/download the MP4 demo</a>
+  <img src="docs/assets/wolfpack-desktop-grid.png" width="700" alt="Wolfpack desktop multi-terminal grid" />
 </p>
 
-**Try the workflow:** install Wolfpack on two machines, connect them to the same Tailscale tailnet, then open the phone QR from either host to control persistent agent sessions remotely. Start with the [Quickstart](#quickstart) and [First five minutes](#first-five-minutes). If you are trialing this workflow, use the [multi-machine feedback template](docs/multi-machine-trial-feedback.md).
+> **security:** wolfpack gives browser users shell-level control over configured projects. Keep it private to a trusted Tailnet. If other people share the Tailnet, configure device/user ACLs and consider JWT. Session control follows the ordinary global API auth policy when configured and has no inter-session authorization layer; read the [full trust model](docs/installation.md#security-and-trust).
 
-## Quickstart
+## quickstart
+
+### curl installer: persistent CLI
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/almogdepaz/wolfpack/main/install.sh | bash
 wolfpack
 ```
 
-The installer downloads the right pre-built binaries for your platform, runs setup, and can install Wolfpack as a login service. Wolfpack uses Tailscale for private HTTPS phone and remote control: when it is installed, setup configures that path by default; otherwise setup explains why and offers installation, with local-only access as the fallback. Setup waits for sign-in and verifies the private HTTPS route before it prints a phone QR code. The bundled `wolfpack-broker` includes its Ghostty VT engine; release installs do not need Zig, Ghostty, or extra system libraries.
-Supported: macOS arm64/x64 and Linux x64/arm64. Release installs and managed services support both platforms. On Linux, automatic Tailscale installation requires `apt`; otherwise install Tailscale yourself. Managed services require `systemd --user`; setup runs `sudo loginctl enable-linger $USER` for persistence after reboot and prints that command if it fails. Otherwise, run `wolfpack` in the foreground.
+A bare `wolfpack` runs setup on first launch. Later, it ensures the managed server is current/running and prints local and verified remote URLs plus a QR code.
 
-Want a package runner instead? Pin `@latest` so Bun/npm does not reuse an older cached release:
+### Bunx or npm: package runner
 
 ```bash
 bunx wolfpack-bridge@latest
@@ -47,237 +36,75 @@ bunx wolfpack-bridge@latest
 npx --yes wolfpack-bridge@latest
 ```
 
-Both package-runner commands resolve the same matching prebuilt `wolfpack` and `wolfpack-broker` pair as the curl installer, then run the same setup wizard. Unlike curl, they do not add `wolfpack` to your shell `PATH`; use curl when you want a persistent CLI installation.
+Package runners use the same setup wizard but do not add `wolfpack` to `PATH`. Use the runner prefix for every later command.
 
-If setup gets weird, run:
+## first success
 
-```bash
-wolfpack doctor
-```
+**you’ll choose:** a projects directory, port, Tailscale remote access, optional Pi integration, and whether Wolfpack starts at login.
 
-Uninstall is explicit. It removes Wolfpack-managed files and its installer-created `/usr/local/bin/wolfpack` symlink, but never an unrelated command with the same name:
+**success looks like:** a local URL; a verified Tailnet HTTPS URL and QR code when remote access is configured; and a diagnosis command with no unresolved failures.
 
-```bash
-wolfpack uninstall --yes
-```
-
-## First five minutes
-
-1. Run the installer.
-2. If Tailscale is installed, setup configures private phone/remote access by default. If it is missing, setup explains why and offers installation; declining continues with local-only access.
-3. Choose your projects directory and port. On a fresh install, setup enables `shell` plus supported providers detected on `PATH`; existing agent settings are never overwritten.
-4. For remote access, sign in to Tailscale when setup opens it (macOS) or prompts for `sudo tailscale up` (Linux). Setup keeps the same run open for retry, then verifies `tailscale serve` before it prints the private Tailnet HTTPS QR code.
-5. Follow the final checklist: start or install the service, open the local or verified Tailnet URL, run `wolfpack doctor`, then create a session with `codex` or `claude`.
-
-Local browser access works only on the host machine. It is not phone access: only a verified Tailnet HTTPS QR code opens Wolfpack from another device.
-
-## Why use it
-
-Use Wolfpack when you want a self-hosted alternative to juggling tmux panes, SSH windows, and cloud workspaces for AI agent sessions.
-It is an AI agent terminal orchestrator for developers who need persistent browser/mobile access to coding agents running on machines they control.
-
-- **Phone-first agent control** — respond to Claude/Codex/Gemini while away from your desk.
-- **Multi-machine view** — manage sessions from every machine in your tailnet, including cloud VMs.
-- **Persistent PTYs** — the Rust broker owns sessions, so server restarts do not kill agents.
-- **Session triage** — cards show running/idle/needs-input state and live output previews.
-- **Desktop grid** — view up to 6 terminals side by side.
-- **PWA UX** — install on your home screen, reconnect on drops, receive notifications when sessions need attention.
-- **Agent-agnostic** — use built-in commands or add your own shell command in Settings → Agents.
-- **Provider readiness** — First-run setup enables detected supported CLIs; Settings → Agents shows path/version and login guidance and lets you add providers installed later.
-- **Agent skills** — `wolfpack-tailnet-control` works with all agent harnesses that support Agent Skills; optionally add Pi Tasks for durable Pi subagent delegation. See [Agent skills](#agent-skills).
-
-## Agent recipes
-
-Wolfpack starts sessions by running a command in the selected project directory.
-Configure commands in **Settings → Agents**.
-
-| Agent | Command |
+| install path | verify |
 | --- | --- |
-| Shell | `shell` |
-| Claude Code | `claude` |
-| Codex | `codex` |
-| Gemini | `gemini` |
-| Cursor | `cursor` |
-| Pi | `pi` |
-| Custom wrapper | any command on `PATH`, for example `opencode` or `my-agent --flag` |
+| curl | `wolfpack doctor` |
+| Bunx | `bunx wolfpack-bridge@latest doctor` |
+| npm/npx | `npx --yes wolfpack-bridge@latest doctor` |
 
-`cmd` validation intentionally rejects shell metacharacters for session commands. If you need complex setup, put it in a wrapper script on `PATH` and add that command.
+Open the local URL on the host machine. For phone or remote access, scan only the verified Tailnet HTTPS QR code.
 
-## CLI
+To uninstall: `wolfpack uninstall --yes` (curl), `bunx wolfpack-bridge@latest uninstall --yes` (Bunx), or `npx --yes wolfpack-bridge@latest uninstall --yes` (npm).
 
-```text
-wolfpack                 Start the server (runs setup on first launch)
-wolfpack setup           Re-run the setup wizard
-wolfpack list [--json]   List active broker sessions
-wolfpack session create  Create a top-level project session
-wolfpack agent spawn     Spawn a same-harness child agent
-wolfpack session ...     Status/read/send/wait/prompt helpers for agent automation
-wolfpack attach [name]   Attach the local terminal to an existing session
-wolfpack kill <name|id>  Kill a session
-wolfpack --version       Print the installed version
-wolfpack doctor          Diagnose broker, binaries, JWT, Tailscale
-wolfpack service ...     install / start / stop / restart / status / uninstall (add --broker to include broker)
-wolfpack uninstall --yes Remove Wolfpack-managed files
-```
+## why wolfpack
 
-Create a top-level project session with its initial instruction delivered at launch:
+| instead of | Wolfpack gives you |
+| --- | --- |
+| SSH and tmux juggling | browser and phone control for agent terminals |
+| sessions dying on server restart | broker-owned persistent PTYs |
+| hosted remote-control SaaS | direct private Tailnet access, without a Wolfpack relay or account |
+| one host at a time | trusted multi-machine session control |
+
+- **see what needs attention** — running, idle, and needs-input session states with live output previews.
+- **work how you prefer** — phone PWA, desktop terminal grid, notifications, and direct terminal attach.
+- **use the agents you already run** — built-in commands or custom commands on `PATH`; configure them in **Settings → Agents**.
+
+## docs
+
+- [installation and first success](docs/installation.md) — install methods, service behavior, platform detail, verification, and uninstall.
+- [troubleshooting](docs/troubleshooting.md) — recover from setup, service, broker, and remote-access failures.
+- [terminal attach](docs/cli-attach.md) — attach a local terminal with `wolfpack attach [name]`.
+- [session control](docs/session-control.md) — scriptable session-control API.
+- [agent skills](docs/agent-skills.md) — install the Wolfpack control skill for supported agent harnesses.
+- [task gateway](docs/task-gateway.md) — durable Pi Task routing, retention, and federation limits.
+- [broker protocol](docs/broker-protocol.md) — broker wire protocol and terminal-state boundary.
+
+## agent skills
+
+`wolfpack-tailnet-control` works with all agent harnesses that support Agent Skills. The opt-in Pi flow in `wolfpack setup` copies the bundled control skill, then installs Pi Tasks with `pi install npm:@sgtbeatdown/pi-tasks`. `wolfpack-tailnet-control` controls sessions; `wolfpack-pi-task-delegation` teaches Pi to use `agent_task_*` for durable task routing.
+
+For a manual audited install, clone or update `https://github.com/almogdepaz/wolfpack`, review `skills/wolfpack-tailnet-control/SKILL.md`, then place the skill in `~/.pi/agent/skills/`, `~/.agents/skills/`, or `~/.claude/skills/`. Start a fresh agent context afterward. Platform binaries do not expose skills as files; detailed safe symlink and copy instructions are in [agent skills](docs/agent-skills.md).
+
+## advanced automation
+
+Create a top-level project session with an initial instruction:
 
 ```bash
 wolfpack session create branchout --harness pi --plan .plans/000-task.md --json
 ```
 
-Spawn a same-harness child from an existing Wolfpack agent:
+Spawn a same-harness child agent:
 
 ```bash
 wolfpack agent spawn wolfpack --plan .plans/000-review.md --notify-parent --json
 ```
 
-Each command makes one server-owned request and returns the stable broker `sessionId`. The server validates the project, allocates the name, persists identity, and passes startup instructions directly to the harness instead of racing terminal readiness. `--plan` generates a compact plan handoff without copying plan contents; `--prompt-file` avoids shell heredoc/quoting failures for bespoke long prompts. Child spawning derives the parent harness and structured hierarchy without inheriting its transcript or context. `wolfpack session open` remains a deprecated child-spawn alias.
+Use `wolfpack session create <project>` for top-level work and `wolfpack agent spawn <project>` for a same-harness child. The CLI validates the project and command, allocates a stable broker session ID, and delivers the initial instruction directly to the harness. For the full command surface and automation contract, use [session control](docs/session-control.md) and [task gateway](docs/task-gateway.md).
 
-Direct terminal attach: [docs/cli-attach.md](docs/cli-attach.md). Scriptable session control: [docs/session-control.md](docs/session-control.md).
+## contributing
 
-Troubleshooting: [docs/troubleshooting.md](docs/troubleshooting.md).
-
-## Trust and security model
-
-Wolfpack is self-hosted software for machines you control. Those machines can be local laptops, workstations, or cloud VMs.
-
-- Browser/PWA talks to the Wolfpack server over HTTP/WebSocket.
-- Remote access is normally private HTTPS through Tailscale.
-- The server talks to the broker over a per-user Unix socket.
-- The broker owns the PTYs and runs your selected commands locally on that machine.
-- Optional JWT auth can be layered on top of Tailscale.
-- Session control follows the ordinary global API auth policy when configured and adds no inter-session authorization layer. Tailnet/global Wolfpack access remains the trust boundary; sessions can list and communicate with other sessions.
-- Wolfpack does not provide a hosted relay, managed account, or prompt upload service.
-
-Running coding agents is intentionally powerful: those commands execute with your local user permissions in the chosen project directory.
-Treat Wolfpack access like shell access to that machine.
-
-## Architecture
-
-```text
-┌─────────────┐    ┌───────────┐    ┌──────────────────────────────────────────┐
-│   Phone /   │    │ Tailscale │    │       Your machine / cloud VM            │
-│   Browser   │◄──►│  (HTTPS)  │◄──►│                                          │
-│   (PWA)     │    │  mesh VPN │    │  ┌──────────┐  unix   ┌──────────────┐  │
-└─────────────┘    └───────────┘    │  │ wolfpack │ socket  │  wolfpack-   │  │
-                                    │  │  server  │◄───────►│   broker     │  │
-                                    │  │ (Bun)    │         │  (Rust, PTY) │  │
-                                    │  │ HTTP/WS  │         │  owns agents │  │
-                                    │  └──────────┘         └──────────────┘  │
-                                    └──────────────────────────────────────────┘
-```
-
-- **PWA** — vanilla JS, no framework. ghostty-web renders the terminal.
-- **Server** — Bun HTTP + WebSocket. Pure broker client; owns no PTYs.
-- **Broker** — `wolfpack-broker`, Rust daemon. Owns every PTY, keeps per-session output rings, and uses a statically linked Ghostty VT engine for authoritative terminal state/snapshots. One Unix-domain socket per host (`$XDG_RUNTIME_DIR/wolfpack-broker.sock`, fallback `~/.wolfpack/broker.sock`). Wire protocol in [docs/broker-protocol.md](docs/broker-protocol.md).
-- **Task gateway** — a server-owned singleton/store at `~/.wolfpack/tasks/` durably routes Pi Tasks locally and between trusted Tailnet peers. Its operational contract, retention, and federation limits are in [docs/task-gateway.md](docs/task-gateway.md).
-
-## Optional JWT auth
-
-Tailscale already gates who can reach the server. If you want an extra auth layer on top — useful if you share your tailnet with others, or for defense-in-depth — set a JWT secret:
-
-```bash
-export WOLFPACK_JWT_SECRET="$(openssl rand -base64 48)"
-```
-
-Tokens are HS256; the server validates, it does not issue — sign them with any JWT library using the same secret.
-
-Optional: `WOLFPACK_JWT_AUDIENCE`, `WOLFPACK_JWT_ISSUER`, `WOLFPACK_JWT_CLOCK_TOLERANCE_SEC` (default 30s).
-
-## Config
-
-`~/.wolfpack/config.json` (mode 0600):
-
-```json
-{
-  "devDir": "/Users/you/Dev",
-  "port": 18790,
-  "tailscaleHostname": "your-machine.tailnet-name.ts.net"
-}
-```
-
-Per-server agent settings live in `~/.wolfpack/bridge-settings.json`.
-
-## Agent skills
-
-### Wolfpack control skill
-
-`wolfpack-tailnet-control` is for all agent harnesses that support Agent Skills,
-not just Pi. It discovers, inspects, and controls visible Wolfpack terminal
-sessions across Tailscale hosts.
-
-### Optional Pi task delegation
-
-When `wolfpack setup` detects `pi` on `PATH`, it offers one default-no,
-opt-in installation. Accepting copies the bundled control skill into Pi, then
-installs the Pi Tasks extension; it does not ask Pi to install the Wolfpack app.
-
-- [`@sgtbeatdown/pi-tasks`](https://www.npmjs.com/package/@sgtbeatdown/pi-tasks) — the Pi Tasks extension and `wolfpack-pi-task-delegation` skill.
-
-```bash
-pi install npm:@sgtbeatdown/pi-tasks
-```
-
-The pieces have separate jobs:
-
-| Owner | Resource | Responsibility |
-| --- | --- | --- |
-| Wolfpack | `wolfpack-tailnet-control` | Creates, selects, inspects, and closes visible Wolfpack sessions. |
-| Pi Tasks extension | `agent_task_*` | Sends assignments and records durable structured status/results; it does not create sessions. |
-| Pi Tasks skill | `wolfpack-pi-task-delegation` | Teaches Pi to combine Wolfpack session control with the task tools and completion protocol. |
-
-Pi Tasks contains both the extension and its matching delegation skill. Every
-participating Pi session needs Pi Tasks loaded and a reachable local Wolfpack
-task gateway; the gateway owns machine-global task state rather than a
-project-local filesystem store. Same-machine and trusted Tailnet peer routing
-use stable broker session IDs. See [docs/task-gateway.md](docs/task-gateway.md)
-for the operational contract and federation limits. Declining the setup prompt
-changes nothing. Non-interactive setup installs nothing and directs users to
-rerun `wolfpack setup` interactively.
-
-Skills and extensions can execute commands with your user permissions. Review
-the packages before accepting. Start a fresh Pi session afterward, or run
-`/reload` in an existing session.
-
-### Install the Wolfpack control skill
-
-For Pi, use the opt-in `wolfpack setup` flow above. For every other agent
-harness, manual installation is required: `wolfpack setup` does not add the
-control skill outside Pi. An agent needs `wolfpack-tailnet-control` in its skill
-root to receive Wolfpack's session-control instructions. Use this audited manual
-workflow for other harnesses or a customized Pi install. Skills are executable
-agent instructions, so install only the ones you have audited. Clone or update
-`https://github.com/almogdepaz/wolfpack`, review the requested file (for example
-`skills/wolfpack-tailnet-control/SKILL.md`), then symlink that skill directory
-into one supported root:
-
-- Pi global: `~/.pi/agent/skills/`
-- shared Agent Skills root supported by Pi: `~/.agents/skills/`
-- Claude global: `~/.claude/skills/`
-- another Agent Skills-capable harness: that harness's documented global skill root
-
-Prefer symlinks so a reviewed `git pull --ff-only` updates the source. Refuse installation when the destination already exists; copying is also supported but must be refreshed manually. Start a fresh agent context afterward so skill descriptions are rescanned. Full fail-safe commands: [docs/agent-skills.md](docs/agent-skills.md).
-
-For a top-level session or a same-harness child, invoke:
-
-```bash
-wolfpack session create <project> --harness pi --plan .plans/000-task.md --json
-wolfpack agent spawn <project> --plan .plans/000-task.md --notify-parent --json
-```
-
-The released Wolfpack CLI bundles the control skill for Pi setup. Platform
-binaries do not expose skills as files; the setup wizard copies the bundled
-control skill and asks Pi's package manager to install Pi Tasks only after
-explicit opt-in. The cloned repository remains the auditable source for manual
-skill installation.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, the asset pipeline, and PR conventions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, the asset pipeline, and PR conventions.
 
 Bugs and feature requests: [GitHub Issues](https://github.com/almogdepaz/wolfpack/issues). Questions and ideas: [Discussions](https://github.com/almogdepaz/wolfpack/discussions).
 
-## License
+## license
 
 MIT

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,80 @@
+# installation and first success
+
+Wolfpack runs selected agent commands with your local user permissions. Install it only on machines and Tailnets you control.
+
+## choose an install path
+
+### curl installer: persistent CLI
+
+Use curl when you want `wolfpack` available on your `PATH`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/almogdepaz/wolfpack/main/install.sh | bash
+wolfpack
+```
+
+The installer downloads the matching `wolfpack` and `wolfpack-broker` releases, verifies them, then runs setup. Once configured, a bare `wolfpack` stages the current server binary, ensures the managed server is running, and prints the local URL, verified remote URL when available, and a QR code. It restarts only the server when updating; broker-owned sessions remain alive.
+
+### Bunx or npm: no persistent CLI
+
+Use a package runner when you do not want a global `wolfpack` command. Pin `@latest` so the runner does not reuse an older cached release:
+
+```bash
+bunx wolfpack-bridge@latest
+# or
+npx --yes wolfpack-bridge@latest
+```
+
+These commands resolve the same matching prebuilt `wolfpack` and `wolfpack-broker` pair and run the same setup wizard, but do **not** add `wolfpack` to your `PATH`. Repeat the runner prefix for every later command.
+
+## setup choices
+
+Setup asks you to choose or confirm:
+
+- the projects directory that contains sessions you want to create;
+- the Wolfpack port;
+- Tailscale sign-in and private HTTPS remote access, when available;
+- optional Pi integration, when Pi is detected; and
+- whether Wolfpack should start automatically at login.
+
+On first setup, Wolfpack enables `shell` and supported agent CLIs detected on `PATH`; it does not overwrite existing agent settings. Tailscale is used for private phone and remote access. Without it, setup continues with local-only access.
+
+## what success looks like
+
+A successful setup prints a local URL. When Tailscale is signed in and `tailscale serve` is verified, it also prints a private Tailnet HTTPS URL and QR code. Open the local URL on the host machine, or scan only the verified remote QR code from a trusted Tailnet device.
+
+Run the matching diagnosis command after setup:
+
+| install path | diagnosis |
+| --- | --- |
+| curl | `wolfpack doctor` |
+| Bunx | `bunx wolfpack-bridge@latest doctor` |
+| npm/npx | `npx --yes wolfpack-bridge@latest doctor` |
+
+`doctor` checks the server, broker, binaries, JWT configuration, Tailscale, and common service problems. Resolve any reported failures; see [troubleshooting](troubleshooting.md) for recovery steps.
+
+## service and platform behavior
+
+The installer supports macOS arm64/x64 and Linux x64/arm64. The bundled broker includes its Ghostty VT engine; release installs do not require Zig, Ghostty, or extra system libraries.
+
+On macOS, Wolfpack can install a login service. On Linux, managed services use `systemd --user`; persistence after reboot needs `sudo loginctl enable-linger $USER`. Automatic Tailscale installation on Linux requires `apt`; otherwise install Tailscale yourself. You can always run Wolfpack in the foreground instead of installing a service.
+
+Use `wolfpack service status` after a curl installation to inspect the managed service. Package-runner users should use the matching Bunx or npm prefix.
+
+## uninstall
+
+Uninstall removes Wolfpack-managed files and the installer-created `/usr/local/bin/wolfpack` symlink, but never an unrelated command with the same name:
+
+| install path | uninstall |
+| --- | --- |
+| curl | `wolfpack uninstall --yes` |
+| Bunx | `bunx wolfpack-bridge@latest uninstall --yes` |
+| npm/npx | `npx --yes wolfpack-bridge@latest uninstall --yes` |
+
+## security and trust
+
+Wolfpack has no inter-session authorization layer. Anyone who can access its Tailnet/global endpoint can list and control visible sessions, and those sessions execute commands as the local user in selected project directories. Treat Wolfpack access as shell access to that machine.
+
+Keep Wolfpack private to a trusted Tailnet. If other people share the Tailnet, use Tailscale device/user ACLs and consider optional JWT authentication. Wolfpack has no hosted relay or managed account; Tailscale normally provides remote HTTPS access.
+
+For architecture and terminal ownership details, see the [README](../README.md). For failures after installation, use [troubleshooting](troubleshooting.md).

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "llms.txt",
     "docs/agent-skills.md",
     "docs/cli-attach.md",
+    "docs/installation.md",
     "docs/session-control.md",
     "docs/task-gateway.md",
     "skills"

--- a/tests/unit/readme-onboarding.test.ts
+++ b/tests/unit/readme-onboarding.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import pkg from "../../package.json";
+
+const README_PATH = "README.md";
+const INSTALLATION_GUIDE_PATH = "docs/installation.md";
+
+describe("README onboarding", () => {
+  test("gives curl, Bunx, and npm users executable diagnosis and uninstall commands", () => {
+    const readme = readFileSync(README_PATH, "utf-8");
+
+    expect(readme).toStartWith("# Wolfpack — browser terminal manager for AI coding agents");
+
+    for (const command of [
+      "curl -fsSL https://raw.githubusercontent.com/almogdepaz/wolfpack/main/install.sh | bash",
+      "bunx wolfpack-bridge@latest",
+      "npx --yes wolfpack-bridge@latest",
+      "wolfpack doctor",
+      "wolfpack uninstall --yes",
+      "bunx wolfpack-bridge@latest doctor",
+      "bunx wolfpack-bridge@latest uninstall --yes",
+      "npx --yes wolfpack-bridge@latest doctor",
+      "npx --yes wolfpack-bridge@latest uninstall --yes",
+    ]) expect(readme).toContain(command);
+  });
+
+  test("links a packaged installation guide instead of embedding platform detail", () => {
+    expect(existsSync(INSTALLATION_GUIDE_PATH)).toBe(true);
+    expect(pkg.files).toContain(INSTALLATION_GUIDE_PATH);
+
+    const readme = readFileSync(README_PATH, "utf-8");
+    expect(readme).toContain(INSTALLATION_GUIDE_PATH);
+  });
+});


### PR DESCRIPTION
## summary
- shorten README around the first-success path, trust boundary, and docs map
- add a packaged installation guide for detailed platform, service, verification, and uninstall guidance
- document executable curl, Bunx, and npm/npx doctor and uninstall paths
- add a README documentation regression

## verification
- bun test
- bun run typecheck

closes #280