### PR TITLE
fix relay inbox continuity after reconnect

### DIFF
--- a/src/task-relay/gateway.ts
+++ b/src/task-relay/gateway.ts
@@ -166,7 +166,7 @@ export class TaskRelayGateway {
     if (!registration || registration.sessionId !== caller.value.sessionId || !isLocalRelay(input.endpoint)) {
       return relayFailure(RELAY_ERROR.SOURCE_MISMATCH, "caller does not own relay endpoint");
     }
-    await this.#store.unregister(caller.value.sessionId, input.endpoint.id);
+    await this.#store.deactivateRegistration(caller.value.sessionId, input.endpoint.id, this.#now().toISOString());
     return { ok: true };
   }
 

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -133,11 +133,13 @@ export class TaskRelayStore {
     return this.#read().registrations.find((item) => item.endpoint.id === endpointId && Date.parse(item.leaseExpiresAt) > now.getTime());
   }
 
-  async unregister(sessionId: string, endpointId: string): Promise<boolean> {
+  async deactivateRegistration(sessionId: string, endpointId: string, leaseExpiresAt: string): Promise<boolean> {
     return this.#mutate((state) => {
       const registration = state.registrations.find((item) => item.sessionId === sessionId && item.endpoint.id === endpointId);
       return {
-        state: registration ? { ...state, registrations: state.registrations.filter((item) => item !== registration) } : state,
+        state: registration
+          ? { ...state, registrations: state.registrations.map((item) => item === registration ? { ...item, leaseExpiresAt } : item) }
+          : state,
         value: registration !== undefined,
       };
     });

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -138,6 +138,41 @@ describe("pi tasks relay v2", () => {
     }
   });
 
+  test("continues mailbox cursors when the same generation reconnects after disconnect", async () => {
+    const directory = root();
+    try {
+      const senderGateway = new TaskRelayGateway({ root: directory, inspectSession: session("sender"), now: () => NOW });
+      const receiverGateway = new TaskRelayGateway({ root: directory, inspectSession: session("receiver"), now: () => NOW });
+      const sender = await connect(senderGateway, "sender", "sender-generation");
+      const receiver = await connect(receiverGateway, "receiver", "receiver-generation");
+      const firstEnvelope = { envelopeId: "before-disconnect", protocolVersion: RELAY_PROTOCOL_VERSION, source: sender, target: receiver, payload: { order: 1 }, createdAt: NOW.toISOString() };
+      await expect(senderGateway.send({ callerSession: "sender", envelope: firstEnvelope })).resolves.toMatchObject({ ok: true });
+      await expect(receiverGateway.receive({ callerSession: "receiver", cursor: "0" })).resolves.toMatchObject({
+        ok: true,
+        envelopes: [expect.objectContaining({ envelopeId: "before-disconnect" })],
+        nextCursor: "1",
+      });
+
+      await expect(receiverGateway.disconnect({ callerSession: "receiver", endpoint: receiver })).resolves.toEqual({ ok: true });
+      await expect(senderGateway.resolve({ callerSession: "sender", target: receiver, protocolVersion: RELAY_PROTOCOL_VERSION })).resolves.toMatchObject({
+        ok: false,
+        error: { code: "TARGET_NOT_REGISTERED" },
+      });
+      const reconnectedReceiver = await connect(receiverGateway, "receiver", "receiver-generation");
+      expect(reconnectedReceiver).toEqual(receiver);
+
+      const secondEnvelope = { envelopeId: "after-disconnect", protocolVersion: RELAY_PROTOCOL_VERSION, source: sender, target: reconnectedReceiver, payload: { order: 2 }, createdAt: NOW.toISOString() };
+      await expect(senderGateway.send({ callerSession: "sender", envelope: secondEnvelope })).resolves.toMatchObject({ ok: true });
+      await expect(receiverGateway.receive({ callerSession: "receiver", cursor: "1" })).resolves.toMatchObject({
+        ok: true,
+        envelopes: [expect.objectContaining({ envelopeId: "after-disconnect" })],
+        nextCursor: "2",
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("expires leases and invalidates the prior endpoint when a process generation reconnects", async () => {
     const directory = root();
     let now = NOW;

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -105,6 +105,39 @@ describe("pi tasks relay v2", () => {
     }
   });
 
+  test("continues mailbox cursors when the same generation reconnects after lease expiry", async () => {
+    const directory = root();
+    let now = NOW;
+    try {
+      const senderGateway = new TaskRelayGateway({ root: directory, inspectSession: session("sender"), now: () => now });
+      const receiverGateway = new TaskRelayGateway({ root: directory, inspectSession: session("receiver"), now: () => now });
+      const sender = await connect(senderGateway, "sender", "sender-generation");
+      const receiver = await connect(receiverGateway, "receiver", "receiver-generation");
+      const firstEnvelope = { envelopeId: "before-expiry", protocolVersion: RELAY_PROTOCOL_VERSION, source: sender, target: receiver, payload: { order: 1 }, createdAt: now.toISOString() };
+      await expect(senderGateway.send({ callerSession: "sender", envelope: firstEnvelope })).resolves.toMatchObject({ ok: true });
+      await expect(receiverGateway.receive({ callerSession: "receiver", cursor: "0" })).resolves.toMatchObject({
+        ok: true,
+        envelopes: [expect.objectContaining({ envelopeId: "before-expiry" })],
+        nextCursor: "1",
+      });
+
+      now = new Date(NOW.getTime() + RELAY_LIMITS.LEASE_MS + 1);
+      const renewedSender = await connect(senderGateway, "sender", "sender-generation");
+      const renewedReceiver = await connect(receiverGateway, "receiver", "receiver-generation");
+      const secondEnvelope = { envelopeId: "after-expiry", protocolVersion: RELAY_PROTOCOL_VERSION, source: renewedSender, target: renewedReceiver, payload: { order: 2 }, createdAt: now.toISOString() };
+      await expect(senderGateway.send({ callerSession: "sender", envelope: secondEnvelope })).resolves.toMatchObject({ ok: true });
+      await expect(receiverGateway.receive({ callerSession: "receiver", cursor: "1" })).resolves.toMatchObject({
+        ok: true,
+        envelopes: [expect.objectContaining({ envelopeId: "after-expiry" })],
+        nextCursor: "2",
+      });
+      expect(renewedSender).toEqual(sender);
+      expect(renewedReceiver).toEqual(receiver);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("expires leases and invalidates the prior endpoint when a process generation reconnects", async () => {
     const directory = root();
     let now = NOW;


### PR DESCRIPTION
## summary
- preserve relay endpoint identity when the same session generation reconnects after explicit disconnect
- keep disconnected endpoints inactive until reconnect
- retain endpoint-scoped mailbox cursor continuity while rotating changed generations

## verification
- `bun test`: 1,841 passed, 22 documented broker-binary skips, 0 failed
- `bun run typecheck`
- live disconnect/reconnect verification: endpoint retained and cursor advanced from 1 to 2
- independent read-only review: no blocker or important findings