### PR TITLE
add opaque pi task relay v2

### DIFF
--- a/docs/control-api-schema.md
+++ b/docs/control-api-schema.md
@@ -31,3 +31,11 @@ Compatibility rules:
 `GET /api/discover` remains the legacy `discoverPeers` operation for existing browser clients. Its `{ peers, error? }` envelope contains only candidates whose local `online` fact is `true`, mapped to `{ hostname, url, name }`. It sends `Deprecation: true` and a `Link` successor-version header for `/api/tailnet/v1/candidates`. Both routes preserve the same non-sensitive error when local Tailscale status is malformed or unavailable.
 
 Schema compatibility checks live in `tests/unit/control-api-schema.test.ts`; representative runtime response checks live in integration tests.
+
+## pi tasks relay v2 boundary
+
+`/api/task-relay/v2/*` is the Pi Tasks adapter contract. It preserves the v1 task routes and ledgers; relay v2 is a separate, content-blind transport and does not interpret task payloads or own task lifecycle.
+
+The relay inherits Wolfpack's trusted local processes and trusted Tailnet machines boundary. It does not provide per-Pi-session authorization or per-session relay credentials in v2. Normal Wolfpack HTTP/JWT and Tailnet admission remain the authority for peer requests.
+
+Relay endpoint fields are opaque IDs. A trusted local adapter qualifies a remote relay's local endpoint through `POST /api/task-relay/v2/peer/resolve`; its canonical Tailnet origin is persisted only in the local relay route directory, and the response contains only the opaque peer-qualified endpoint. Peer Tailnet origins never appear in generic Pi Tasks records or endpoint fields. Remote envelopes persist only in the sender's forwarding outbox until the target relay accepts them; the recipient mailbox is created solely by the target relay. Forwarding retries are single-flight per envelope, bounded, durable, and retain exhaustion diagnostics for cleanup.

--- a/docs/generated/control-api.schema.json
+++ b/docs/generated/control-api.schema.json
@@ -30,7 +30,8 @@
     "filesystem containment remains in src/server/validate-project-dir.ts and src/validation.ts",
     "broker wire compatibility remains covered by broker codec/protocol tests, not by this schema",
     "session-open follows ordinary global JWT policy when configured and adds no inter-session authorization layer",
-    "task schema maxLength values are character ceilings; runtime validates UTF-8 byte limits and returns PAYLOAD_TOO_LARGE"
+    "task schema maxLength values are character ceilings; runtime validates UTF-8 byte limits and returns PAYLOAD_TOO_LARGE",
+    "Pi Tasks relay v2 inherits trusted local-process and trusted Tailnet-machine admission; it is content-blind and does not provide per-Pi-session authorization"
   ],
   "http": {
     "getInfo": {
@@ -75,6 +76,311 @@
       },
       "errors": [
         "503 ErrorEnvelope"
+      ]
+    },
+    "connectTaskRelay": {
+      "route": "POST /api/task-relay/v2/connect",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:connectTaskRelay:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "connectTaskRelay request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "generation": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512
+          },
+          "protocolVersions": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "leaseMs": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 300000
+          }
+        },
+        "required": [
+          "callerSession",
+          "generation",
+          "protocolVersions"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:connectTaskRelay:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "connectTaskRelay response",
+        "$ref": "#/$defs/RelayConnectResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "disconnectTaskRelay": {
+      "route": "POST /api/task-relay/v2/disconnect",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:disconnectTaskRelay:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "disconnectTaskRelay request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "endpoint": {
+            "$ref": "#/$defs/RelayEndpoint"
+          }
+        },
+        "required": [
+          "callerSession",
+          "endpoint"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:disconnectTaskRelay:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "disconnectTaskRelay response",
+        "$ref": "#/$defs/RelayEmptyResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "409 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "resolveTaskRelayEndpoint": {
+      "route": "POST /api/task-relay/v2/resolve",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:resolveTaskRelayEndpoint:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "resolveTaskRelayEndpoint request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "target": {
+            "$ref": "#/$defs/RelayEndpoint"
+          },
+          "protocolVersion": {
+            "const": 2
+          }
+        },
+        "required": [
+          "callerSession",
+          "target",
+          "protocolVersion"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:resolveTaskRelayEndpoint:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "resolveTaskRelayEndpoint response",
+        "$ref": "#/$defs/RelayResolveResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "resolvePeerTaskRelayTopology": {
+      "route": "POST /api/task-relay/v2/peer/resolve",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:resolvePeerTaskRelayTopology:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "resolvePeerTaskRelayTopology request",
+        "type": "object",
+        "properties": {
+          "origin": {
+            "$ref": "#/$defs/TailnetOrigin"
+          },
+          "endpoint": {
+            "$ref": "#/$defs/RelayEndpoint"
+          }
+        },
+        "required": [
+          "origin",
+          "endpoint"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:resolvePeerTaskRelayTopology:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "resolvePeerTaskRelayTopology response",
+        "$ref": "#/$defs/RelayResolveResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "sendTaskRelayEnvelope": {
+      "route": "POST /api/task-relay/v2/send",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:sendTaskRelayEnvelope:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "sendTaskRelayEnvelope request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "envelope": {
+            "$ref": "#/$defs/RelayEnvelope"
+          }
+        },
+        "required": [
+          "callerSession",
+          "envelope"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:sendTaskRelayEnvelope:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "sendTaskRelayEnvelope response",
+        "$ref": "#/$defs/RelaySendResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "409 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "413 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "receiveTaskRelayEnvelopes": {
+      "route": "GET /api/task-relay/v2/receive",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "request": {
+        "$id": "wolfpack:control-api:http:receiveTaskRelayEnvelopes:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "receiveTaskRelayEnvelopes request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "cursor": {
+            "type": "string",
+            "pattern": "^(0|[1-9][0-9]*)$"
+          }
+        },
+        "required": [
+          "callerSession",
+          "cursor"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:receiveTaskRelayEnvelopes:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "receiveTaskRelayEnvelopes response",
+        "$ref": "#/$defs/RelayReceiveResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "acknowledgeTaskRelayDelivery": {
+      "route": "POST /api/task-relay/v2/delivery-ack",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:acknowledgeTaskRelayDelivery:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "acknowledgeTaskRelayDelivery request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "envelopeId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512
+          }
+        },
+        "required": [
+          "callerSession",
+          "envelopeId"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:acknowledgeTaskRelayDelivery:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "acknowledgeTaskRelayDelivery response",
+        "$ref": "#/$defs/RelayAcknowledgementResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "receivePeerTaskRelayEnvelope": {
+      "route": "POST /api/task-relay/v2/peer/receive",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:receivePeerTaskRelayEnvelope:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "receivePeerTaskRelayEnvelope request",
+        "$ref": "#/$defs/RelayEnvelope"
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:receivePeerTaskRelayEnvelope:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "receivePeerTaskRelayEnvelope response",
+        "$ref": "#/$defs/RelayPeerReceiveResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "409 RelayErrorEnvelope",
+        "413 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
       ]
     },
     "sendTask": {
@@ -2770,6 +3076,9 @@
         },
         "parentSession": {
           "$ref": "#/$defs/SessionControlIdentity"
+        },
+        "taskEndpoint": {
+          "$ref": "#/$defs/RelayEndpoint"
         }
       },
       "required": [
@@ -2933,6 +3242,304 @@
         "url"
       ],
       "additionalProperties": true
+    },
+    "RelayEndpoint": {
+      "type": "object",
+      "properties": {
+        "relay": {
+          "type": "string",
+          "pattern": "^wolfpack\\-pi\\-tasks\\-v2(?::peer:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})?$"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "required": [
+        "relay",
+        "id"
+      ],
+      "additionalProperties": false,
+      "description": "Opaque local or locally-routed peer endpoint. It never contains a machine name or origin."
+    },
+    "RelayEnvelope": {
+      "type": "object",
+      "properties": {
+        "envelopeId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "protocolVersion": {
+          "const": 2
+        },
+        "source": {
+          "$ref": "#/$defs/RelayEndpoint"
+        },
+        "target": {
+          "$ref": "#/$defs/RelayEndpoint"
+        },
+        "payload": {},
+        "createdAt": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "envelopeId",
+        "protocolVersion",
+        "source",
+        "target",
+        "payload",
+        "createdAt"
+      ],
+      "additionalProperties": false
+    },
+    "RelayErrorEnvelope": {
+      "type": "object",
+      "properties": {
+        "ok": {
+          "const": false
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "enum": [
+                "INVALID_REQUEST",
+                "CALLER_NOT_FOUND",
+                "CALLER_DEAD",
+                "CALLER_NOT_PI",
+                "INCOMPATIBLE_PROTOCOL",
+                "REGISTRATION_EXPIRED",
+                "SOURCE_MISMATCH",
+                "TARGET_NOT_REGISTERED",
+                "CROSS_RELAY_ENDPOINT",
+                "PAYLOAD_TOO_LARGE",
+                "ENVELOPE_CONFLICT",
+                "PEER_UNREACHABLE",
+                "STORE_UNAVAILABLE"
+              ]
+            },
+            "message": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "message",
+            "retryable"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "ok",
+        "error"
+      ],
+      "additionalProperties": false
+    },
+    "RelayConnectResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "endpoint": {
+              "$ref": "#/$defs/RelayEndpoint"
+            },
+            "leaseExpiresAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ok",
+            "endpoint",
+            "leaseExpiresAt"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayResolveResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "endpoint": {
+              "$ref": "#/$defs/RelayEndpoint"
+            }
+          },
+          "required": [
+            "ok",
+            "endpoint"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelaySendResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "kind": {
+              "enum": [
+                "accepted",
+                "duplicate"
+              ]
+            },
+            "acceptanceId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "forwarding": {
+              "enum": [
+                "local",
+                "forwarded",
+                "pending"
+              ]
+            }
+          },
+          "required": [
+            "ok",
+            "kind",
+            "acceptanceId",
+            "forwarding"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayReceiveResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "envelopes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/RelayEnvelope"
+              }
+            },
+            "nextCursor": {
+              "type": "string",
+              "pattern": "^(0|[1-9][0-9]*)$"
+            },
+            "hasMore": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "ok",
+            "envelopes",
+            "nextCursor",
+            "hasMore"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayAcknowledgementResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "kind": {
+              "enum": [
+                "acknowledged",
+                "duplicate"
+              ]
+            }
+          },
+          "required": [
+            "ok",
+            "kind"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayPeerReceiveResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "kind": {
+              "enum": [
+                "accepted",
+                "duplicate"
+              ]
+            },
+            "acceptanceId": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "required": [
+            "ok",
+            "kind",
+            "acceptanceId"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayEmptyResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "ok"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
     },
     "TaskId": {
       "type": "string",

--- a/src/control-api/schema.ts
+++ b/src/control-api/schema.ts
@@ -39,6 +39,7 @@ import {
   TASK_LIMITS,
   TASK_STATUS,
 } from "../tasks/domain.ts";
+import { RELAY_ERROR, RELAY_ID, RELAY_LIMITS, RELAY_PROTOCOL_VERSION } from "../task-relay/domain.ts";
 
 export const CONTROL_API_SCHEMA_VERSION = "1.0.0";
 export const CONTROL_API_SCHEMA_ARTIFACT = "docs/generated/control-api.schema.json";
@@ -142,6 +143,7 @@ const object = (
 
 const ok = object({ ok: boolean() }, ["ok"]);
 const error = ref("ErrorEnvelope");
+const OPAQUE_RELAY_UUID_PATTERN = "[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}";
 
 function taskEventVariant(
   type: string,
@@ -233,6 +235,7 @@ export const controlApiSource: ControlApiSource = {
     "broker wire compatibility remains covered by broker codec/protocol tests, not by this schema",
     "session-open follows ordinary global JWT policy when configured and adds no inter-session authorization layer",
     "task schema maxLength values are character ceilings; runtime validates UTF-8 byte limits and returns PAYLOAD_TOO_LARGE",
+    "Pi Tasks relay v2 inherits trusted local-process and trusted Tailnet-machine admission; it is content-blind and does not provide per-Pi-session authorization",
   ],
   defs: {
     ErrorEnvelope: object({ error: string() }, ["error"], { additionalProperties: true }),
@@ -378,6 +381,7 @@ export const controlApiSource: ControlApiSource = {
       harness: string(),
       terminal: ref("SessionTerminalLiveness"),
       parentSession: ref("SessionControlIdentity"),
+      taskEndpoint: ref("RelayEndpoint"),
     }, [
       "ok",
       "selector",
@@ -431,6 +435,47 @@ export const controlApiSource: ControlApiSource = {
       name: string(),
       url: string(),
     }, ["name", "url"], { additionalProperties: true }),
+    RelayEndpoint: object({
+      relay: { type: "string", pattern: `^${RELAY_ID.replaceAll("-", "\\-")}(?::peer:${OPAQUE_RELAY_UUID_PATTERN})?$` },
+      id: { type: "string", format: "uuid" },
+    }, ["relay", "id"], { description: "Opaque local or locally-routed peer endpoint. It never contains a machine name or origin." }),
+    RelayEnvelope: object({
+      envelopeId: { type: "string", minLength: 1, maxLength: 512 },
+      protocolVersion: { const: RELAY_PROTOCOL_VERSION },
+      source: ref("RelayEndpoint"),
+      target: ref("RelayEndpoint"),
+      payload: {},
+      createdAt: string(),
+    }, ["envelopeId", "protocolVersion", "source", "target", "payload", "createdAt"]),
+    RelayErrorEnvelope: object({
+      ok: { const: false },
+      error: object({ code: { enum: Object.values(RELAY_ERROR) }, message: string(), retryable: boolean() }, ["code", "message", "retryable"]),
+    }, ["ok", "error"]),
+    RelayConnectResponse: { oneOf: [
+      object({ ok: { const: true }, endpoint: ref("RelayEndpoint"), leaseExpiresAt: string() }, ["ok", "endpoint", "leaseExpiresAt"]),
+      ref("RelayErrorEnvelope"),
+    ] },
+    RelayResolveResponse: { oneOf: [
+      object({ ok: { const: true }, endpoint: ref("RelayEndpoint") }, ["ok", "endpoint"]),
+      ref("RelayErrorEnvelope"),
+    ] },
+    RelaySendResponse: { oneOf: [
+      object({ ok: { const: true }, kind: { enum: ["accepted", "duplicate"] }, acceptanceId: { type: "string", format: "uuid" }, forwarding: { enum: ["local", "forwarded", "pending"] } }, ["ok", "kind", "acceptanceId", "forwarding"]),
+      ref("RelayErrorEnvelope"),
+    ] },
+    RelayReceiveResponse: { oneOf: [
+      object({ ok: { const: true }, envelopes: arrayOf(ref("RelayEnvelope")), nextCursor: { type: "string", pattern: "^(0|[1-9][0-9]*)$" }, hasMore: boolean() }, ["ok", "envelopes", "nextCursor", "hasMore"]),
+      ref("RelayErrorEnvelope"),
+    ] },
+    RelayAcknowledgementResponse: { oneOf: [
+      object({ ok: { const: true }, kind: { enum: ["acknowledged", "duplicate"] } }, ["ok", "kind"]),
+      ref("RelayErrorEnvelope"),
+    ] },
+    RelayPeerReceiveResponse: { oneOf: [
+      object({ ok: { const: true }, kind: { enum: ["accepted", "duplicate"] }, acceptanceId: { type: "string", format: "uuid" } }, ["ok", "kind", "acceptanceId"]),
+      ref("RelayErrorEnvelope"),
+    ] },
+    RelayEmptyResponse: { oneOf: [ok, ref("RelayErrorEnvelope")] },
     TaskId: {
       type: "string",
       pattern: "^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
@@ -574,6 +619,82 @@ export const controlApiSource: ControlApiSource = {
       auth: "public",
       response: ref("MachineHandshake"),
       errors: ["503 ErrorEnvelope"],
+    },
+    "POST /api/task-relay/v2/connect": {
+      operationId: "connectTaskRelay",
+      stable: true,
+      auth: "jwt-when-configured",
+      requestContentType: "application/json",
+      request: object({
+        callerSession: ref("SessionSelector"),
+        generation: { type: "string", minLength: 1, maxLength: 512 },
+        protocolVersions: arrayOf({ type: "integer" }),
+        leaseMs: { type: "integer", minimum: 1, maximum: RELAY_LIMITS.MAX_LEASE_MS },
+      }, ["callerSession", "generation", "protocolVersions"]),
+      response: ref("RelayConnectResponse"),
+      errors: ["400 RelayErrorEnvelope", "404 RelayErrorEnvelope", "410 RelayErrorEnvelope", "503 RelayErrorEnvelope"],
+    },
+    "POST /api/task-relay/v2/disconnect": {
+      operationId: "disconnectTaskRelay",
+      stable: true,
+      auth: "jwt-when-configured",
+      requestContentType: "application/json",
+      request: object({ callerSession: ref("SessionSelector"), endpoint: ref("RelayEndpoint") }, ["callerSession", "endpoint"]),
+      response: ref("RelayEmptyResponse"),
+      errors: ["400 RelayErrorEnvelope", "404 RelayErrorEnvelope", "409 RelayErrorEnvelope", "410 RelayErrorEnvelope", "503 RelayErrorEnvelope"],
+    },
+    "POST /api/task-relay/v2/resolve": {
+      operationId: "resolveTaskRelayEndpoint",
+      stable: true,
+      auth: "jwt-when-configured",
+      requestContentType: "application/json",
+      request: object({ callerSession: ref("SessionSelector"), target: ref("RelayEndpoint"), protocolVersion: { const: RELAY_PROTOCOL_VERSION } }, ["callerSession", "target", "protocolVersion"]),
+      response: ref("RelayResolveResponse"),
+      errors: ["400 RelayErrorEnvelope", "404 RelayErrorEnvelope", "410 RelayErrorEnvelope", "503 RelayErrorEnvelope"],
+    },
+    "POST /api/task-relay/v2/peer/resolve": {
+      operationId: "resolvePeerTaskRelayTopology",
+      stable: true,
+      auth: "jwt-when-configured",
+      requestContentType: "application/json",
+      request: object({ origin: ref("TailnetOrigin"), endpoint: ref("RelayEndpoint") }, ["origin", "endpoint"]),
+      response: ref("RelayResolveResponse"),
+      errors: ["400 RelayErrorEnvelope", "503 RelayErrorEnvelope"],
+    },
+    "POST /api/task-relay/v2/send": {
+      operationId: "sendTaskRelayEnvelope",
+      stable: true,
+      auth: "jwt-when-configured",
+      requestContentType: "application/json",
+      request: object({ callerSession: ref("SessionSelector"), envelope: ref("RelayEnvelope") }, ["callerSession", "envelope"]),
+      response: ref("RelaySendResponse"),
+      errors: ["400 RelayErrorEnvelope", "404 RelayErrorEnvelope", "409 RelayErrorEnvelope", "410 RelayErrorEnvelope", "413 RelayErrorEnvelope", "503 RelayErrorEnvelope"],
+    },
+    "GET /api/task-relay/v2/receive": {
+      operationId: "receiveTaskRelayEnvelopes",
+      stable: true,
+      auth: "jwt-when-configured",
+      request: object({ callerSession: ref("SessionSelector"), cursor: { type: "string", pattern: "^(0|[1-9][0-9]*)$" } }, ["callerSession", "cursor"]),
+      response: ref("RelayReceiveResponse"),
+      errors: ["400 RelayErrorEnvelope", "404 RelayErrorEnvelope", "410 RelayErrorEnvelope", "503 RelayErrorEnvelope"],
+    },
+    "POST /api/task-relay/v2/delivery-ack": {
+      operationId: "acknowledgeTaskRelayDelivery",
+      stable: true,
+      auth: "jwt-when-configured",
+      requestContentType: "application/json",
+      request: object({ callerSession: ref("SessionSelector"), envelopeId: { type: "string", minLength: 1, maxLength: 512 } }, ["callerSession", "envelopeId"]),
+      response: ref("RelayAcknowledgementResponse"),
+      errors: ["400 RelayErrorEnvelope", "404 RelayErrorEnvelope", "410 RelayErrorEnvelope", "503 RelayErrorEnvelope"],
+    },
+    "POST /api/task-relay/v2/peer/receive": {
+      operationId: "receivePeerTaskRelayEnvelope",
+      stable: true,
+      auth: "jwt-when-configured",
+      requestContentType: "application/json",
+      request: ref("RelayEnvelope"),
+      response: ref("RelayPeerReceiveResponse"),
+      errors: ["400 RelayErrorEnvelope", "404 RelayErrorEnvelope", "409 RelayErrorEnvelope", "413 RelayErrorEnvelope", "503 RelayErrorEnvelope"],
     },
     "POST /api/tasks/v1/send": {
       operationId: "sendTask",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -16,6 +16,7 @@ import { SHELL } from "./shell.js";
 import { initBackend, getBackend, getRouter } from "./backend.js";
 import { routes } from "./routes.js";
 import { getTaskGateway } from "../tasks/gateway.ts";
+import { getTaskRelayGateway } from "../task-relay/gateway.ts";
 import {
   startSessionNotificationObserver,
   stopSessionNotificationObserver,
@@ -244,9 +245,14 @@ export async function startServer(port = PORT, host = "127.0.0.1"): Promise<void
   }
 
   await getTaskGateway().initialize();
+  const taskRelay = getTaskRelayGateway();
+  await taskRelay.initialize();
   getBackend().cleanupOrphans();
   startSessionNotificationObserver();
-  server.once("close", stopSessionNotificationObserver);
+  server.once("close", () => {
+    taskRelay.close();
+    stopSessionNotificationObserver();
+  });
 
   server.on("error", (err: NodeJS.ErrnoException) => {
     if (err.code === "EADDRINUSE") {

--- a/src/server/routes.ts
+++ b/src/server/routes.ts
@@ -132,6 +132,9 @@ import { createTopLevelSession } from "./session-create.js";
 import { resolveSessionSelector } from "./session-selector.js";
 import type { SessionSelectorResult } from "./session-selector.js";
 import { taskRoutes } from "./task-routes.ts";
+import { taskRelayRoutes } from "./task-relay-routes.ts";
+import { getTaskRelayGateway } from "../task-relay/gateway.ts";
+import type { RelayEndpoint } from "../task-relay/domain.ts";
 import { getTaskGateway } from "../tasks/gateway.ts";
 
 const SESSION_OPEN_INVALID_BODY_RESPONSE = {
@@ -347,7 +350,7 @@ function sessionTerminalLiveness(name: string): SessionTerminalLiveness {
   };
 }
 
-function sessionStatusPayload(name: string, identity: PublicSessionIdentity, selector: string = name) {
+function sessionStatusPayload(name: string, identity: PublicSessionIdentity, taskEndpoint: RelayEndpoint | undefined, selector: string = name) {
   const terminal = sessionTerminalLiveness(name);
   return {
     ok: true as const,
@@ -366,12 +369,13 @@ function sessionStatusPayload(name: string, identity: PublicSessionIdentity, sel
         sessionId: identity.parentSession.wolfpackSessionId,
       },
     }),
+    ...(taskEndpoint && { taskEndpoint }),
   };
 }
 
 type SuccessfulSessionInspection = Extract<SessionInspectionResult, { readonly ok: true }>;
 
-function inspectedSessionStatusPayload(selector: string, inspection: SuccessfulSessionInspection) {
+function inspectedSessionStatusPayload(selector: string, inspection: SuccessfulSessionInspection, taskEndpoint: RelayEndpoint | undefined) {
   const terminal: SessionTerminalLiveness = {
     exists: true,
     alive: inspection.alive,
@@ -389,6 +393,7 @@ function inspectedSessionStatusPayload(selector: string, inspection: SuccessfulS
     harness: inspection.harness,
     terminal,
     ...(inspection.parentSession && { parentSession: inspection.parentSession }),
+    ...(taskEndpoint && { taskEndpoint }),
   };
 }
 
@@ -978,9 +983,10 @@ export const routes: Record<
       if (!identities || names.some(name => !identities[name])) {
         return json(res, { error: "session identity unavailable" }, 503);
       }
-      const sessions = names
-        .map(name => sessionStatusPayload(name, identities[name]!))
-        .sort((left, right) => left.session.localeCompare(right.session));
+      const sessions = (await Promise.all(names.map(async (name) => {
+        const identity = identities[name]!;
+        return sessionStatusPayload(name, identity, await getTaskRelayGateway().endpointForSession(identity.wolfpackSessionId));
+      }))).sort((left, right) => left.session.localeCompare(right.session));
       json(res, { sessions });
     } catch (error: unknown) {
       log.warn("session-control list failed", { error: errMsg(error) });
@@ -1021,7 +1027,7 @@ export const routes: Record<
           ambiguous ? 409 : 404,
         );
       }
-      const status = inspectedSessionStatusPayload(selector, inspection);
+      const status = inspectedSessionStatusPayload(selector, inspection, await getTaskRelayGateway().endpointForSession(inspection.sessionId));
       if (!inspection.alive) {
         return json(
           res,
@@ -1303,6 +1309,7 @@ export const routes: Record<
   // ── Agent-triggered notifications ──
 
   ...taskRoutes,
+  ...taskRelayRoutes,
 
   "POST /api/notify": async (req, res) => {
     const body = await parseObjectBody(req, res);

--- a/src/server/task-relay-routes.ts
+++ b/src/server/task-relay-routes.ts
@@ -1,0 +1,117 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { RELAY_ERROR, RELAY_LIMITS } from "../task-relay/domain.ts";
+import type { RelayEndpoint, RelayResult } from "../task-relay/domain.ts";
+import { getTaskRelayGateway } from "../task-relay/gateway.ts";
+import { json, parseBody } from "./http.ts";
+
+type Handler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+type Body = Record<string, unknown>;
+
+function object(value: unknown): value is Body {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function endpoint(value: unknown): value is RelayEndpoint {
+  return object(value) && typeof value.relay === "string" && value.relay.length > 0 && typeof value.id === "string" && value.id.length > 0;
+}
+
+function only(body: Body, keys: readonly string[]): boolean {
+  return Object.keys(body).every((key) => keys.includes(key));
+}
+
+function response(res: ServerResponse, value: RelayResult<object>): void {
+  if (value.ok) return json(res, value);
+  const status = value.error.code === RELAY_ERROR.CALLER_NOT_FOUND || value.error.code === RELAY_ERROR.TARGET_NOT_REGISTERED ? 404
+    : value.error.code === RELAY_ERROR.CALLER_DEAD || value.error.code === RELAY_ERROR.REGISTRATION_EXPIRED ? 410
+      : value.error.code === RELAY_ERROR.PAYLOAD_TOO_LARGE ? 413
+        : value.error.code === RELAY_ERROR.STORE_UNAVAILABLE || value.error.code === RELAY_ERROR.PEER_UNREACHABLE ? 503
+          : value.error.code === RELAY_ERROR.SOURCE_MISMATCH || value.error.code === RELAY_ERROR.ENVELOPE_CONFLICT ? 409 : 400;
+  json(res, value, status);
+}
+
+async function relayBody(req: IncomingMessage, res: ServerResponse): Promise<Body | undefined> {
+  if (typeof req.headers["content-type"] !== "string" || !req.headers["content-type"].toLowerCase().startsWith("application/json")) {
+    json(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "relay routes require application/json", retryable: false } }, 400);
+    return undefined;
+  }
+  const body = await parseBody(req, res, {
+    maxBytes: RELAY_LIMITS.HTTP_BODY_BYTES,
+    respondOnTooLarge: true,
+    invalidResponse: { envelope: { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "invalid relay JSON", retryable: false } }, status: 400 },
+    tooLargeResponse: { envelope: { ok: false, error: { code: RELAY_ERROR.PAYLOAD_TOO_LARGE, message: "relay request body exceeds limit", retryable: false } }, status: 413 },
+  });
+  if (!object(body)) {
+    if (body !== undefined) json(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "relay request body must be an object", retryable: false } }, 400);
+    return undefined;
+  }
+  return body;
+}
+
+export const taskRelayRoutes: Record<string, Handler> = {
+  "POST /api/task-relay/v2/connect": async (req, res) => {
+    const body = await relayBody(req, res);
+    if (!body) return;
+    if (!only(body, ["callerSession", "generation", "protocolVersions", "leaseMs"]) || typeof body.callerSession !== "string" || typeof body.generation !== "string"
+      || !Array.isArray(body.protocolVersions) || !body.protocolVersions.every(Number.isInteger) || (body.leaseMs !== undefined && typeof body.leaseMs !== "number")) {
+      return response(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "invalid relay registration", retryable: false } });
+    }
+    response(res, await getTaskRelayGateway().connect({ callerSession: body.callerSession, generation: body.generation, protocolVersions: body.protocolVersions, leaseMs: body.leaseMs as number | undefined }));
+  },
+  "POST /api/task-relay/v2/disconnect": async (req, res) => {
+    const body = await relayBody(req, res);
+    if (!body) return;
+    if (!only(body, ["callerSession", "endpoint"]) || typeof body.callerSession !== "string" || !endpoint(body.endpoint)) {
+      return response(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "invalid relay disconnect", retryable: false } });
+    }
+    response(res, await getTaskRelayGateway().disconnect({ callerSession: body.callerSession, endpoint: body.endpoint }));
+  },
+  "POST /api/task-relay/v2/resolve": async (req, res) => {
+    const body = await relayBody(req, res);
+    if (!body) return;
+    if (!only(body, ["callerSession", "target", "protocolVersion"]) || typeof body.callerSession !== "string" || !endpoint(body.target) || typeof body.protocolVersion !== "number") {
+      return response(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "invalid relay resolve request", retryable: false } });
+    }
+    response(res, await getTaskRelayGateway().resolve({ callerSession: body.callerSession, target: body.target, protocolVersion: body.protocolVersion }));
+  },
+  "POST /api/task-relay/v2/send": async (req, res) => {
+    const body = await relayBody(req, res);
+    if (!body) return;
+    if (!only(body, ["callerSession", "envelope"]) || typeof body.callerSession !== "string" || !object(body.envelope)) {
+      return response(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "invalid relay send request", retryable: false } });
+    }
+    response(res, await getTaskRelayGateway().send({ callerSession: body.callerSession, envelope: body.envelope as never }));
+  },
+  "GET /api/task-relay/v2/receive": async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const callerSession = url.searchParams.get("callerSession");
+    const cursor = url.searchParams.get("cursor");
+    if (!callerSession || !cursor || [...url.searchParams.keys()].some((key) => key !== "callerSession" && key !== "cursor")) {
+      return response(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "invalid relay receive query", retryable: false } });
+    }
+    response(res, await getTaskRelayGateway().receive({ callerSession, cursor }));
+  },
+  "POST /api/task-relay/v2/delivery-ack": async (req, res) => {
+    const body = await relayBody(req, res);
+    if (!body) return;
+    if (!only(body, ["callerSession", "envelopeId"]) || typeof body.callerSession !== "string" || typeof body.envelopeId !== "string") {
+      return response(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "invalid relay acknowledgement", retryable: false } });
+    }
+    response(res, await getTaskRelayGateway().acknowledgeDelivery({ callerSession: body.callerSession, envelopeId: body.envelopeId }));
+  },
+  "POST /api/task-relay/v2/peer/resolve": async (req, res) => {
+    const body = await relayBody(req, res);
+    if (!body) return;
+    if (!only(body, ["origin", "endpoint"]) || typeof body.origin !== "string" || !endpoint(body.endpoint)) {
+      return response(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "invalid peer topology request", retryable: false } });
+    }
+    response(res, await getTaskRelayGateway().resolvePeerEndpoint({ origin: body.origin, endpoint: body.endpoint }));
+  },
+  "POST /api/task-relay/v2/peer/receive": async (req, res) => {
+    const body = await relayBody(req, res);
+    if (!body) return;
+    if (!only(body, ["envelopeId", "protocolVersion", "source", "target", "payload", "createdAt"])) {
+      return response(res, { ok: false, error: { code: RELAY_ERROR.INVALID_REQUEST, message: "invalid peer relay envelope", retryable: false } });
+    }
+    response(res, await getTaskRelayGateway().receivePeer(body));
+  },
+};

--- a/src/task-relay/domain.ts
+++ b/src/task-relay/domain.ts
@@ -1,0 +1,77 @@
+export const RELAY_ID = "wolfpack-pi-tasks-v2";
+export const RELAY_PROTOCOL_VERSION = 2;
+
+export const RELAY_LIMITS = {
+  HTTP_BODY_BYTES: 64 * 1024,
+  PAYLOAD_BYTES: 48 * 1024,
+  INBOX_PAGE_ITEMS: 50,
+  INBOX_PAGE_BYTES: 256 * 1024,
+  LEASE_MS: 60_000,
+  MAX_LEASE_MS: 5 * 60_000,
+  MAX_FORWARD_ATTEMPTS: 4,
+  FORWARD_RETRY_MS: 1_000,
+} as const;
+
+export const RELAY_ERROR = {
+  INVALID_REQUEST: "INVALID_REQUEST",
+  CALLER_NOT_FOUND: "CALLER_NOT_FOUND",
+  CALLER_DEAD: "CALLER_DEAD",
+  CALLER_NOT_PI: "CALLER_NOT_PI",
+  INCOMPATIBLE_PROTOCOL: "INCOMPATIBLE_PROTOCOL",
+  REGISTRATION_EXPIRED: "REGISTRATION_EXPIRED",
+  SOURCE_MISMATCH: "SOURCE_MISMATCH",
+  TARGET_NOT_REGISTERED: "TARGET_NOT_REGISTERED",
+  CROSS_RELAY_ENDPOINT: "CROSS_RELAY_ENDPOINT",
+  PAYLOAD_TOO_LARGE: "PAYLOAD_TOO_LARGE",
+  ENVELOPE_CONFLICT: "ENVELOPE_CONFLICT",
+  PEER_UNREACHABLE: "PEER_UNREACHABLE",
+  STORE_UNAVAILABLE: "STORE_UNAVAILABLE",
+} as const;
+
+export type RelayErrorCode = (typeof RELAY_ERROR)[keyof typeof RELAY_ERROR];
+
+export interface RelayEndpoint {
+  readonly relay: string;
+  readonly id: string;
+}
+
+export interface RelayEnvelope {
+  readonly envelopeId: string;
+  readonly protocolVersion: number;
+  readonly source: RelayEndpoint;
+  readonly target: RelayEndpoint;
+  /** Relay content is deliberately only JSON data. No task fields are interpreted. */
+  readonly payload: unknown;
+  readonly createdAt: string;
+}
+
+export interface RelayRegistration {
+  readonly endpoint: RelayEndpoint;
+  readonly sessionId: string;
+  readonly generation: string;
+  readonly protocolVersions: readonly number[];
+  readonly leaseExpiresAt: string;
+}
+
+export interface RelayInboxItem {
+  readonly cursor: string;
+  readonly envelope: RelayEnvelope;
+  readonly acknowledgedAt: string | undefined;
+}
+
+export type RelayResult<T> =
+  | ({ readonly ok: true } & T)
+  | { readonly ok: false; readonly error: { readonly code: RelayErrorCode; readonly message: string; readonly retryable: boolean } };
+
+export function relayFailure(code: RelayErrorCode, message: string, retryable = false): RelayResult<never> {
+  return { ok: false, error: { code, message, retryable } };
+}
+
+export function isLocalRelay(endpoint: RelayEndpoint): boolean {
+  return endpoint.relay === RELAY_ID;
+}
+
+export function encodedJsonBytes(value: unknown): number {
+  const json = JSON.stringify(value);
+  return json === undefined ? 0 : new TextEncoder().encode(json).byteLength;
+}

--- a/src/task-relay/gateway.ts
+++ b/src/task-relay/gateway.ts
@@ -1,0 +1,384 @@
+import { AGENT_KIND } from "../agent-kind.ts";
+import { loadConfig, remoteUrl } from "../cli/config.ts";
+import { getBackend } from "../server/backend.ts";
+import type { SessionInspectionResult } from "../session-status-contract.ts";
+import { canonicalTailnetOrigin } from "../tailnet-machine-contract.ts";
+import {
+  RELAY_ERROR,
+  RELAY_ID,
+  RELAY_LIMITS,
+  RELAY_PROTOCOL_VERSION,
+  encodedJsonBytes,
+  isLocalRelay,
+  relayFailure,
+} from "./domain.ts";
+import type { RelayEndpoint, RelayEnvelope, RelayInboxItem, RelayRegistration, RelayResult } from "./domain.ts";
+import { TaskRelayStore, newOpaqueEndpoint } from "./store.ts";
+import type { PeerOutboxItem } from "./store.ts";
+
+type PeerFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+type Inspection = Extract<SessionInspectionResult, { readonly ok: true }>;
+type RetryTimer = ReturnType<typeof setInterval>;
+
+interface GatewayOptions {
+  readonly root: string | undefined;
+  readonly now?: () => Date;
+  readonly peerOrigin?: string;
+  readonly peerFetch?: PeerFetch;
+  readonly inspectSession?: (selector: string) => Promise<SessionInspectionResult>;
+  readonly retryIntervalMs?: number;
+}
+
+interface ConnectInput {
+  readonly callerSession: string;
+  readonly generation: string;
+  readonly protocolVersions: readonly number[];
+  readonly leaseMs?: number;
+}
+
+function nonEmpty(value: unknown, maximum = 512): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= maximum;
+}
+
+const OPAQUE_ENDPOINT_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PEER_RELAY_ID = new RegExp(`^${RELAY_ID}:peer:${OPAQUE_ENDPOINT_ID.source.slice(1, -1)}$`);
+
+function validEndpoint(value: unknown): value is RelayEndpoint {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    && nonEmpty((value as Record<string, unknown>).relay) && typeof (value as Record<string, unknown>).id === "string"
+    && OPAQUE_ENDPOINT_ID.test((value as Record<string, unknown>).id as string);
+}
+
+function validEnvelope(value: unknown): value is RelayEnvelope {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const envelope = value as Record<string, unknown>;
+  return nonEmpty(envelope.envelopeId) && typeof envelope.protocolVersion === "number" && validEndpoint(envelope.source)
+    && validEndpoint(envelope.target) && typeof envelope.createdAt === "string" && envelope.payload !== undefined;
+}
+
+function validPeerRelay(value: string): boolean {
+  return PEER_RELAY_ID.test(value);
+}
+
+export class TaskRelayGateway {
+  readonly #store: TaskRelayStore;
+  readonly #now: () => Date;
+  readonly #peerOrigin: string | undefined;
+  readonly #peerFetch: PeerFetch;
+  readonly #inspectSession: (selector: string) => Promise<SessionInspectionResult>;
+  readonly #retryIntervalMs: number;
+  #retryTimer: RetryTimer | undefined;
+  #initialization: Promise<void> | undefined;
+  readonly #forwarding = new Map<string, Promise<boolean>>();
+
+  constructor(options: GatewayOptions = { root: undefined }) {
+    this.#store = new TaskRelayStore(options.root);
+    this.#now = options.now ?? (() => new Date());
+    this.#peerOrigin = options.peerOrigin;
+    this.#peerFetch = options.peerFetch ?? fetch;
+    this.#inspectSession = options.inspectSession ?? (async (selector) => {
+      const inspect = getBackend().inspectSession;
+      return inspect ? inspect.call(getBackend(), selector) : { ok: false, code: "NOT_FOUND" };
+    });
+    this.#retryIntervalMs = options.retryIntervalMs ?? RELAY_LIMITS.FORWARD_RETRY_MS;
+  }
+
+  get root(): string {
+    return this.#store.root;
+  }
+
+  /** Starts restart recovery and bounded background retry for durable peer outbox records. */
+  async initialize(): Promise<void> {
+    this.#initialization ??= (async () => {
+      try {
+        await this.flushPeerOutbox(true);
+      } finally {
+        this.#retryTimer ??= setInterval(() => {
+          void this.flushPeerOutbox().catch(() => undefined);
+        }, this.#retryIntervalMs);
+        this.#retryTimer.unref?.();
+      }
+    })();
+    await this.#initialization;
+  }
+
+  close(): void {
+    if (this.#retryTimer) clearInterval(this.#retryTimer);
+    this.#retryTimer = undefined;
+    this.#initialization = undefined;
+  }
+
+  async peerRelay(origin: string): Promise<string> {
+    let url: URL;
+    try { url = new URL(origin); } catch { throw new TypeError("peer relay origin must be a canonical Tailnet HTTPS origin"); }
+    const canonicalOrigin = canonicalTailnetOrigin(url.hostname);
+    if (url.protocol !== "https:" || url.origin !== origin || url.pathname !== "/" || url.search !== "" || url.hash !== "" || canonicalOrigin !== origin) {
+      throw new TypeError("peer relay origin must be a canonical Tailnet HTTPS origin");
+    }
+    return (await this.#store.peerRoute(origin)).id;
+  }
+
+  async resolvePeerEndpoint(input: { readonly origin: string; readonly endpoint: RelayEndpoint }): Promise<RelayResult<{ readonly endpoint: RelayEndpoint }>> {
+    if (!validEndpoint(input.endpoint) || !isLocalRelay(input.endpoint)) {
+      return relayFailure(RELAY_ERROR.INVALID_REQUEST, "peer topology requires a local opaque endpoint");
+    }
+    try {
+      return { ok: true, endpoint: { relay: await this.peerRelay(input.origin), id: input.endpoint.id } };
+    } catch {
+      return relayFailure(RELAY_ERROR.INVALID_REQUEST, "peer relay origin must be a canonical Tailnet HTTPS origin");
+    }
+  }
+
+  async connect(input: ConnectInput): Promise<RelayResult<{ readonly endpoint: RelayEndpoint; readonly leaseExpiresAt: string }>> {
+    if (!nonEmpty(input.callerSession) || !nonEmpty(input.generation) || !Array.isArray(input.protocolVersions)
+      || input.protocolVersions.length === 0 || !input.protocolVersions.every(Number.isInteger)) {
+      return relayFailure(RELAY_ERROR.INVALID_REQUEST, "invalid relay registration");
+    }
+    if (!input.protocolVersions.includes(RELAY_PROTOCOL_VERSION)) {
+      return relayFailure(RELAY_ERROR.INCOMPATIBLE_PROTOCOL, "relay does not support a requested protocol version");
+    }
+    const caller = await this.#caller(input.callerSession);
+    if (!caller.ok) return caller;
+    const existing = await this.#store.registrationForSession(caller.value.sessionId, this.#now());
+    const leaseMs = input.leaseMs ?? RELAY_LIMITS.LEASE_MS;
+    if (!Number.isInteger(leaseMs) || leaseMs < 1 || leaseMs > RELAY_LIMITS.MAX_LEASE_MS) {
+      return relayFailure(RELAY_ERROR.INVALID_REQUEST, "invalid registration lease");
+    }
+    const registration: RelayRegistration = {
+      endpoint: existing?.generation === input.generation ? existing.endpoint : newOpaqueEndpoint(),
+      sessionId: caller.value.sessionId,
+      generation: input.generation,
+      protocolVersions: [...new Set(input.protocolVersions)].sort((left, right) => left - right),
+      leaseExpiresAt: new Date(this.#now().getTime() + leaseMs).toISOString(),
+    };
+    await this.#store.register(registration);
+    return { ok: true, endpoint: registration.endpoint, leaseExpiresAt: registration.leaseExpiresAt };
+  }
+
+  async endpointForSession(sessionId: string): Promise<RelayEndpoint | undefined> {
+    return (await this.#store.registrationForSession(sessionId, this.#now()))?.endpoint;
+  }
+
+  async disconnect(input: { readonly callerSession: string; readonly endpoint: RelayEndpoint }): Promise<RelayResult<Record<never, never>>> {
+    if (!validEndpoint(input.endpoint)) return relayFailure(RELAY_ERROR.INVALID_REQUEST, "invalid relay endpoint");
+    const caller = await this.#caller(input.callerSession);
+    if (!caller.ok) return caller;
+    const registration = await this.#store.registration(input.endpoint.id, this.#now());
+    if (!registration || registration.sessionId !== caller.value.sessionId || !isLocalRelay(input.endpoint)) {
+      return relayFailure(RELAY_ERROR.SOURCE_MISMATCH, "caller does not own relay endpoint");
+    }
+    await this.#store.unregister(caller.value.sessionId, input.endpoint.id);
+    return { ok: true };
+  }
+
+  async resolve(input: { readonly callerSession: string; readonly target: RelayEndpoint; readonly protocolVersion: number }): Promise<RelayResult<{ readonly endpoint: RelayEndpoint }>> {
+    const caller = await this.#caller(input.callerSession);
+    if (!caller.ok) return caller;
+    if (!validEndpoint(input.target) || input.protocolVersion !== RELAY_PROTOCOL_VERSION) {
+      return relayFailure(RELAY_ERROR.INCOMPATIBLE_PROTOCOL, "invalid or incompatible relay target");
+    }
+    if (!isLocalRelay(input.target)) {
+      if (!validPeerRelay(input.target.relay) || await this.#store.peerOrigin(input.target.relay) === undefined) {
+        return relayFailure(RELAY_ERROR.CROSS_RELAY_ENDPOINT, "endpoint belongs to another relay");
+      }
+      return { ok: true, endpoint: input.target };
+    }
+    const target = await this.#store.registration(input.target.id, this.#now());
+    if (!target || !target.protocolVersions.includes(input.protocolVersion)) {
+      return relayFailure(RELAY_ERROR.TARGET_NOT_REGISTERED, "target endpoint is not actively registered");
+    }
+    return { ok: true, endpoint: target.endpoint };
+  }
+
+  async send(input: { readonly callerSession: string; readonly envelope: RelayEnvelope }): Promise<RelayResult<{ readonly kind: "accepted" | "duplicate"; readonly acceptanceId: string; readonly forwarding: "local" | "forwarded" | "pending" }>> {
+    if (!validEnvelope(input.envelope)) return relayFailure(RELAY_ERROR.INVALID_REQUEST, "invalid relay envelope");
+    if (input.envelope.protocolVersion !== RELAY_PROTOCOL_VERSION) return relayFailure(RELAY_ERROR.INCOMPATIBLE_PROTOCOL, "unsupported envelope protocol version");
+    if (encodedJsonBytes(input.envelope.payload) > RELAY_LIMITS.PAYLOAD_BYTES) return relayFailure(RELAY_ERROR.PAYLOAD_TOO_LARGE, "relay payload exceeds byte limit");
+    const caller = await this.#caller(input.callerSession);
+    if (!caller.ok) return caller;
+    const source = await this.#store.registration(input.envelope.source.id, this.#now());
+    if (!source) return relayFailure(RELAY_ERROR.REGISTRATION_EXPIRED, "source endpoint registration is absent or expired");
+    if (source.sessionId !== caller.value.sessionId || source.generation.length === 0 || !isLocalRelay(input.envelope.source)) {
+      return relayFailure(RELAY_ERROR.SOURCE_MISMATCH, "caller does not own envelope source endpoint");
+    }
+    if (isLocalRelay(input.envelope.target)) {
+      const target = await this.#store.registration(input.envelope.target.id, this.#now());
+      if (!target || !target.protocolVersions.includes(input.envelope.protocolVersion)) {
+        return relayFailure(RELAY_ERROR.TARGET_NOT_REGISTERED, "target endpoint is not actively registered");
+      }
+      const accepted = await this.#store.accept(input.envelope, this.#now().toISOString());
+      if (accepted.kind === "conflict") return relayFailure(RELAY_ERROR.ENVELOPE_CONFLICT, "envelope id conflicts with durable content");
+      return { ok: true, kind: accepted.kind, acceptanceId: accepted.acceptanceId, forwarding: "local" };
+    }
+    if (!validPeerRelay(input.envelope.target.relay)) {
+      return relayFailure(RELAY_ERROR.CROSS_RELAY_ENDPOINT, "target endpoint belongs to another relay");
+    }
+    const peerOrigin = await this.#store.peerOrigin(input.envelope.target.relay);
+    if (!peerOrigin) return relayFailure(RELAY_ERROR.CROSS_RELAY_ENDPOINT, "target endpoint belongs to another relay");
+    const accepted = await this.#store.queuePeer({
+      envelope: input.envelope,
+      peerOrigin,
+      queuedAt: this.#now().toISOString(),
+      attempts: 0,
+      lastAttemptAt: undefined,
+      forwardedAt: undefined,
+      exhaustedAt: undefined,
+      lastError: undefined,
+    });
+    if (accepted.kind === "conflict") return relayFailure(RELAY_ERROR.ENVELOPE_CONFLICT, "envelope id conflicts with durable content");
+    const forwarded = await this.#forwardEnvelope(input.envelope.envelopeId);
+    return { ok: true, kind: accepted.kind, acceptanceId: accepted.acceptanceId, forwarding: forwarded ? "forwarded" : "pending" };
+  }
+
+  async receive(input: { readonly callerSession: string; readonly cursor: string }): Promise<RelayResult<{ readonly envelopes: readonly RelayEnvelope[]; readonly nextCursor: string; readonly hasMore: boolean }>> {
+    if (!/^(0|[1-9][0-9]*)$/.test(input.cursor)) return relayFailure(RELAY_ERROR.INVALID_REQUEST, "invalid relay inbox cursor");
+    const endpoint = await this.#endpointForCaller(input.callerSession);
+    if (!endpoint.ok) return endpoint;
+    const items = await this.#store.inbox(endpoint.endpoint.id, input.cursor);
+    const page: RelayInboxItem[] = [];
+    let bytes = 0;
+    for (const item of items) {
+      const itemBytes = encodedJsonBytes(item.envelope);
+      if (page.length === RELAY_LIMITS.INBOX_PAGE_ITEMS || bytes + itemBytes > RELAY_LIMITS.INBOX_PAGE_BYTES) break;
+      page.push(item);
+      bytes += itemBytes;
+    }
+    return { ok: true, envelopes: page.map((item) => item.envelope), nextCursor: page.at(-1)?.cursor ?? input.cursor, hasMore: page.length < items.length };
+  }
+
+  async acknowledgeDelivery(input: { readonly callerSession: string; readonly envelopeId: string }): Promise<RelayResult<{ readonly kind: "acknowledged" | "duplicate" }>> {
+    if (!nonEmpty(input.envelopeId)) return relayFailure(RELAY_ERROR.INVALID_REQUEST, "invalid relay delivery acknowledgement");
+    const endpoint = await this.#endpointForCaller(input.callerSession);
+    if (!endpoint.ok) return endpoint;
+    const result = await this.#store.acknowledge(endpoint.endpoint.id, input.envelopeId, this.#now().toISOString());
+    if (result === "missing") return relayFailure(RELAY_ERROR.INVALID_REQUEST, "envelope is not in caller mailbox");
+    return { ok: true, kind: result };
+  }
+
+  /** Peer input is admitted by Wolfpack's inherited trusted-Tailnet HTTP policy. */
+  async receivePeer(input: unknown): Promise<RelayResult<{ readonly kind: "accepted" | "duplicate"; readonly acceptanceId: string }>> {
+    if (!validEnvelope(input) || input.protocolVersion !== RELAY_PROTOCOL_VERSION || !isLocalRelay(input.target)
+      || !isLocalRelay(input.source) || encodedJsonBytes(input.payload) > RELAY_LIMITS.PAYLOAD_BYTES) {
+      return relayFailure(RELAY_ERROR.INVALID_REQUEST, "invalid peer relay envelope");
+    }
+    const target = await this.#store.registration(input.target.id, this.#now());
+    if (!target || !target.protocolVersions.includes(input.protocolVersion)) {
+      return relayFailure(RELAY_ERROR.TARGET_NOT_REGISTERED, "peer target endpoint is not actively registered");
+    }
+    const accepted = await this.#store.accept(input, this.#now().toISOString());
+    if (accepted.kind === "conflict") return relayFailure(RELAY_ERROR.ENVELOPE_CONFLICT, "peer envelope id conflicts with durable content");
+    return { ok: true, kind: accepted.kind, acceptanceId: accepted.acceptanceId };
+  }
+
+  async flushPeerOutbox(recoverImmediately = false): Promise<{ readonly forwarded: number; readonly pending: number }> {
+    let forwarded = 0;
+    for (const item of await this.#store.outbox()) {
+      if (item.forwardedAt !== undefined || item.exhaustedAt !== undefined) continue;
+      if (await this.#forwardEnvelope(item.envelope.envelopeId, recoverImmediately)) forwarded += 1;
+    }
+    const pending = (await this.#store.outbox()).filter((item) => item.forwardedAt === undefined && item.exhaustedAt === undefined).length;
+    return { forwarded, pending };
+  }
+
+  async cleanup(before: Date): Promise<number> {
+    return this.#store.cleanup(before);
+  }
+
+  async #forwardEnvelope(envelopeId: string, recoverImmediately = false): Promise<boolean> {
+    const inFlight = this.#forwarding.get(envelopeId);
+    if (inFlight) return inFlight;
+    let forwarding: Promise<boolean>;
+    forwarding = this.#forwardEnvelopeOnce(envelopeId, recoverImmediately).finally(() => {
+      if (this.#forwarding.get(envelopeId) === forwarding) this.#forwarding.delete(envelopeId);
+    });
+    this.#forwarding.set(envelopeId, forwarding);
+    return forwarding;
+  }
+
+  async #forwardEnvelopeOnce(envelopeId: string, recoverImmediately = false): Promise<boolean> {
+    const item = (await this.#store.outbox()).find((candidate) => candidate.envelope.envelopeId === envelopeId);
+    if (!item || item.forwardedAt !== undefined || item.exhaustedAt !== undefined) return item?.forwardedAt !== undefined;
+    if (item.attempts >= RELAY_LIMITS.MAX_FORWARD_ATTEMPTS) {
+      await this.#store.updateOutbox(envelopeId, (current) => current.exhaustedAt === undefined
+        ? { ...current, exhaustedAt: this.#now().toISOString() }
+        : current);
+      return false;
+    }
+    const retryAfter = item.lastAttemptAt === undefined ? undefined : Date.parse(item.lastAttemptAt) + this.#retryIntervalMs;
+    if (!recoverImmediately && retryAfter !== undefined && this.#now().getTime() < retryAfter) return false;
+    const attemptedAt = this.#now().toISOString();
+    const attempts = item.attempts + 1;
+    await this.#store.updateOutbox(envelopeId, (current) => ({ ...current, attempts, lastAttemptAt: attemptedAt }));
+    if (!this.#peerOrigin || canonicalTailnetOrigin(new URL(this.#peerOrigin).hostname) !== this.#peerOrigin) {
+      await this.#store.updateOutbox(envelopeId, (current) => ({
+        ...current,
+        lastError: "local peer origin unavailable",
+        ...(attempts >= RELAY_LIMITS.MAX_FORWARD_ATTEMPTS && { exhaustedAt: this.#now().toISOString() }),
+      }));
+      return false;
+    }
+    try {
+      const response = await this.#peerFetch(`${item.peerOrigin}/api/task-relay/v2/peer/receive`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(this.#peerEnvelope(item)),
+        redirect: "error",
+        signal: AbortSignal.timeout(5_000),
+      });
+      const payload = await response.json() as unknown;
+      if (!response.ok || typeof payload !== "object" || payload === null || (payload as { ok?: unknown }).ok !== true) throw new Error("peer rejected relay envelope");
+      await this.#store.updateOutbox(envelopeId, (current) => ({ ...current, forwardedAt: this.#now().toISOString(), lastError: undefined }));
+      return true;
+    } catch {
+      await this.#store.updateOutbox(envelopeId, (current) => ({
+        ...current,
+        lastError: "peer unavailable",
+        ...(attempts >= RELAY_LIMITS.MAX_FORWARD_ATTEMPTS && { exhaustedAt: this.#now().toISOString() }),
+      }));
+      return false;
+    }
+  }
+
+  #peerEnvelope(item: PeerOutboxItem): RelayEnvelope {
+    return {
+      ...item.envelope,
+      source: { ...item.envelope.source, relay: RELAY_ID },
+      target: { ...item.envelope.target, relay: RELAY_ID },
+    };
+  }
+
+  async #endpointForCaller(callerSession: string): Promise<RelayResult<{ readonly endpoint: RelayEndpoint }>> {
+    const caller = await this.#caller(callerSession);
+    if (!caller.ok) return caller;
+    const registration = await this.#store.registrationForSession(caller.value.sessionId, this.#now());
+    if (!registration) return relayFailure(RELAY_ERROR.REGISTRATION_EXPIRED, "caller has no active relay registration");
+    return { ok: true, endpoint: registration.endpoint };
+  }
+
+  async #caller(selector: string): Promise<RelayResult<{ readonly value: Inspection }>> {
+    if (!nonEmpty(selector)) return relayFailure(RELAY_ERROR.CALLER_NOT_FOUND, "caller session is required");
+    let inspected: SessionInspectionResult;
+    try { inspected = await this.#inspectSession(selector); } catch { return relayFailure(RELAY_ERROR.STORE_UNAVAILABLE, "session inspection is unavailable", true); }
+    if (!inspected.ok) return relayFailure(RELAY_ERROR.CALLER_NOT_FOUND, "caller session was not found");
+    if (!inspected.alive) return relayFailure(RELAY_ERROR.CALLER_DEAD, "caller session is not alive");
+    if (inspected.harness !== AGENT_KIND.PI) return relayFailure(RELAY_ERROR.CALLER_NOT_PI, "caller session is not a Pi endpoint");
+    return { ok: true, value: inspected };
+  }
+}
+
+let singleton: TaskRelayGateway | undefined;
+
+export function getTaskRelayGateway(): TaskRelayGateway {
+  const config = loadConfig();
+  singleton ??= new TaskRelayGateway({
+    root: process.env.WOLFPACK_TASK_RELAY_ROOT,
+    peerOrigin: config ? remoteUrl(config) ?? undefined : undefined,
+  });
+  return singleton;
+}
+
+export function __resetTaskRelayGatewayForTests(): void {
+  if (!process.env.WOLFPACK_TEST) throw new Error("task relay gateway reset is test-only");
+  singleton?.close();
+  singleton = undefined;
+}

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -1,0 +1,255 @@
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync, closeSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { RELAY_ID } from "./domain.ts";
+import type { RelayEndpoint, RelayEnvelope, RelayInboxItem, RelayRegistration } from "./domain.ts";
+
+interface StoredEnvelope {
+  readonly envelope: RelayEnvelope;
+  readonly digest: string;
+  readonly acceptedAt: string;
+  readonly acceptanceId: string;
+}
+
+interface StoredMailboxItem {
+  readonly endpointId: string;
+  readonly envelopeId: string;
+  readonly cursor: string;
+  readonly acknowledgedAt: string | undefined;
+}
+
+export interface PeerRoute {
+  readonly id: string;
+  readonly origin: string;
+}
+
+export interface PeerOutboxItem {
+  readonly envelope: RelayEnvelope;
+  readonly peerOrigin: string;
+  readonly digest: string;
+  readonly acceptanceId: string;
+  readonly queuedAt: string;
+  readonly attempts: number;
+  readonly lastAttemptAt: string | undefined;
+  readonly forwardedAt: string | undefined;
+  readonly exhaustedAt: string | undefined;
+  readonly lastError: string | undefined;
+}
+
+interface RelayState {
+  readonly version: 1;
+  readonly registrations: readonly RelayRegistration[];
+  readonly envelopes: readonly StoredEnvelope[];
+  readonly mailbox: readonly StoredMailboxItem[];
+  readonly peerRoutes: readonly PeerRoute[];
+  readonly outbox: readonly PeerOutboxItem[];
+}
+
+const EMPTY: RelayState = { version: 1, registrations: [], envelopes: [], mailbox: [], peerRoutes: [], outbox: [] };
+const PEER_RELAY_PREFIX = `${RELAY_ID}:peer:`;
+const locks = new Map<string, Promise<void>>();
+
+function canonical(value: unknown): unknown {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("relay records require finite JSON numbers");
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(canonical);
+  if (typeof value === "object") {
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+      .filter(([, child]) => child !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, canonical(child)]));
+  }
+  throw new TypeError("relay records require JSON values");
+}
+
+function digest(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(canonical(value)), "utf8").digest("hex");
+}
+
+function validState(value: unknown): value is Omit<RelayState, "peerRoutes"> & { readonly peerRoutes?: unknown } {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const state = value as Record<string, unknown>;
+  return state.version === 1 && Array.isArray(state.registrations) && Array.isArray(state.envelopes)
+    && Array.isArray(state.mailbox) && Array.isArray(state.outbox)
+    && (state.peerRoutes === undefined || Array.isArray(state.peerRoutes));
+}
+
+function atomicWrite(path: string, state: RelayState): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  const descriptor = openSync(temporary, "w", 0o600);
+  try {
+    writeFileSync(descriptor, JSON.stringify(canonical(state)), "utf8");
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+  renameSync(temporary, path);
+  const directory = openSync(dirname(path), "r");
+  try { fsyncSync(directory); } finally { closeSync(directory); }
+}
+
+async function serialized<T>(path: string, operation: () => Promise<T>): Promise<T> {
+  const previous = (locks.get(path) ?? Promise.resolve()).catch(() => undefined);
+  let release: (() => void) | undefined;
+  const current = new Promise<void>((resolveRelease) => { release = resolveRelease; });
+  const queued = previous.then(() => current);
+  locks.set(path, queued);
+  await previous;
+  try { return await operation(); } finally {
+    release?.();
+    if (locks.get(path) === queued) locks.delete(path);
+  }
+}
+
+export class TaskRelayStore {
+  readonly root: string;
+  readonly path: string;
+
+  constructor(root: string | undefined = undefined) {
+    this.root = resolve(root ?? join(homedir(), ".wolfpack", "pi-tasks-relay-v2"));
+    this.path = join(this.root, "relay-state.json");
+  }
+
+  async register(input: Omit<RelayRegistration, "endpoint" | "leaseExpiresAt"> & { readonly endpoint: RelayEndpoint; readonly leaseExpiresAt: string }): Promise<RelayRegistration> {
+    return this.#mutate((state) => {
+      const existing = state.registrations.find((item) => item.sessionId === input.sessionId && item.generation === input.generation);
+      const registration = existing
+        ? { ...existing, protocolVersions: input.protocolVersions, leaseExpiresAt: input.leaseExpiresAt }
+        : input;
+      return { state: { ...state, registrations: [...state.registrations.filter((item) => item.sessionId !== input.sessionId), registration] }, value: registration };
+    });
+  }
+
+  async registrationForSession(sessionId: string, now: Date): Promise<RelayRegistration | undefined> {
+    return this.#read().registrations.find((item) => item.sessionId === sessionId && Date.parse(item.leaseExpiresAt) > now.getTime());
+  }
+
+  async registration(endpointId: string, now: Date): Promise<RelayRegistration | undefined> {
+    return this.#read().registrations.find((item) => item.endpoint.id === endpointId && Date.parse(item.leaseExpiresAt) > now.getTime());
+  }
+
+  async unregister(sessionId: string, endpointId: string): Promise<boolean> {
+    return this.#mutate((state) => {
+      const registration = state.registrations.find((item) => item.sessionId === sessionId && item.endpoint.id === endpointId);
+      return {
+        state: registration ? { ...state, registrations: state.registrations.filter((item) => item !== registration) } : state,
+        value: registration !== undefined,
+      };
+    });
+  }
+
+  async accept(envelope: RelayEnvelope, acceptedAt: string): Promise<{ readonly kind: "accepted" | "duplicate" | "conflict"; readonly acceptanceId: string }> {
+    return this.#mutate<{ readonly kind: "accepted" | "duplicate" | "conflict"; readonly acceptanceId: string }>((state) => {
+      const existing = state.envelopes.find((item) => item.envelope.envelopeId === envelope.envelopeId);
+      const nextDigest = digest(envelope);
+      if (existing) return { state, value: { kind: existing.digest === nextDigest ? "duplicate" as const : "conflict" as const, acceptanceId: existing.acceptanceId } };
+      const stored: StoredEnvelope = { envelope, digest: nextDigest, acceptedAt, acceptanceId: randomUUID() };
+      const cursor = (state.mailbox.filter((item) => item.endpointId === envelope.target.id)
+        .reduce((maximum, item) => BigInt(item.cursor) > maximum ? BigInt(item.cursor) : maximum, 0n) + 1n).toString();
+      const mailbox: StoredMailboxItem = { endpointId: envelope.target.id, envelopeId: envelope.envelopeId, cursor, acknowledgedAt: undefined };
+      return { state: { ...state, envelopes: [...state.envelopes, stored], mailbox: [...state.mailbox, mailbox] }, value: { kind: "accepted" as const, acceptanceId: stored.acceptanceId } };
+    });
+  }
+
+  async inbox(endpointId: string, cursor: string): Promise<readonly RelayInboxItem[]> {
+    const state = this.#read();
+    const envelopes = new Map(state.envelopes.map((item) => [item.envelope.envelopeId, item.envelope]));
+    return state.mailbox
+      .filter((item) => item.endpointId === endpointId && BigInt(item.cursor) > BigInt(cursor))
+      .sort((left, right) => BigInt(left.cursor) < BigInt(right.cursor) ? -1 : 1)
+      .flatMap((item) => {
+        const envelope = envelopes.get(item.envelopeId);
+        return envelope ? [{ cursor: item.cursor, envelope, acknowledgedAt: item.acknowledgedAt }] : [];
+      });
+  }
+
+  async acknowledge(endpointId: string, envelopeId: string, at: string): Promise<"acknowledged" | "duplicate" | "missing"> {
+    return this.#mutate((state) => {
+      const item = state.mailbox.find((candidate) => candidate.endpointId === endpointId && candidate.envelopeId === envelopeId);
+      if (!item) return { state, value: "missing" as const };
+      if (item.acknowledgedAt !== undefined) return { state, value: "duplicate" as const };
+      return { state: { ...state, mailbox: state.mailbox.map((candidate) => candidate === item ? { ...candidate, acknowledgedAt: at } : candidate) }, value: "acknowledged" as const };
+    });
+  }
+
+  async peerRoute(origin: string): Promise<PeerRoute> {
+    return this.#mutate((state) => {
+      const existing = state.peerRoutes.find((item) => item.origin === origin);
+      if (existing) return { state, value: existing };
+      const route = { id: `${PEER_RELAY_PREFIX}${randomUUID()}`, origin };
+      return { state: { ...state, peerRoutes: [...state.peerRoutes, route] }, value: route };
+    });
+  }
+
+  async peerOrigin(routeId: string): Promise<string | undefined> {
+    return this.#read().peerRoutes.find((item) => item.id === routeId)?.origin;
+  }
+
+  async queuePeer(input: Omit<PeerOutboxItem, "digest" | "acceptanceId">): Promise<{ readonly kind: "accepted" | "duplicate" | "conflict"; readonly acceptanceId: string }> {
+    return this.#mutate<{ readonly kind: "accepted" | "duplicate" | "conflict"; readonly acceptanceId: string }>((state) => {
+      const existing = state.outbox.find((item) => item.envelope.envelopeId === input.envelope.envelopeId);
+      const nextDigest = digest(input.envelope);
+      if (existing) return {
+        state,
+        value: {
+          kind: existing.digest === nextDigest ? "duplicate" as const : "conflict" as const,
+          acceptanceId: existing.acceptanceId,
+        },
+      };
+      const item: PeerOutboxItem = { ...input, digest: nextDigest, acceptanceId: randomUUID() };
+      return { state: { ...state, outbox: [...state.outbox, item] }, value: { kind: "accepted" as const, acceptanceId: item.acceptanceId } };
+    });
+  }
+
+  async outbox(): Promise<readonly PeerOutboxItem[]> {
+    return this.#read().outbox;
+  }
+
+  async updateOutbox(envelopeId: string, update: (item: PeerOutboxItem) => PeerOutboxItem): Promise<void> {
+    await this.#mutate((state) => ({ state: { ...state, outbox: state.outbox.map((item) => item.envelope.envelopeId === envelopeId ? update(item) : item) }, value: undefined }));
+  }
+
+  async cleanup(before: Date): Promise<number> {
+    return this.#mutate((state) => {
+      const retainedMailbox = state.mailbox.filter((item) => item.acknowledgedAt === undefined || Date.parse(item.acknowledgedAt) >= before.getTime());
+      const retainedIds = new Set(retainedMailbox.map((item) => item.envelopeId));
+      const retainedOutbox = state.outbox.filter((item) => {
+        const completedAt = item.forwardedAt ?? item.exhaustedAt;
+        return completedAt === undefined || Date.parse(completedAt) >= before.getTime();
+      });
+      return {
+        state: {
+          ...state,
+          mailbox: retainedMailbox,
+          envelopes: state.envelopes.filter((item) => retainedIds.has(item.envelope.envelopeId)),
+          outbox: retainedOutbox,
+        },
+        value: state.mailbox.length - retainedMailbox.length + state.outbox.length - retainedOutbox.length,
+      };
+    });
+  }
+
+  #read(): RelayState {
+    if (!existsSync(this.path)) return EMPTY;
+    const parsed = JSON.parse(readFileSync(this.path, "utf8")) as unknown;
+    if (!validState(parsed)) throw new TypeError("relay store is malformed");
+    return { ...EMPTY, ...parsed, peerRoutes: Array.isArray(parsed.peerRoutes) ? parsed.peerRoutes as PeerRoute[] : [] };
+  }
+
+  async #mutate<T>(operation: (state: RelayState) => { readonly state: RelayState; readonly value: T }): Promise<T> {
+    return serialized(this.path, async () => {
+      const { state, value } = operation(this.#read());
+      atomicWrite(this.path, state);
+      return value;
+    });
+  }
+}
+
+export function newOpaqueEndpoint(): RelayEndpoint {
+  return { relay: RELAY_ID, id: randomUUID() };
+}

--- a/tests/integration/fixtures/task-gateway-peer-server.ts
+++ b/tests/integration/fixtures/task-gateway-peer-server.ts
@@ -17,6 +17,7 @@ const crashAfterPeerEvent = process.env.WOLFPACK_TEST_CRASH_AFTER_PEER_EVENT;
 const crashBeforePeerEvent = process.env.WOLFPACK_TEST_CRASH_BEFORE_PEER_EVENT;
 const crashBeforePeerEventAttempt = Number(process.env.WOLFPACK_TEST_CRASH_BEFORE_PEER_EVENT_ATTEMPT ?? "0");
 const peerEventResponseDelayMs = Number(process.env.WOLFPACK_TEST_PEER_EVENT_RESPONSE_DELAY_MS ?? "0");
+const taskRelay = process.env.WOLFPACK_TEST_TASK_RELAY === "1";
 if (!Number.isInteger(crashBeforePeerEventAttempt) || crashBeforePeerEventAttempt < 0) throw new Error("peer event crash attempt must be a non-negative integer");
 if (!Number.isInteger(peerEventResponseDelayMs) || peerEventResponseDelayMs < 0) throw new Error("peer event response delay must be a non-negative integer");
 let crashBeforePeerEventCount = 0;
@@ -48,7 +49,10 @@ process.env.WOLFPACK_TEST = "1";
 process.env.WOLFPACK_TAILNET_SUFFIX = "example.ts.net";
 mkdirSync(projectRoot, { recursive: true });
 mkdirSync(join(process.env.HOME ?? "", ".wolfpack"), { recursive: true });
-writeFileSync(join(process.env.HOME ?? "", ".wolfpack", "config.json"), JSON.stringify({ tailscaleHostname: new URL(peerOrigin).hostname }));
+writeFileSync(join(process.env.HOME ?? "", ".wolfpack", "config.json"), JSON.stringify({
+  ...(taskRelay ? { devDir: projectRoot, port: listenPort } : {}),
+  tailscaleHostname: new URL(peerOrigin).hostname,
+}));
 
 const NativeDate = Date;
 if (clockPath) {

--- a/tests/integration/task-gateway.test.ts
+++ b/tests/integration/task-gateway.test.ts
@@ -23,6 +23,7 @@ const { __setTestBackend } = await import("../../src/server/backend.ts");
 const { MockBackend } = await import("../../src/server/mock-backend.ts");
 const { createServerInstance } = await import("../../src/server/index.ts");
 const { TASK_EVENT_TYPE, TASK_LIMITS, hashImmutableAssignment } = await import("../../src/tasks/domain.ts");
+const { RELAY_ID, RELAY_PROTOCOL_VERSION } = await import("../../src/task-relay/domain.ts");
 const { TASK_LEDGER_ROLE, TaskStore } = await import("../../src/tasks/store.ts");
 const { TaskGateway, __resetTaskGatewayForTests } = await import("../../src/tasks/gateway.ts");
 
@@ -93,6 +94,7 @@ interface PeerServerOptions {
   readonly crashBeforePeerEvent?: string;
   readonly crashBeforePeerEventAttempt?: number;
   readonly fastRetry?: boolean;
+  readonly taskRelay?: boolean;
 }
 
 async function reservePort(): Promise<number> {
@@ -144,6 +146,7 @@ async function spawnPeerServer(options: PeerServerOptions): Promise<PeerServer> 
       WOLFPACK_TEST_CRASH_BEFORE_PEER_EVENT: options.crashBeforePeerEvent ?? "",
       WOLFPACK_TEST_CRASH_BEFORE_PEER_EVENT_ATTEMPT: String(options.crashBeforePeerEventAttempt ?? 0),
       WOLFPACK_TEST_FAST_RETRY: options.fastRetry ? "1" : "",
+      WOLFPACK_TEST_TASK_RELAY: options.taskRelay ? "1" : "",
       WOLFPACK_TEST_LISTEN_PORT: String(options.port),
       WOLFPACK_TEST_PEER_MAP: options.peerMapPath,
       WOLFPACK_TEST_PEER_ORIGIN: options.peerOrigin,
@@ -356,6 +359,10 @@ function peerServerOptions(
   };
 }
 
+function taskRelayPeerServerOptions(fixture: HttpPeerFixture, role: "sender" | "receiver"): PeerServerOptions {
+  return { ...peerServerOptions(fixture, role), taskRelay: true };
+}
+
 function peerDispatches(fixture: HttpPeerFixture): readonly Record<string, unknown>[] {
   if (!existsSync(fixture.dispatchLogPath)) return [];
   const text = readFileSync(fixture.dispatchLogPath, "utf8").trim();
@@ -395,6 +402,64 @@ function remoteSendInput(task: string, timeoutMs: number | undefined = undefined
 }
 
 describe("cross-process peer task gateway", () => {
+  test("resolves and forwards opaque relay endpoints through two isolated HTTP servers", async () => {
+    const fixture = await createHttpPeerFixture("relay-topology");
+    let sender: PeerServer | undefined;
+    let receiver: PeerServer | undefined;
+    try {
+      receiver = await spawnPeerServer(taskRelayPeerServerOptions(fixture, "receiver"));
+      sender = await spawnPeerServer(taskRelayPeerServerOptions(fixture, "sender"));
+      const receiverConnect = await postPeerRequest(receiver.base, "/api/task-relay/v2/connect", {
+        callerSession: "receiver",
+        generation: "receiver-process",
+        protocolVersions: [RELAY_PROTOCOL_VERSION],
+      });
+      const receiverEndpoint = await receiverConnect.json() as { readonly endpoint: { readonly relay: string; readonly id: string } };
+      const senderConnect = await postPeerRequest(sender.base, "/api/task-relay/v2/connect", {
+        callerSession: "parent",
+        generation: "sender-process",
+        protocolVersions: [RELAY_PROTOCOL_VERSION],
+      });
+      const senderEndpoint = await senderConnect.json() as { readonly endpoint: { readonly relay: string; readonly id: string } };
+      const topology = await postPeerRequest(sender.base, "/api/task-relay/v2/peer/resolve", {
+        origin: fixture.receiverOrigin,
+        endpoint: receiverEndpoint.endpoint,
+      });
+      const target = await topology.json() as { readonly endpoint: { readonly relay: string; readonly id: string } };
+
+      expect(receiverConnect.status).toBe(200);
+      expect(senderConnect.status).toBe(200);
+      expect(topology.status).toBe(200);
+      expect(target.endpoint).toMatchObject({ id: receiverEndpoint.endpoint.id });
+      expect(target.endpoint.relay).toMatch(/^wolfpack-pi-tasks-v2:peer:[0-9a-f-]{36}$/);
+      expect(JSON.stringify(target)).not.toContain(fixture.receiverOrigin);
+      const accepted = await postPeerRequest(sender.base, "/api/task-relay/v2/send", {
+        callerSession: "parent",
+        envelope: {
+          envelopeId: "two-server-relay-envelope",
+          protocolVersion: RELAY_PROTOCOL_VERSION,
+          source: senderEndpoint.endpoint,
+          target: target.endpoint,
+          payload: { opaque: true },
+          createdAt: new Date(0).toISOString(),
+        },
+      });
+      expect(await accepted.json()).toMatchObject({ ok: true, forwarding: "forwarded" });
+      const inbox = await fetch(`${receiver.base}/api/task-relay/v2/receive?callerSession=receiver&cursor=0`);
+      const inboxBody = await inbox.json() as { readonly ok: boolean; readonly envelopes: readonly { readonly envelopeId: string; readonly source: { readonly relay: string }; readonly target: { readonly relay: string; readonly id: string } }[] };
+      expect(inboxBody.ok).toBe(true);
+      expect(inboxBody.envelopes).toHaveLength(1);
+      expect(inboxBody.envelopes[0]).toMatchObject({
+        envelopeId: "two-server-relay-envelope",
+        source: { relay: RELAY_ID },
+        target: receiverEndpoint.endpoint,
+      });
+    } finally {
+      await Promise.all([stopPeerServer(sender), stopPeerServer(receiver)]);
+      rmSync(fixture.root, { recursive: true, force: true });
+    }
+  });
+
   test("routes a canonical remote task lifecycle through two isolated HTTP servers", async () => {
     const fixtureRoot = join(tmpdir(), `wolfpack-task-peer-http-${process.pid}-${Date.now()}`);
     const senderPort = await reservePort();
@@ -632,6 +697,7 @@ describe("cross-process peer task gateway", () => {
     }
   });
 
+  // This lifecycle starts six peer-server processes across crash recovery; keep the deadline above Bun's 5s default.
   test("recovers a pending canonical sender intent after a crash before peer delivery", async () => {
     const fixture = await createHttpPeerFixture("sender-recovery");
     let sender: PeerServer | undefined;
@@ -689,7 +755,7 @@ describe("cross-process peer task gateway", () => {
       await Promise.all([stopPeerServer(sender), stopPeerServer(receiver)]);
       rmSync(fixture.root, { recursive: true, force: true });
     }
-  });
+  }, 20_000);
 
   test("finalizes a four-attempt sender intent after a crash before the delivery failure record", async () => {
     const fixture = await createHttpPeerFixture("sender-exhaustion-finalization");

--- a/tests/integration/task-relay.test.ts
+++ b/tests/integration/task-relay.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.WOLFPACK_TEST = "1";
+const originalHome = process.env.HOME;
+const root = mkdtempSync(join(tmpdir(), "wolfpack-task-relay-http-"));
+process.env.HOME = root;
+process.env.WOLFPACK_TASK_RELAY_ROOT = join(root, "relay");
+mkdirSync(join(root, "project"), { recursive: true });
+mkdirSync(join(root, ".wolfpack"), { recursive: true });
+writeFileSync(join(root, ".wolfpack", "config.json"), JSON.stringify({
+  devDir: join(root, "project"),
+  port: 18790,
+  tailscaleHostname: "sender.example.ts.net",
+}));
+
+const { __setTestBackend } = await import("../../src/server/backend.ts");
+const { MockBackend } = await import("../../src/server/mock-backend.ts");
+const { __resetTaskRelayGatewayForTests, getTaskRelayGateway } = await import("../../src/task-relay/gateway.ts");
+const { RELAY_ID, RELAY_PROTOCOL_VERSION } = await import("../../src/task-relay/domain.ts");
+const { createServerInstance } = await import("../../src/server/index.ts");
+if (originalHome === undefined) delete process.env.HOME;
+else process.env.HOME = originalHome;
+
+class PiBackend extends MockBackend {
+  override async listIdentities() {
+    const now = new Date(0).toISOString();
+    return {
+      sender: { wolfpackSessionId: "sender-id", wolfpackSessionName: "sender", projectPath: join(root, "project"), agentKind: "pi", createdAt: now, updatedAt: now },
+      receiver: { wolfpackSessionId: "receiver-id", wolfpackSessionName: "receiver", projectPath: join(root, "project"), agentKind: "pi", createdAt: now, updatedAt: now },
+    };
+  }
+}
+
+__setTestBackend(new PiBackend({ sessions: ["sender", "receiver"] }));
+__resetTaskRelayGatewayForTests();
+const { server } = createServerInstance();
+let base = "";
+
+beforeAll(async () => {
+  await new Promise<void>((resolve) => (server as Server).listen(0, "127.0.0.1", () => {
+    base = `http://127.0.0.1:${((server as Server).address() as AddressInfo).port}`;
+    resolve();
+  }));
+});
+
+afterAll(() => {
+  (server as Server).close();
+  rmSync(root, { recursive: true, force: true });
+});
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return fetch(`${base}${path}`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+}
+
+describe("task relay v2 routes", () => {
+  test("resolves a trusted peer topology through HTTP into a persisted opaque endpoint", async () => {
+    const remoteEndpoint = { relay: RELAY_ID, id: "2af8af29-c4fe-44f9-9a99-9a0e35952d74" };
+    const resolved = await post("/api/task-relay/v2/peer/resolve", {
+      origin: "https://receiver.example.ts.net",
+      endpoint: remoteEndpoint,
+    });
+
+    expect(resolved.status).toBe(200);
+    const body = await resolved.json() as { readonly ok: boolean; readonly endpoint: { readonly relay: string; readonly id: string } };
+    expect(body).toMatchObject({ ok: true, endpoint: { id: remoteEndpoint.id } });
+    expect(body.endpoint.relay).toMatch(/^wolfpack-pi-tasks-v2:peer:[0-9a-f-]{36}$/);
+    expect(JSON.stringify(body)).not.toContain("receiver.example.ts.net");
+    await expect(getTaskRelayGateway().resolve({ callerSession: "sender", target: body.endpoint, protocolVersion: RELAY_PROTOCOL_VERSION })).resolves.toMatchObject({
+      ok: true,
+      endpoint: body.endpoint,
+    });
+    __resetTaskRelayGatewayForTests();
+  });
+
+  test("uses the production Tailnet origin for opaque remote forwarding", async () => {
+    const systemFetch = globalThis.fetch;
+    let outbound: Record<string, unknown> | undefined;
+    const peerFetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      if (String(input).startsWith("https://receiver.example.ts.net/api/task-relay/v2/peer/receive")) {
+        outbound = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return Response.json({ ok: true });
+      }
+      return systemFetch(input, init);
+    }) as unknown as typeof fetch;
+    globalThis.fetch = peerFetch;
+    try {
+      const senderConnect = await post("/api/task-relay/v2/connect", { callerSession: "sender", generation: "production-process", protocolVersions: [RELAY_PROTOCOL_VERSION] });
+      const sender = await senderConnect.json() as { readonly endpoint: { readonly relay: string; readonly id: string } };
+      const relay = getTaskRelayGateway();
+      const target = { relay: await relay.peerRelay("https://receiver.example.ts.net"), id: "2af8af29-c4fe-44f9-9a99-9a0e35952d74" };
+      expect(target.relay).toMatch(/^wolfpack-pi-tasks-v2:peer:[0-9a-f-]{36}$/);
+
+      const accepted = await post("/api/task-relay/v2/send", {
+        callerSession: "sender",
+        envelope: {
+          envelopeId: "production-remote-envelope", protocolVersion: RELAY_PROTOCOL_VERSION, source: sender.endpoint, target,
+          payload: { content: "opaque" }, createdAt: new Date(0).toISOString(),
+        },
+      });
+      expect(await accepted.json()).toMatchObject({ ok: true, forwarding: "forwarded" });
+      expect(outbound).toMatchObject({ source: { relay: RELAY_ID }, target: { relay: RELAY_ID } });
+      expect(JSON.stringify(outbound)).not.toContain("sender.example.ts.net");
+      expect(JSON.stringify(outbound)).not.toContain("receiver.example.ts.net");
+    } finally {
+      globalThis.fetch = systemFetch;
+    }
+  });
+
+  test("registers opaque Pi endpoints through session inspection and routes an opaque durable mailbox", async () => {
+    const senderConnect = await post("/api/task-relay/v2/connect", { callerSession: "sender", generation: "sender-process", protocolVersions: [RELAY_PROTOCOL_VERSION] });
+    const receiverConnect = await post("/api/task-relay/v2/connect", { callerSession: "receiver", generation: "receiver-process", protocolVersions: [RELAY_PROTOCOL_VERSION] });
+    expect(senderConnect.status).toBe(200);
+    expect(receiverConnect.status).toBe(200);
+    const sender = await senderConnect.json() as { readonly endpoint: { readonly relay: string; readonly id: string } };
+    const receiver = await receiverConnect.json() as { readonly endpoint: { readonly relay: string; readonly id: string } };
+
+    const sessionProjection = await fetch(`${base}/api/session-control/status?session=receiver`);
+    expect(await sessionProjection.json()).toMatchObject({ taskEndpoint: receiver.endpoint });
+    const accepted = await post("/api/task-relay/v2/send", {
+      callerSession: "sender",
+      envelope: {
+        envelopeId: "route-envelope", protocolVersion: RELAY_PROTOCOL_VERSION, source: sender.endpoint, target: receiver.endpoint,
+        payload: { event: "unknown to wolfpack", taskId: "not indexed" }, createdAt: new Date(0).toISOString(),
+      },
+    });
+    expect(accepted.status).toBe(200);
+    expect(await accepted.json()).toMatchObject({ ok: true, forwarding: "local" });
+    const inbox = await fetch(`${base}/api/task-relay/v2/receive?callerSession=receiver&cursor=0`);
+    expect(await inbox.json()).toMatchObject({ envelopes: [expect.objectContaining({ envelopeId: "route-envelope" })] });
+    const acknowledgement = await post("/api/task-relay/v2/delivery-ack", { callerSession: "receiver", envelopeId: "route-envelope" });
+    expect(acknowledgement.status).toBe(200);
+  });
+});

--- a/tests/unit/__snapshots__/control-api-schema.test.ts.snap
+++ b/tests/unit/__snapshots__/control-api-schema.test.ts.snap
@@ -33,7 +33,8 @@ exports[`control api schema generation schema source emits a stable snapshot 1`]
     "filesystem containment remains in src/server/validate-project-dir.ts and src/validation.ts",
     "broker wire compatibility remains covered by broker codec/protocol tests, not by this schema",
     "session-open follows ordinary global JWT policy when configured and adds no inter-session authorization layer",
-    "task schema maxLength values are character ceilings; runtime validates UTF-8 byte limits and returns PAYLOAD_TOO_LARGE"
+    "task schema maxLength values are character ceilings; runtime validates UTF-8 byte limits and returns PAYLOAD_TOO_LARGE",
+    "Pi Tasks relay v2 inherits trusted local-process and trusted Tailnet-machine admission; it is content-blind and does not provide per-Pi-session authorization"
   ],
   "http": {
     "getInfo": {
@@ -78,6 +79,311 @@ exports[`control api schema generation schema source emits a stable snapshot 1`]
       },
       "errors": [
         "503 ErrorEnvelope"
+      ]
+    },
+    "connectTaskRelay": {
+      "route": "POST /api/task-relay/v2/connect",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:connectTaskRelay:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "connectTaskRelay request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "generation": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512
+          },
+          "protocolVersions": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "leaseMs": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 300000
+          }
+        },
+        "required": [
+          "callerSession",
+          "generation",
+          "protocolVersions"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:connectTaskRelay:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "connectTaskRelay response",
+        "$ref": "#/$defs/RelayConnectResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "disconnectTaskRelay": {
+      "route": "POST /api/task-relay/v2/disconnect",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:disconnectTaskRelay:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "disconnectTaskRelay request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "endpoint": {
+            "$ref": "#/$defs/RelayEndpoint"
+          }
+        },
+        "required": [
+          "callerSession",
+          "endpoint"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:disconnectTaskRelay:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "disconnectTaskRelay response",
+        "$ref": "#/$defs/RelayEmptyResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "409 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "resolveTaskRelayEndpoint": {
+      "route": "POST /api/task-relay/v2/resolve",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:resolveTaskRelayEndpoint:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "resolveTaskRelayEndpoint request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "target": {
+            "$ref": "#/$defs/RelayEndpoint"
+          },
+          "protocolVersion": {
+            "const": 2
+          }
+        },
+        "required": [
+          "callerSession",
+          "target",
+          "protocolVersion"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:resolveTaskRelayEndpoint:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "resolveTaskRelayEndpoint response",
+        "$ref": "#/$defs/RelayResolveResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "resolvePeerTaskRelayTopology": {
+      "route": "POST /api/task-relay/v2/peer/resolve",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:resolvePeerTaskRelayTopology:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "resolvePeerTaskRelayTopology request",
+        "type": "object",
+        "properties": {
+          "origin": {
+            "$ref": "#/$defs/TailnetOrigin"
+          },
+          "endpoint": {
+            "$ref": "#/$defs/RelayEndpoint"
+          }
+        },
+        "required": [
+          "origin",
+          "endpoint"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:resolvePeerTaskRelayTopology:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "resolvePeerTaskRelayTopology response",
+        "$ref": "#/$defs/RelayResolveResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "sendTaskRelayEnvelope": {
+      "route": "POST /api/task-relay/v2/send",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:sendTaskRelayEnvelope:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "sendTaskRelayEnvelope request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "envelope": {
+            "$ref": "#/$defs/RelayEnvelope"
+          }
+        },
+        "required": [
+          "callerSession",
+          "envelope"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:sendTaskRelayEnvelope:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "sendTaskRelayEnvelope response",
+        "$ref": "#/$defs/RelaySendResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "409 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "413 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "receiveTaskRelayEnvelopes": {
+      "route": "GET /api/task-relay/v2/receive",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "request": {
+        "$id": "wolfpack:control-api:http:receiveTaskRelayEnvelopes:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "receiveTaskRelayEnvelopes request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "cursor": {
+            "type": "string",
+            "pattern": "^(0|[1-9][0-9]*)$"
+          }
+        },
+        "required": [
+          "callerSession",
+          "cursor"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:receiveTaskRelayEnvelopes:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "receiveTaskRelayEnvelopes response",
+        "$ref": "#/$defs/RelayReceiveResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "acknowledgeTaskRelayDelivery": {
+      "route": "POST /api/task-relay/v2/delivery-ack",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:acknowledgeTaskRelayDelivery:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "acknowledgeTaskRelayDelivery request",
+        "type": "object",
+        "properties": {
+          "callerSession": {
+            "$ref": "#/$defs/SessionSelector"
+          },
+          "envelopeId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512
+          }
+        },
+        "required": [
+          "callerSession",
+          "envelopeId"
+        ],
+        "additionalProperties": false
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:acknowledgeTaskRelayDelivery:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "acknowledgeTaskRelayDelivery response",
+        "$ref": "#/$defs/RelayAcknowledgementResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "410 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
+      ]
+    },
+    "receivePeerTaskRelayEnvelope": {
+      "route": "POST /api/task-relay/v2/peer/receive",
+      "stable": true,
+      "auth": "jwt-when-configured",
+      "requestContentType": "application/json",
+      "request": {
+        "$id": "wolfpack:control-api:http:receivePeerTaskRelayEnvelope:request",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "receivePeerTaskRelayEnvelope request",
+        "$ref": "#/$defs/RelayEnvelope"
+      },
+      "response": {
+        "$id": "wolfpack:control-api:http:receivePeerTaskRelayEnvelope:response",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "receivePeerTaskRelayEnvelope response",
+        "$ref": "#/$defs/RelayPeerReceiveResponse"
+      },
+      "errors": [
+        "400 RelayErrorEnvelope",
+        "404 RelayErrorEnvelope",
+        "409 RelayErrorEnvelope",
+        "413 RelayErrorEnvelope",
+        "503 RelayErrorEnvelope"
       ]
     },
     "sendTask": {
@@ -2773,6 +3079,9 @@ exports[`control api schema generation schema source emits a stable snapshot 1`]
         },
         "parentSession": {
           "$ref": "#/$defs/SessionControlIdentity"
+        },
+        "taskEndpoint": {
+          "$ref": "#/$defs/RelayEndpoint"
         }
       },
       "required": [
@@ -2936,6 +3245,304 @@ exports[`control api schema generation schema source emits a stable snapshot 1`]
         "url"
       ],
       "additionalProperties": true
+    },
+    "RelayEndpoint": {
+      "type": "object",
+      "properties": {
+        "relay": {
+          "type": "string",
+          "pattern": "^wolfpack\\\\-pi\\\\-tasks\\\\-v2(?::peer:[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})?$"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "required": [
+        "relay",
+        "id"
+      ],
+      "additionalProperties": false,
+      "description": "Opaque local or locally-routed peer endpoint. It never contains a machine name or origin."
+    },
+    "RelayEnvelope": {
+      "type": "object",
+      "properties": {
+        "envelopeId": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "protocolVersion": {
+          "const": 2
+        },
+        "source": {
+          "$ref": "#/$defs/RelayEndpoint"
+        },
+        "target": {
+          "$ref": "#/$defs/RelayEndpoint"
+        },
+        "payload": {},
+        "createdAt": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "envelopeId",
+        "protocolVersion",
+        "source",
+        "target",
+        "payload",
+        "createdAt"
+      ],
+      "additionalProperties": false
+    },
+    "RelayErrorEnvelope": {
+      "type": "object",
+      "properties": {
+        "ok": {
+          "const": false
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "code": {
+              "enum": [
+                "INVALID_REQUEST",
+                "CALLER_NOT_FOUND",
+                "CALLER_DEAD",
+                "CALLER_NOT_PI",
+                "INCOMPATIBLE_PROTOCOL",
+                "REGISTRATION_EXPIRED",
+                "SOURCE_MISMATCH",
+                "TARGET_NOT_REGISTERED",
+                "CROSS_RELAY_ENDPOINT",
+                "PAYLOAD_TOO_LARGE",
+                "ENVELOPE_CONFLICT",
+                "PEER_UNREACHABLE",
+                "STORE_UNAVAILABLE"
+              ]
+            },
+            "message": {
+              "type": "string"
+            },
+            "retryable": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "code",
+            "message",
+            "retryable"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "ok",
+        "error"
+      ],
+      "additionalProperties": false
+    },
+    "RelayConnectResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "endpoint": {
+              "$ref": "#/$defs/RelayEndpoint"
+            },
+            "leaseExpiresAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "ok",
+            "endpoint",
+            "leaseExpiresAt"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayResolveResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "endpoint": {
+              "$ref": "#/$defs/RelayEndpoint"
+            }
+          },
+          "required": [
+            "ok",
+            "endpoint"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelaySendResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "kind": {
+              "enum": [
+                "accepted",
+                "duplicate"
+              ]
+            },
+            "acceptanceId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "forwarding": {
+              "enum": [
+                "local",
+                "forwarded",
+                "pending"
+              ]
+            }
+          },
+          "required": [
+            "ok",
+            "kind",
+            "acceptanceId",
+            "forwarding"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayReceiveResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "envelopes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/RelayEnvelope"
+              }
+            },
+            "nextCursor": {
+              "type": "string",
+              "pattern": "^(0|[1-9][0-9]*)$"
+            },
+            "hasMore": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "ok",
+            "envelopes",
+            "nextCursor",
+            "hasMore"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayAcknowledgementResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "kind": {
+              "enum": [
+                "acknowledged",
+                "duplicate"
+              ]
+            }
+          },
+          "required": [
+            "ok",
+            "kind"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayPeerReceiveResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "const": true
+            },
+            "kind": {
+              "enum": [
+                "accepted",
+                "duplicate"
+              ]
+            },
+            "acceptanceId": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "required": [
+            "ok",
+            "kind",
+            "acceptanceId"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
+    },
+    "RelayEmptyResponse": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "ok": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "ok"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "$ref": "#/$defs/RelayErrorEnvelope"
+        }
+      ]
     },
     "TaskId": {
       "type": "string",

--- a/tests/unit/control-api-schema.test.ts
+++ b/tests/unit/control-api-schema.test.ts
@@ -179,6 +179,28 @@ describe("control api schema docs", () => {
 
     expect(docs).toContain("Runtime routes remain authoritative");
   });
+
+  test("publishes the opaque relay adapter contract and its inherited trust boundary", () => {
+    const docs = readFileSync("docs/control-api-schema.md", "utf-8");
+    const connect = httpOperation("connectTaskRelay");
+    const peerTopology = httpOperation("resolvePeerTaskRelayTopology");
+    const send = httpOperation("sendTaskRelayEnvelope");
+    const endpoint = resolveRef({ $ref: "#/$defs/RelayEndpoint" }, artifact);
+    const relay = (endpoint.properties as JsonObject).relay as JsonObject;
+
+    expect(connect.route).toBe("POST /api/task-relay/v2/connect");
+    expect(peerTopology.route).toBe("POST /api/task-relay/v2/peer/resolve");
+    expect(peerTopology.request).toMatchObject({
+      required: ["origin", "endpoint"],
+      properties: { origin: { $ref: "#/$defs/TailnetOrigin" }, endpoint: { $ref: "#/$defs/RelayEndpoint" } },
+    });
+    expect(send.route).toBe("POST /api/task-relay/v2/send");
+    expect(relay).toMatchObject({ type: "string" });
+    expect(String(relay.pattern)).toContain("wolfpack");
+    expect(JSON.stringify(endpoint)).not.toContain("ts.net");
+    expect(docs).toContain("trusted local processes and trusted Tailnet machines");
+    expect(docs).toContain("does not provide per-Pi-session authorization");
+  });
 });
 
 describe("control api schema compatibility samples", () => {

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { RELAY_ID, RELAY_LIMITS, RELAY_PROTOCOL_VERSION } from "../../src/task-relay/domain.ts";
+import { TaskRelayGateway } from "../../src/task-relay/gateway.ts";
+
+const NOW = new Date("2026-08-09T00:00:00.000Z");
+const session = (sessionId: string) => async (selector: string) => selector === sessionId
+  ? { ok: true as const, session: selector, sessionId, projectPath: "/tmp", harness: "pi", alive: true }
+  : { ok: false as const, code: "NOT_FOUND" as const };
+
+function root(): string {
+  return mkdtempSync(join(tmpdir(), "wolfpack-task-relay-"));
+}
+
+async function connect(gateway: TaskRelayGateway, sessionId: string, generation = "process-1") {
+  const connected = await gateway.connect({ callerSession: sessionId, generation, protocolVersions: [RELAY_PROTOCOL_VERSION] });
+  expect(connected.ok).toBe(true);
+  if (!connected.ok) throw new Error("expected relay connection");
+  return connected.endpoint;
+}
+
+describe("pi tasks relay v2", () => {
+  test("authenticates a generation-bound source, accepts opaque payloads exactly once, and retains ordered mailbox delivery until acknowledgement", async () => {
+    const directory = root();
+    try {
+      const gateway = new TaskRelayGateway({ root: directory, inspectSession: session("sender"), now: () => NOW });
+      const sender = await connect(gateway, "sender");
+      const receiverGateway = new TaskRelayGateway({ root: directory, inspectSession: session("receiver"), now: () => NOW });
+      const receiver = await connect(receiverGateway, "receiver");
+      const envelope = {
+        envelopeId: "envelope-1",
+        protocolVersion: RELAY_PROTOCOL_VERSION,
+        source: sender,
+        target: receiver,
+        payload: { taskId: "this is opaque", kind: "assignment", nested: { terminal: "completed" } },
+        createdAt: NOW.toISOString(),
+      };
+
+      await expect(gateway.send({ callerSession: "sender", envelope })).resolves.toMatchObject({ ok: true, kind: "accepted" });
+      await expect(gateway.send({ callerSession: "sender", envelope })).resolves.toMatchObject({ ok: true, kind: "duplicate" });
+      await expect(gateway.send({ callerSession: "sender", envelope: { ...envelope, source: receiver } })).resolves.toMatchObject({
+        ok: false,
+        error: { code: "SOURCE_MISMATCH" },
+      });
+
+      await expect(receiverGateway.receive({ callerSession: "receiver", cursor: "0" })).resolves.toMatchObject({
+        ok: true,
+        envelopes: [expect.objectContaining({ envelopeId: "envelope-1", payload: envelope.payload })],
+        nextCursor: "1",
+      });
+      await expect(receiverGateway.acknowledgeDelivery({ callerSession: "receiver", envelopeId: "envelope-1" })).resolves.toMatchObject({ ok: true });
+      await expect(receiverGateway.acknowledgeDelivery({ callerSession: "receiver", envelopeId: "envelope-1" })).resolves.toMatchObject({ ok: true, kind: "duplicate" });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects stale, incompatible, cross-relay, and oversized endpoint envelopes without inspecting payload semantics", async () => {
+    const directory = root();
+    try {
+      const gateway = new TaskRelayGateway({ root: directory, inspectSession: session("sender"), now: () => NOW });
+      const sender = await connect(gateway, "sender");
+      const targetGateway = new TaskRelayGateway({ root: directory, inspectSession: session("target"), now: () => NOW });
+      const target = await connect(targetGateway, "target");
+      const base = { envelopeId: "envelope-check", protocolVersion: RELAY_PROTOCOL_VERSION, source: sender, target, payload: { arbitrary: true }, createdAt: NOW.toISOString() };
+      await expect(gateway.send({ callerSession: "sender", envelope: { ...base, target: { relay: "other-relay", id: target.id } } })).resolves.toMatchObject({ ok: false, error: { code: "CROSS_RELAY_ENDPOINT" } });
+      await expect(gateway.send({ callerSession: "sender", envelope: { ...base, protocolVersion: 999 } })).resolves.toMatchObject({ ok: false, error: { code: "INCOMPATIBLE_PROTOCOL" } });
+      await expect(gateway.send({ callerSession: "sender", envelope: { ...base, payload: "x".repeat(64 * 1024) } })).resolves.toMatchObject({ ok: false, error: { code: "PAYLOAD_TOO_LARGE" } });
+      await expect(gateway.connect({ callerSession: "sender", generation: "process-2", protocolVersions: [99] })).resolves.toMatchObject({ ok: false, error: { code: "INCOMPATIBLE_PROTOCOL" } });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("expires leases and invalidates the prior endpoint when a process generation reconnects", async () => {
+    const directory = root();
+    let now = NOW;
+    try {
+      const senderGateway = new TaskRelayGateway({ root: directory, inspectSession: session("sender"), now: () => now });
+      const targetGateway = new TaskRelayGateway({ root: directory, inspectSession: session("target"), now: () => now });
+      const original = await connect(senderGateway, "sender", "generation-1");
+      const target = await connect(targetGateway, "target");
+      const envelope = { envelopeId: "generation-envelope", protocolVersion: RELAY_PROTOCOL_VERSION, source: original, target, payload: { opaque: true }, createdAt: now.toISOString() };
+      const replacement = await connect(senderGateway, "sender", "generation-2");
+      expect(replacement.id).not.toBe(original.id);
+      await expect(senderGateway.send({ callerSession: "sender", envelope })).resolves.toMatchObject({ ok: false, error: { code: "REGISTRATION_EXPIRED" } });
+      now = new Date(NOW.getTime() + 60_001);
+      await expect(senderGateway.resolve({ callerSession: "sender", target, protocolVersion: RELAY_PROTOCOL_VERSION })).resolves.toMatchObject({ ok: false, error: { code: "TARGET_NOT_REGISTERED" } });
+      await expect(senderGateway.resolve({ callerSession: "sender", target: { relay: RELAY_ID, id: "target" }, protocolVersion: RELAY_PROTOCOL_VERSION })).resolves.toMatchObject({ ok: false, error: { code: "INCOMPATIBLE_PROTOCOL" } });
+      await expect(senderGateway.resolve({ callerSession: "sender", target: { relay: RELAY_ID, id: "https://receiver.example.ts.net" }, protocolVersion: RELAY_PROTOCOL_VERSION })).resolves.toMatchObject({ ok: false, error: { code: "INCOMPATIBLE_PROTOCOL" } });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("persists a remote outbox before forwarding and receiver deduplicates a lost response", async () => {
+    const senderRoot = root();
+    const receiverRoot = root();
+    let now = NOW;
+    try {
+      let receiver: TaskRelayGateway;
+      let loseResponse = true;
+      const sender = new TaskRelayGateway({
+        root: senderRoot,
+        inspectSession: session("sender"),
+        now: () => now,
+        peerOrigin: "https://sender.example.ts.net",
+        peerFetch: async (_url, init) => {
+          const accepted = await receiver.receivePeer(JSON.parse(String(init?.body)));
+          if (loseResponse) {
+            loseResponse = false;
+            throw new Error("lost after durable peer acceptance");
+          }
+          return Response.json(accepted);
+        },
+      });
+      receiver = new TaskRelayGateway({ root: receiverRoot, inspectSession: session("receiver"), now: () => NOW, peerOrigin: "https://receiver.example.ts.net" });
+      const source = await connect(sender, "sender");
+      const target = await connect(receiver, "receiver");
+      const remoteTarget = { relay: await sender.peerRelay("https://receiver.example.ts.net"), id: target.id };
+      const envelope = { envelopeId: "remote-envelope", protocolVersion: RELAY_PROTOCOL_VERSION, source, target: remoteTarget, payload: { any: "payload" }, createdAt: NOW.toISOString() };
+
+      await expect(sender.send({ callerSession: "sender", envelope })).resolves.toMatchObject({ ok: true, forwarding: "pending" });
+      await expect(receiver.receive({ callerSession: "receiver", cursor: "0" })).resolves.toMatchObject({ ok: true, envelopes: [expect.objectContaining({ envelopeId: "remote-envelope" })] });
+      now = new Date(now.getTime() + RELAY_LIMITS.FORWARD_RETRY_MS);
+      await expect(sender.flushPeerOutbox()).resolves.toMatchObject({ forwarded: 1, pending: 0 });
+      await expect(receiver.receive({ callerSession: "receiver", cursor: "0" })).resolves.toMatchObject({ ok: true, envelopes: [expect.anything()] });
+    } finally {
+      rmSync(senderRoot, { recursive: true, force: true });
+      rmSync(receiverRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("persists opaque peer routes and recovers remote forwarding without a sender mailbox", async () => {
+    const senderRoot = root();
+    const receiverRoot = root();
+    let sender: TaskRelayGateway | undefined;
+    let restarted: TaskRelayGateway | undefined;
+    try {
+      let receiver: TaskRelayGateway;
+      let available = false;
+      const peerOrigin = "https://receiver.example.ts.net";
+      const peerFetch = async (_url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+        if (!available) throw new Error("peer is offline");
+        return Response.json(await receiver.receivePeer(JSON.parse(String(init?.body))));
+      };
+      sender = new TaskRelayGateway({ root: senderRoot, inspectSession: session("sender"), now: () => NOW, peerOrigin: "https://sender.example.ts.net", peerFetch });
+      receiver = new TaskRelayGateway({ root: receiverRoot, inspectSession: session("receiver"), now: () => NOW, peerOrigin });
+      const source = await connect(sender, "sender");
+      const target = await connect(receiver, "receiver");
+      const remoteTarget = { relay: await sender.peerRelay(peerOrigin), id: target.id };
+      expect(remoteTarget.relay).toMatch(/^wolfpack-pi-tasks-v2:peer:[0-9a-f-]{36}$/);
+      const envelope = { envelopeId: "restart-envelope", protocolVersion: RELAY_PROTOCOL_VERSION, source, target: remoteTarget, payload: { opaque: true }, createdAt: NOW.toISOString() };
+
+      await expect(sender.send({ callerSession: "sender", envelope })).resolves.toMatchObject({ ok: true, forwarding: "pending" });
+      const beforeRestart = JSON.parse(readFileSync(join(senderRoot, "relay-state.json"), "utf8"));
+      expect(beforeRestart.mailbox).toEqual([]);
+      expect(beforeRestart.envelopes).toEqual([]);
+      expect(beforeRestart.peerRoutes).toEqual([{ id: remoteTarget.relay, origin: peerOrigin }]);
+
+      available = true;
+      restarted = new TaskRelayGateway({ root: senderRoot, inspectSession: session("sender"), now: () => NOW, peerOrigin: "https://sender.example.ts.net", peerFetch });
+      await expect(restarted.peerRelay(peerOrigin)).resolves.toBe(remoteTarget.relay);
+      await restarted.initialize();
+      await expect(receiver.receive({ callerSession: "receiver", cursor: "0" })).resolves.toMatchObject({
+        ok: true,
+        envelopes: [expect.objectContaining({ envelopeId: "restart-envelope" })],
+      });
+      await restarted.cleanup(new Date(NOW.getTime() + 1));
+      const afterCleanup = JSON.parse(readFileSync(join(senderRoot, "relay-state.json"), "utf8"));
+      expect(afterCleanup.outbox).toEqual([]);
+    } finally {
+      if (sender && "close" in sender) (sender as { close(): void }).close();
+      if (restarted && "close" in restarted) (restarted as { close(): void }).close();
+      rmSync(senderRoot, { recursive: true, force: true });
+      rmSync(receiverRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("does not spend retry attempts when a duplicate remote send arrives before its retry window", async () => {
+    const directory = root();
+    try {
+      const gateway = new TaskRelayGateway({
+        root: directory,
+        inspectSession: session("sender"),
+        now: () => NOW,
+        peerOrigin: "https://sender.example.ts.net",
+        peerFetch: async () => { throw new Error("peer is offline"); },
+      });
+      const source = await connect(gateway, "sender");
+      const target = { relay: await gateway.peerRelay("https://receiver.example.ts.net"), id: "2af8af29-c4fe-44f9-9a99-9a0e35952d74" };
+      const envelope = { envelopeId: "duplicate-pending-envelope", protocolVersion: RELAY_PROTOCOL_VERSION, source, target, payload: { opaque: true }, createdAt: NOW.toISOString() };
+
+      await expect(gateway.send({ callerSession: "sender", envelope })).resolves.toMatchObject({ ok: true, kind: "accepted", forwarding: "pending" });
+      await expect(gateway.send({ callerSession: "sender", envelope })).resolves.toMatchObject({ ok: true, kind: "duplicate", forwarding: "pending" });
+
+      const state = JSON.parse(readFileSync(join(directory, "relay-state.json"), "utf8"));
+      expect(state.outbox).toEqual([expect.objectContaining({ attempts: 1, lastError: "peer unavailable" })]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("single-flights slow peer forwarding so concurrent retries do not exceed the attempt limit", async () => {
+    const directory = root();
+    let releasePeer: (() => void) | undefined;
+    let peerStarted: (() => void) | undefined;
+    const peerStartedPromise = new Promise<void>((resolve) => { peerStarted = resolve; });
+    const peerReleasePromise = new Promise<void>((resolve) => { releasePeer = resolve; });
+    let peerRequests = 0;
+    try {
+      const gateway = new TaskRelayGateway({
+        root: directory,
+        inspectSession: session("sender"),
+        now: () => NOW,
+        peerOrigin: "https://sender.example.ts.net",
+        peerFetch: async () => {
+          peerRequests += 1;
+          peerStarted?.();
+          await peerReleasePromise;
+          return Response.json({ ok: true });
+        },
+      });
+      const source = await connect(gateway, "sender");
+      const target = { relay: await gateway.peerRelay("https://receiver.example.ts.net"), id: "2af8af29-c4fe-44f9-9a99-9a0e35952d74" };
+      const envelope = { envelopeId: "slow-peer-envelope", protocolVersion: RELAY_PROTOCOL_VERSION, source, target, payload: { opaque: true }, createdAt: NOW.toISOString() };
+
+      const sending = gateway.send({ callerSession: "sender", envelope });
+      await peerStartedPromise;
+      const flushing = Promise.all(Array.from({ length: RELAY_LIMITS.MAX_FORWARD_ATTEMPTS + 1 }, () => gateway.flushPeerOutbox(true)));
+      await Promise.resolve();
+      releasePeer?.();
+
+      await expect(sending).resolves.toMatchObject({ ok: true, forwarding: "forwarded" });
+      await expect(flushing).resolves.toEqual(Array.from({ length: RELAY_LIMITS.MAX_FORWARD_ATTEMPTS + 1 }, () => ({ forwarded: 1, pending: 0 })));
+      expect(peerRequests).toBe(1);
+      const state = JSON.parse(readFileSync(join(directory, "relay-state.json"), "utf8"));
+      expect(state.outbox).toEqual([expect.objectContaining({ attempts: 1, forwardedAt: NOW.toISOString() })]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("retains recent forwarding diagnostics until their retention cutoff", async () => {
+    const directory = root();
+    try {
+      const gateway = new TaskRelayGateway({
+        root: directory,
+        inspectSession: session("sender"),
+        now: () => NOW,
+        peerOrigin: "https://sender.example.ts.net",
+        peerFetch: async () => Response.json({ ok: true }),
+      });
+      const source = await connect(gateway, "sender");
+      const target = { relay: await gateway.peerRelay("https://receiver.example.ts.net"), id: "2af8af29-c4fe-44f9-9a99-9a0e35952d74" };
+      const envelope = { envelopeId: "recent-forward-envelope", protocolVersion: RELAY_PROTOCOL_VERSION, source, target, payload: { opaque: true }, createdAt: NOW.toISOString() };
+
+      await expect(gateway.send({ callerSession: "sender", envelope })).resolves.toMatchObject({ ok: true, forwarding: "forwarded" });
+      await expect(gateway.cleanup(new Date(NOW.getTime() - 1))).resolves.toBe(0);
+
+      const state = JSON.parse(readFileSync(join(directory, "relay-state.json"), "utf8"));
+      expect(state.outbox).toEqual([expect.objectContaining({ forwardedAt: NOW.toISOString() })]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("bounds unavailable forwarding and persists exhaustion diagnostics", async () => {
+    const directory = root();
+    let now = NOW;
+    try {
+      const gateway = new TaskRelayGateway({ root: directory, inspectSession: session("sender"), now: () => now });
+      const source = await connect(gateway, "sender");
+      const target = { relay: await gateway.peerRelay("https://receiver.example.ts.net"), id: "2af8af29-c4fe-44f9-9a99-9a0e35952d74" };
+      await expect(gateway.send({
+        callerSession: "sender",
+        envelope: { envelopeId: "exhausted-envelope", protocolVersion: RELAY_PROTOCOL_VERSION, source, target, payload: { opaque: true }, createdAt: NOW.toISOString() },
+      })).resolves.toMatchObject({ ok: true, forwarding: "pending" });
+      for (let attempt = 1; attempt < 4; attempt += 1) {
+        now = new Date(now.getTime() + RELAY_LIMITS.FORWARD_RETRY_MS);
+        await gateway.flushPeerOutbox();
+      }
+      const state = JSON.parse(readFileSync(join(directory, "relay-state.json"), "utf8"));
+      expect(state.outbox).toEqual([expect.objectContaining({
+        attempts: 4,
+        lastError: "local peer origin unavailable",
+        exhaustedAt: now.toISOString(),
+      })]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("uses a distinct v2 storage root", () => {
+    expect(RELAY_ID).toBe("wolfpack-pi-tasks-v2");
+  });
+});


### PR DESCRIPTION
## summary
- add content-blind opaque endpoint relay v2 with durable mailboxes and peer forwarding
- add public trusted topology resolution, bounded recovery, and v1 fixture isolation
- preserve v1 task routes and ledgers

## verification
- bun test (1736 pass, 22 broker-dependent skips)
- bun run typecheck
- git diff --check main