### PR TITLE
feat: add remote machine CLI targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ For a manual audited install, clone or update `https://github.com/almogdepaz/wol
 
 ## advanced automation
 
+Target the supported session-control surface on a configured Tailnet peer with the global selector:
+
+```bash
+wolfpack --machine <short-name-or-fqdn> list --json
+wolfpack --machine <short-name-or-fqdn> session status <session-or-id> --json
+```
+
+Short names use the exact suffix from configured `tailscaleHostname`; full names must be canonical hostnames in that same suffix. Wolfpack sends the normal JWT authorization on a bounded `GET /api/machine` handshake and subsequent requests. Invalid, incompatible, redirected, timed-out, or unreachable targets fail closed without localhost fallback. Remote JSON successes add verified `"machine"` identity while retaining server-owned `sessionId` values. `agent spawn` still resolves its parent on the selected machine and does not invent cross-machine lineage.
+
 Create a top-level project session with an initial instruction:
 
 ```bash

--- a/docs/session-control.md
+++ b/docs/session-control.md
@@ -2,6 +2,20 @@
 
 Wolfpack exposes a scriptable session surface for agents and operators. The server remains authoritative for auth, project selection and path validation, session naming, stable broker identity, and PTY operations. Commands use Wolfpack's ordinary global API auth policy and add no inter-session authorization layer.
 
+## Target a configured Tailnet machine
+
+```bash
+wolfpack --machine <short-name-or-fqdn> <control-command> ...
+```
+
+The global selector supports `list`/`ls`, `session create`, deprecated `session open`, `agent spawn`, `session status`, `session read`, `session send`, `session wait`, `session prompt`, and `kill`. Other commands reject it.
+
+A short name is expanded using the exact Tailnet suffix from configured `tailscaleHostname`. A full name must be a canonical HTTPS Tailnet hostname in that suffix; URLs, ports, paths, foreign suffixes, malformed or duplicate selectors, and missing configuration fail closed without a localhost fallback. Before any control request, the CLI sends an exact, bounded `GET /api/machine` probe with redirects disabled, a bounded timeout, and the normal Wolfpack JWT `Authorization` header when configured. The structured handshake must report the selected canonical origin and session-control capability.
+
+Subsequent requests go directly to that verified HTTPS origin. Remote JSON successes retain every server field and add the verified identity as `"machine": { "tailnetNodeId": string, "installationId": string, "displayName": string, "origin": string }`; server-owned `sessionId` values are unchanged. Without `--machine`, request routing and JSON output remain local and unchanged.
+
+`agent spawn` still uses `POST /api/session-open` and resolves its parent on the selected machine. It does not create cross-machine lineage: a parent absent from the selected machine fails through the existing structured response.
+
 ## Create a top-level session
 
 ```bash

--- a/skills/wolfpack-tailnet-control/SKILL.md
+++ b/skills/wolfpack-tailnet-control/SKILL.md
@@ -30,6 +30,14 @@ Use `--name <session>` for child agents and choose a short meaningful issue/role
 
 ## Structured inspection and control
 
+To explicitly target a configured Tailnet peer, prefix only supported control commands:
+
+```bash
+wolfpack --machine <short-name-or-fqdn> list --json
+```
+
+Short names use the exact suffix from configured `tailscaleHostname`; full names must be canonical hostnames in that suffix. The CLI verifies bounded structured `GET /api/machine` identity, uses normal JWT auth, and makes invalid targets fail closed without localhost fallback. Remote JSON success adds verified `machine` identity and preserves server-owned `sessionId`. Remote `agent spawn` resolves the parent on the selected machine; no cross-machine parent lineage is created. Unsupported commands reject `--machine`.
+
 ```bash
 wolfpack list --json
 wolfpack session status <session-or-id> --json

--- a/src/cli/api.ts
+++ b/src/cli/api.ts
@@ -3,9 +3,11 @@
  */
 import { createHmac, randomBytes } from "node:crypto";
 import { loadConfig } from "./config.js";
+import type { VerifiedMachineTarget } from "./machine-target.js";
 import { printError, yellow } from "./formatting.js";
 
-export function baseUrl(): string {
+export function baseUrl(target?: VerifiedMachineTarget): string {
+  if (target) return target.origin;
   const config = loadConfig();
   const port = config?.port ?? 18790;
   return `http://127.0.0.1:${port}`;
@@ -41,10 +43,14 @@ export function issueJwt(): string | null {
   return `${data}.${sig}`;
 }
 
-export async function call(path: string, init: RequestInit = {}): Promise<Response> {
+export async function call(
+  path: string,
+  init: RequestInit = {},
+  target?: VerifiedMachineTarget,
+): Promise<Response> {
   const headers = new Headers(init.headers);
   const jwt = issueJwt();
   if (jwt) headers.set("Authorization", `Bearer ${jwt}`);
   if (!headers.has("Content-Type") && init.body) headers.set("Content-Type", "application/json");
-  return fetch(`${baseUrl()}${path}`, { ...init, headers });
+  return fetch(`${baseUrl(target)}${path}`, { ...init, headers });
 }

--- a/src/cli/formatting.ts
+++ b/src/cli/formatting.ts
@@ -1,6 +1,7 @@
 /**
  * Terminal formatting helpers — WOLF ascii art, color functions, and output policy.
  */
+import type { VerifiedMachineTarget } from "./machine-target.js";
 
 interface CliWritable {
   readonly isTTY?: boolean;
@@ -35,6 +36,14 @@ export function printError(message: string): void {
 
 export function printJson(value: unknown): void {
   process.stdout.write(`${JSON.stringify(value)}\n`);
+}
+
+export function printApiJson(value: unknown, target?: VerifiedMachineTarget): void {
+  if (target && value && typeof value === "object" && !Array.isArray(value)) {
+    printJson({ ...value, machine: target.machine });
+    return;
+  }
+  printJson(value);
 }
 
 export const WOLF = `

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,7 @@
  * CLI dispatch entry point.
  */
 import { printQR } from "../qr.js";
-import { print, printError, bold, dim, red, yellow, WOLF } from "./formatting.js";
+import { print, printError, printJson, bold, dim, red, yellow, WOLF } from "./formatting.js";
 import pkg from "../../package.json";
 import {
   loadConfig,
@@ -29,6 +29,15 @@ import { attachCommand } from "./attach.js";
 import { runAgentCommand, runSessionCommand } from "./session-control.js";
 import { applyServiceAuthFile } from "./service-auth.js";
 import { logsCommand } from "./logs.js";
+import { issueJwt } from "./api.js";
+import {
+  extractMachineSelector,
+  verifyMachineTarget,
+} from "./machine-target.js";
+import type {
+  MachineTargetFailure,
+  VerifiedMachineTarget,
+} from "./machine-target.js";
 
 export {
   loadConfig,
@@ -63,7 +72,10 @@ export function hasUninstallConfirmationFlag(argv: string[]): boolean {
 const HELP_ALIASES = new Set(["--help", "-h", "help"]);
 
 export function topLevelUsage(): string {
-  return `Usage: wolfpack [command]
+  return `Usage: wolfpack [--machine <short-name-or-fqdn>] [command]
+
+Global selector:
+  --machine <short-name-or-fqdn>    Target a verified peer for supported session control commands
 
 Commands:
   wolfpack                         Start the dashboard/server
@@ -200,9 +212,62 @@ async function start() {
   print("");
 }
 
+function isMachineHelpRequest(argv: readonly string[]): boolean {
+  const help = argv.at(-1);
+  if (!help || !HELP_ALIASES.has(help)) return false;
+  const command = argv.slice(0, -1);
+  if (command.length === 0) return true;
+  const [family, action] = command;
+  if (["list", "ls", "kill"].includes(family ?? "")) return command.length === 1;
+  if (family === "session") {
+    return command.length === 1 || (command.length === 2 && [
+      "create", "open", "status", "read", "send", "wait", "prompt",
+    ].includes(action ?? ""));
+  }
+  return family === "agent"
+    && (command.length === 1 || (command.length === 2 && action === "spawn"));
+}
+
+function isMachineCommandSupported(argv: readonly string[]): boolean {
+  const [family, action] = argv;
+  if (["list", "ls", "kill"].includes(family ?? "")) return true;
+  if (family === "session") {
+    return ["create", "open", "status", "read", "send", "wait", "prompt"].includes(action ?? "");
+  }
+  return family === "agent" && action === "spawn";
+}
+
+function emitMachineFailure(
+  failure: MachineTargetFailure,
+  jsonOutput: boolean,
+): never {
+  if (jsonOutput) printJson({ ok: false, error: { code: failure.code, message: failure.message } });
+  else printError(red(`  ${failure.message}`));
+  process.exit(failure.exitCode);
+}
+
 async function main() {
-  const argv = process.argv.slice(2);
+  const rawArgv = process.argv.slice(2);
+  const extracted = extractMachineSelector(rawArgv);
+  if (!extracted.ok) emitMachineFailure(extracted.error, rawArgv.includes("--json"));
+  const argv = [...extracted.argv];
   const [cmd] = argv;
+  let target: VerifiedMachineTarget | undefined;
+  if (extracted.selector !== undefined && !isMachineHelpRequest(argv)) {
+    if (!isMachineCommandSupported(argv)) {
+      emitMachineFailure({
+        code: "INVALID_MACHINE_SELECTOR",
+        message: "--machine is not supported for this command",
+        exitCode: 2,
+      }, argv.includes("--json"));
+    }
+    const verified = await verifyMachineTarget(extracted.selector, {
+      tailscaleHostname: loadConfig()?.tailscaleHostname,
+      jwt: issueJwt(),
+    });
+    if (!verified.ok) emitMachineFailure(verified.error, argv.includes("--json"));
+    target = verified.target;
+  }
 
   if (argv.length === 1 && HELP_ALIASES.has(cmd)) {
     print(topLevelUsage());
@@ -235,13 +300,13 @@ async function main() {
     if (flags.some(flag => flag !== "--json" && flag !== "--fix")) throw new Error("Usage: wolfpack doctor [--json] [--fix]");
     process.exit(await doctor({ fix: flags.includes("--fix"), json: flags.includes("--json") }));
   } else if (cmd === "ls" || cmd === "list") {
-    process.exit(await lsSessions(argv.slice(1)));
+    process.exit(await lsSessions(argv.slice(1), target));
   } else if (cmd === "session") {
-    process.exit(await runSessionCommand(argv.slice(1)));
+    process.exit(await runSessionCommand(argv.slice(1), target));
   } else if (cmd === "agent") {
-    process.exit(await runAgentCommand(argv.slice(1)));
+    process.exit(await runAgentCommand(argv.slice(1), target));
   } else if (cmd === "kill") {
-    process.exit(await killSession(argv.slice(1)));
+    process.exit(await killSession(argv.slice(1), target));
   } else if (cmd === "logs" && argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
     print("Usage: wolfpack logs [--follow] [--json] [--broker]");
   } else if (cmd === "logs") {

--- a/src/cli/machine-target.ts
+++ b/src/cli/machine-target.ts
@@ -1,0 +1,290 @@
+import {
+  canonicalTailnetOrigin,
+  classifyMachineHandshakeForOrigin,
+} from "../tailnet-machine-contract.js";
+import type { MachineHandshake } from "../tailnet-machine-contract.js";
+
+const MACHINE_SELECTOR = "--machine";
+const DNS_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const MACHINE_HANDSHAKE_MAX_BYTES = 32 * 1024;
+const MACHINE_HANDSHAKE_TIMEOUT_MS = 8_000;
+
+export interface VerifiedMachineTarget {
+  readonly kind: "remote";
+  readonly origin: string;
+  readonly machine: MachineHandshake["machine"];
+}
+
+export interface MachineTargetFailure {
+  readonly code:
+    | "INVALID_MACHINE_SELECTOR"
+    | "MACHINE_CONFIGURATION_REQUIRED"
+    | "MACHINE_UNREACHABLE"
+    | "MACHINE_AUTH_REQUIRED"
+    | "INVALID_MACHINE_RESPONSE"
+    | "INCOMPATIBLE_MACHINE";
+  readonly message: string;
+  readonly exitCode: number;
+}
+
+export type ExtractedMachineSelector =
+  | {
+    readonly ok: true;
+    readonly selector: string | undefined;
+    readonly argv: readonly string[];
+  }
+  | { readonly ok: false; readonly error: MachineTargetFailure };
+
+export type MachineOriginResolution =
+  | { readonly ok: true; readonly origin: string }
+  | { readonly ok: false; readonly error: MachineTargetFailure };
+
+export type MachineTargetVerification =
+  | { readonly ok: true; readonly target: VerifiedMachineTarget }
+  | { readonly ok: false; readonly error: MachineTargetFailure };
+
+export type MachineTargetFetch = (input: string, init: RequestInit) => Promise<Response>;
+
+export interface VerifyMachineTargetOptions {
+  readonly tailscaleHostname: string | undefined;
+  readonly jwt?: string | null;
+  readonly fetcher?: MachineTargetFetch;
+  readonly timeoutMs?: number;
+}
+
+function failure(
+  code: MachineTargetFailure["code"],
+  message: string,
+  exitCode = 1,
+): MachineTargetFailure {
+  return { code, message, exitCode };
+}
+
+function isMachineSelectorArgument(value: string): boolean {
+  return value === MACHINE_SELECTOR || value.startsWith(`${MACHINE_SELECTOR}=`);
+}
+
+export function extractMachineSelector(argv: readonly string[]): ExtractedMachineSelector {
+  if (!isMachineSelectorArgument(argv[0] ?? "")) {
+    if (argv.some(isMachineSelectorArgument)) {
+      return {
+        ok: false,
+        error: failure(
+          "INVALID_MACHINE_SELECTOR",
+          "--machine must be the sole leading global selector",
+          2,
+        ),
+      };
+    }
+    return { ok: true, selector: undefined, argv: [...argv] };
+  }
+  if (argv[0] !== MACHINE_SELECTOR) {
+    return {
+      ok: false,
+      error: failure(
+        "INVALID_MACHINE_SELECTOR",
+        "use the leading --machine <short-name-or-fqdn> selector form",
+        2,
+      ),
+    };
+  }
+  const selector = argv[1];
+  if (!selector || selector.startsWith("-")) {
+    return {
+      ok: false,
+      error: failure("INVALID_MACHINE_SELECTOR", "--machine requires a machine name", 2),
+    };
+  }
+  const remaining = argv.slice(2);
+  if (remaining.some(isMachineSelectorArgument)) {
+    return {
+      ok: false,
+      error: failure("INVALID_MACHINE_SELECTOR", "duplicate --machine selector", 2),
+    };
+  }
+  return { ok: true, selector, argv: remaining };
+}
+
+export function resolveMachineOrigin(
+  selector: string,
+  tailscaleHostname: string | undefined,
+): MachineOriginResolution {
+  const configuredOrigin = canonicalTailnetOrigin(tailscaleHostname);
+  if (!configuredOrigin || configuredOrigin.slice("https://".length) !== tailscaleHostname) {
+    return {
+      ok: false,
+      error: failure(
+        "MACHINE_CONFIGURATION_REQUIRED",
+        "a canonical tailscaleHostname is required; run 'wolfpack setup'",
+      ),
+    };
+  }
+
+  const configuredLabels = tailscaleHostname.split(".");
+  if (configuredLabels.length < 4) {
+    return {
+      ok: false,
+      error: failure(
+        "MACHINE_CONFIGURATION_REQUIRED",
+        "configured tailscaleHostname does not include a tailnet namespace",
+      ),
+    };
+  }
+  const tailnetSuffix = `.${configuredLabels.slice(1).join(".")}`;
+  if (!selector.includes(".")) {
+    if (!DNS_LABEL_PATTERN.test(selector)) {
+      return {
+        ok: false,
+        error: failure("INVALID_MACHINE_SELECTOR", "--machine must be a canonical DNS name", 2),
+      };
+    }
+    return { ok: true, origin: `https://${selector}${tailnetSuffix}` };
+  }
+
+  const selectedOrigin = canonicalTailnetOrigin(selector);
+  const selectedHostname = selectedOrigin?.slice("https://".length);
+  const machineLabel = selectedHostname?.slice(0, -tailnetSuffix.length);
+  if (
+    !selectedOrigin
+    || selectedHostname !== selector
+    || !selectedHostname.endsWith(tailnetSuffix)
+    || !machineLabel
+    || machineLabel.includes(".")
+    || !DNS_LABEL_PATTERN.test(machineLabel)
+  ) {
+    return {
+      ok: false,
+      error: failure(
+        "INVALID_MACHINE_SELECTOR",
+        "--machine must be a short name or canonical hostname in the configured tailnet",
+        2,
+      ),
+    };
+  }
+  return { ok: true, origin: selectedOrigin };
+}
+
+class MachineProbeTimeoutError extends Error {}
+class MachineProbeBodyError extends Error {}
+
+function declaredBodyExceedsLimit(response: Response): boolean {
+  const contentLength = response.headers.get("content-length");
+  return contentLength !== null && Number(contentLength) > MACHINE_HANDSHAKE_MAX_BYTES;
+}
+
+async function readBoundedBody(
+  response: Response,
+  expired: Promise<never>,
+): Promise<Uint8Array> {
+  const reader = response.body?.getReader();
+  if (!reader) return new Uint8Array();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  try {
+    for (;;) {
+      const chunk = await Promise.race([reader.read(), expired]);
+      if (chunk.done) break;
+      byteLength += chunk.value.byteLength;
+      if (byteLength > MACHINE_HANDSHAKE_MAX_BYTES) {
+        void reader.cancel().catch(() => undefined);
+        throw new MachineProbeBodyError();
+      }
+      chunks.push(chunk.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+export async function verifyMachineTarget(
+  selector: string,
+  options: VerifyMachineTargetOptions,
+): Promise<MachineTargetVerification> {
+  const resolved = resolveMachineOrigin(selector, options.tailscaleHostname);
+  if (!resolved.ok) return resolved;
+
+  const timeoutMs = options.timeoutMs ?? MACHINE_HANDSHAKE_TIMEOUT_MS;
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new MachineProbeTimeoutError());
+    }, timeoutMs);
+  });
+  const headers = new Headers();
+  if (options.jwt) headers.set("Authorization", `Bearer ${options.jwt}`);
+
+  try {
+    const response = await Promise.race([
+      (options.fetcher ?? fetch)(`${resolved.origin}/api/machine`, {
+        method: "GET",
+        headers,
+        redirect: "error",
+        cache: "no-store",
+        signal: controller.signal,
+      }),
+      expired,
+    ]);
+    if (response.status === 401) {
+      return {
+        ok: false,
+        error: failure("MACHINE_AUTH_REQUIRED", "machine handshake requires authentication", 5),
+      };
+    }
+    if (!response.ok) {
+      return {
+        ok: false,
+        error: failure("MACHINE_UNREACHABLE", `machine handshake returned HTTP ${response.status}`),
+      };
+    }
+    if (declaredBodyExceedsLimit(response)) {
+      controller.abort();
+      return {
+        ok: false,
+        error: failure("INVALID_MACHINE_RESPONSE", "machine handshake exceeds 32 KiB"),
+      };
+    }
+
+    let body: unknown;
+    try {
+      const bytes = await readBoundedBody(response, expired);
+      body = JSON.parse(new TextDecoder().decode(bytes));
+    } catch (error: unknown) {
+      if (error instanceof MachineProbeTimeoutError) throw error;
+      return {
+        ok: false,
+        error: failure("INVALID_MACHINE_RESPONSE", "machine handshake is not bounded valid JSON"),
+      };
+    }
+    const classification = classifyMachineHandshakeForOrigin(resolved.origin, body);
+    if (classification.kind !== "ready") {
+      return {
+        ok: false,
+        error: failure("INCOMPATIBLE_MACHINE", "machine handshake is incompatible with session control"),
+      };
+    }
+    return {
+      ok: true,
+      target: {
+        kind: "remote",
+        origin: classification.handshake.machine.origin,
+        machine: classification.handshake.machine,
+      },
+    };
+  } catch {
+    return {
+      ok: false,
+      error: failure("MACHINE_UNREACHABLE", "could not verify the selected machine"),
+    };
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/src/cli/session-control.ts
+++ b/src/cli/session-control.ts
@@ -35,7 +35,8 @@ import type {
   SessionPromptWaitResult,
 } from "../session-prompt-contract.js";
 import { call as callApi } from "./api.js";
-import { print, printError, printJson, red, yellow } from "./formatting.js";
+import type { VerifiedMachineTarget } from "./machine-target.js";
+import { print, printApiJson, printError, printJson, red, yellow } from "./formatting.js";
 
 export const SESSION_EXIT = {
   OK: 0,
@@ -60,6 +61,8 @@ export function sessionCreateUsage(): string {
   return `Usage: wolfpack session create <project> [--harness <agent>] [--prompt|--prompt-file|--plan <value>] [--json]
        wolfpack session create --project-dir <path> [--harness <agent>] [--prompt|--prompt-file|--plan <value>] [--json]
 
+Global selector: wolfpack --machine <short-name-or-fqdn> session create ...
+
 Creates a top-level session. A project name selects under WOLFPACK_DEV_DIR;
 --project-dir selects an existing directory and is resolved to an absolute path.
 The server owns validation, naming, identity, and launch.`;
@@ -69,11 +72,15 @@ export function sessionOpenUsage(): string {
   return `Usage: wolfpack session open <project> [--name <session>] [--prompt|--prompt-file|--plan <value>] [--notify-parent] [--json]
        wolfpack session open --project-dir <path> [--name <session>] [--prompt|--prompt-file|--plan <value>] [--notify-parent] [--json]
 
+Global selector: wolfpack --machine <short-name-or-fqdn> session open ...
+
 Deprecated alias for: wolfpack agent spawn`;
 }
 
 export function agentUsage(): string {
   return `Usage: wolfpack agent <command> [options]
+
+Global selector: wolfpack --machine <short-name-or-fqdn> agent spawn ...
 
 Commands:
   wolfpack agent spawn <project> [--name <session>] [--prompt|--prompt-file|--plan <value>] [--notify-parent] [--json]
@@ -85,6 +92,8 @@ Spawns a same-harness child of the current Wolfpack agent session or sends a use
 
 export function sessionUsage(): string {
   return `Usage: wolfpack session <command> [options]
+
+Global selector: wolfpack --machine <short-name-or-fqdn> session <supported-command> ...
 
 Commands:
   wolfpack session create <project> [--harness <agent>] [--prompt|--prompt-file|--plan <value>] [--json]
@@ -190,10 +199,14 @@ function structuredErrorCode(body: string): string | undefined {
   }
 }
 
-async function call(path: string, init: RequestInit = {}): Promise<unknown> {
+async function call(
+  path: string,
+  init: RequestInit = {},
+  target?: VerifiedMachineTarget,
+): Promise<unknown> {
   let resp: Response;
   try {
-    resp = await callApi(path, init);
+    resp = await callApi(path, init, target);
   } catch (e: unknown) {
     throw { status: 0, body: e instanceof Error ? e.message : String(e) } satisfies ApiError;
   }
@@ -433,8 +446,9 @@ export function parseAgentCommand(argv: readonly string[]): ParsedAgentCommand {
   };
 }
 
-function jsonOut(value: unknown): void {
-  printJson(value);
+function jsonOut(value: unknown, target?: VerifiedMachineTarget): void {
+  if (target) printApiJson(value, target);
+  else printJson(value);
 }
 
 function shellQuote(value: string): string {
@@ -725,7 +739,10 @@ async function materializeInitialPrompt(source: LaunchPromptSource): Promise<str
   return prompt;
 }
 
-async function runSessionOpen(parsed: SessionOpenLaunchArgs): Promise<number> {
+async function runSessionOpen(
+  parsed: SessionOpenLaunchArgs,
+  target?: VerifiedMachineTarget,
+): Promise<number> {
   const context = resolveSessionOpenContext(process.env);
   if (!context.ok) {
     return writeOpenError(parsed.output, context.code, context.message, SESSION_EXIT.NOT_FOUND);
@@ -742,8 +759,8 @@ async function runSessionOpen(parsed: SessionOpenLaunchArgs): Promise<number> {
         ...(parsed.sessionName !== undefined && { sessionName: parsed.sessionName }),
         ...(initialPrompt !== undefined && { initialPrompt }),
       }),
-    }) as SessionLaunchResponse;
-    if (parsed.output === "json") jsonOut(response);
+    }, target) as SessionLaunchResponse;
+    if (parsed.output === "json") jsonOut(response, target);
     else print(response.session);
     return SESSION_EXIT.OK;
   } catch (error: unknown) {
@@ -753,6 +770,7 @@ async function runSessionOpen(parsed: SessionOpenLaunchArgs): Promise<number> {
 
 async function runSessionCreate(
   parsed: Extract<ParsedSessionCommand, { readonly action: "create" }>,
+  target?: VerifiedMachineTarget,
 ): Promise<number> {
   const initialPrompt = await materializeInitialPrompt(parsed);
   if (typeof initialPrompt === "number") return initialPrompt;
@@ -765,8 +783,8 @@ async function runSessionCreate(
         ...(parsed.harness !== undefined && { harness: parsed.harness }),
         ...(initialPrompt !== undefined && { initialPrompt }),
       }),
-    }) as SessionLaunchResponse;
-    if (parsed.output === "json") jsonOut(response);
+    }, target) as SessionLaunchResponse;
+    if (parsed.output === "json") jsonOut(response, target);
     else print(response.session);
     return SESSION_EXIT.OK;
   } catch (error: unknown) {
@@ -804,7 +822,10 @@ async function runNotifyParent(
   }
 }
 
-export async function runAgentCommand(argv: readonly string[]): Promise<number> {
+export async function runAgentCommand(
+  argv: readonly string[],
+  target?: VerifiedMachineTarget,
+): Promise<number> {
   if (argv.length === 1 && HELP_ALIASES.has(argv[0])) {
     print(agentUsage());
     return SESSION_EXIT.OK;
@@ -822,11 +843,20 @@ export async function runAgentCommand(argv: readonly string[]): Promise<number> 
     printError(red(parsed.message));
     return SESSION_EXIT.USAGE;
   }
-  if (parsed.action === "notify-parent") return runNotifyParent(parsed);
-  return runSessionOpen(parsed);
+  if (parsed.action === "notify-parent") {
+    if (target) {
+      printError(red("--machine is not supported for agent notify-parent"));
+      return SESSION_EXIT.USAGE;
+    }
+    return runNotifyParent(parsed);
+  }
+  return runSessionOpen(parsed, target);
 }
 
-export async function runSessionCommand(argv: readonly string[]): Promise<number> {
+export async function runSessionCommand(
+  argv: readonly string[],
+  target?: VerifiedMachineTarget,
+): Promise<number> {
   if (argv.length === 1 && HELP_ALIASES.has(argv[0])) {
     print(sessionUsage());
     return SESSION_EXIT.OK;
@@ -839,6 +869,14 @@ export async function runSessionCommand(argv: readonly string[]): Promise<number
     print(sessionOpenUsage());
     return SESSION_EXIT.OK;
   }
+  if (
+    argv.length === 2
+    && ["status", "read", "send", "wait", "prompt"].includes(argv[0] ?? "")
+    && HELP_ALIASES.has(argv[1] ?? "")
+  ) {
+    print(sessionUsage());
+    return SESSION_EXIT.OK;
+  }
 
   const parsed = parseSessionCommand(argv);
   if (!parsed.ok) {
@@ -846,10 +884,14 @@ export async function runSessionCommand(argv: readonly string[]): Promise<number
     return SESSION_EXIT.USAGE;
   }
 
-  if (parsed.action === "create") return runSessionCreate(parsed);
-  if (parsed.action === "open") return runSessionOpen(parsed);
+  if (parsed.action === "create") return runSessionCreate(parsed, target);
+  if (parsed.action === "open") return runSessionOpen(parsed, target);
 
   if (parsed.action === "current-context") {
+    if (target) {
+      printError(red("--machine is not supported for session current-context"));
+      return SESSION_EXIT.USAGE;
+    }
     const context = {
       session: process.env.WOLFPACK_SESSION_NAME || "",
       projectDir: process.env.WOLFPACK_PROJECT_DIR || "",
@@ -874,8 +916,10 @@ export async function runSessionCommand(argv: readonly string[]): Promise<number
     if (parsed.action === "status") {
       const data = await call(
         `/api/session-control/status?session=${encodeURIComponent(parsed.session)}`,
+        {},
+        target,
       ) as SessionStatusResponse;
-      if (parsed.output === "json") jsonOut(data);
+      if (parsed.output === "json") jsonOut(data, target);
       else {
         print(`${data.session} (${data.sessionId})`);
         print(`${data.state} ${data.harness} ${data.projectPath}`);
@@ -883,12 +927,12 @@ export async function runSessionCommand(argv: readonly string[]): Promise<number
       return SESSION_EXIT.OK;
     }
     if (parsed.action === "read") {
-      const data = await call(`/api/session-control/read?session=${encodeURIComponent(parsed.session)}`) as {
+      const data = await call(`/api/session-control/read?session=${encodeURIComponent(parsed.session)}`, {}, target) as {
         session: string;
         sessionId: string;
         output: string;
       };
-      if (parsed.output === "json") jsonOut(data);
+      if (parsed.output === "json") jsonOut(data, target);
       else process.stdout.write(data.output);
       return SESSION_EXIT.OK;
     }
@@ -896,8 +940,8 @@ export async function runSessionCommand(argv: readonly string[]): Promise<number
       const data = await call("/api/session-control/send", {
         method: "POST",
         body: JSON.stringify({ session: parsed.session, text: parsed.text, noEnter: parsed.noEnter }),
-      });
-      if (parsed.output === "json") jsonOut(data);
+      }, target);
+      if (parsed.output === "json") jsonOut(data, target);
       return SESSION_EXIT.OK;
     }
     if (parsed.action === "prompt") {
@@ -910,16 +954,16 @@ export async function runSessionCommand(argv: readonly string[]): Promise<number
           noEnter: parsed.noEnter,
           timeoutMs: parsed.timeoutMs,
         }),
-      }) as SessionPromptResponse;
-      if (parsed.output === "json") jsonOut(data);
+      }, target) as SessionPromptResponse;
+      if (parsed.output === "json") jsonOut(data, target);
       else if (data.outcome !== SESSION_PROMPT_OUTCOME.MATCHED) print(yellow(data.outcome));
       return SESSION_PROMPT_EXIT[data.outcome] ?? SESSION_EXIT.GENERAL;
     }
     const data = await call("/api/session-control/wait", {
       method: "POST",
       body: JSON.stringify({ session: parsed.session, text: parsed.text, timeoutMs: parsed.timeoutMs }),
-    });
-    if (parsed.output === "json") jsonOut(data);
+    }, target);
+    if (parsed.output === "json") jsonOut(data, target);
     return SESSION_EXIT.OK;
   } catch (e: unknown) {
     return mapApiError(e, parsed.output);

--- a/src/cli/sessions.ts
+++ b/src/cli/sessions.ts
@@ -2,7 +2,8 @@
  * `wolfpack ls` and `wolfpack kill <name>` — talk to the local server's
  * HTTP API. JWT auth is honored when WOLFPACK_JWT_SECRET is set.
  */
-import { print, printError, printJson, bold, dim, red, green, yellow } from "./formatting.js";
+import type { VerifiedMachineTarget } from "./machine-target.js";
+import { print, printError, printApiJson, printJson, bold, dim, red, green, yellow } from "./formatting.js";
 import { baseUrl, call } from "./api.js";
 
 interface SessionRow {
@@ -30,9 +31,12 @@ function emitFailure(jsonOutput: boolean, failure: CliFailure): number {
   return failure.exitCode;
 }
 
-export async function lsSessions(argv: readonly string[] = []): Promise<number> {
+export async function lsSessions(
+  argv: readonly string[] = [],
+  target?: VerifiedMachineTarget,
+): Promise<number> {
   if (argv.length === 1 && ["--help", "-h", "help"].includes(argv[0])) {
-    print("Usage: wolfpack list [--json]");
+    print("Usage: wolfpack list [--json]\nGlobal selector: wolfpack --machine <short-name-or-fqdn> list [--json]");
     return 0;
   }
   const jsonOutput = argv.includes("--json");
@@ -48,13 +52,13 @@ export async function lsSessions(argv: readonly string[] = []): Promise<number> 
   let resp: Response;
   const apiPath = jsonOutput ? "/api/session-control/list" : "/api/sessions";
   try {
-    resp = await call(apiPath);
+    resp = await call(apiPath, {}, target);
   } catch (error: unknown) {
     return emitFailure(jsonOutput, {
       code: "SERVER_UNREACHABLE",
       message: "could not reach the wolfpack server",
       human: [
-        red(`  Could not reach the wolfpack server at ${baseUrl()}.`),
+        red(`  Could not reach the wolfpack server at ${baseUrl(target)}.`),
         dim("  Is it running? Try: wolfpack service status"),
         dim(`  Error: ${error instanceof Error ? error.message : String(error)}`),
       ],
@@ -92,7 +96,7 @@ export async function lsSessions(argv: readonly string[] = []): Promise<number> 
   }
   const sessions = data.sessions ?? [];
   if (jsonOutput) {
-    printJson({ sessions });
+    printApiJson({ sessions }, target);
     return 0;
   }
   if (sessions.length === 0) {
@@ -112,12 +116,15 @@ export async function lsSessions(argv: readonly string[] = []): Promise<number> 
   return 0;
 }
 
-export async function killSession(argv: readonly string[]): Promise<number> {
+export async function killSession(
+  argv: readonly string[],
+  target?: VerifiedMachineTarget,
+): Promise<number> {
   const args = [...argv];
   const jsonOutput = args.includes("--json");
   if (jsonOutput) args.splice(args.indexOf("--json"), 1);
   if (args.length === 1 && ["--help", "-h", "help"].includes(args[0])) {
-    print("Usage: wolfpack kill <session-or-id> [--json]");
+    print("Usage: wolfpack kill <session-or-id> [--json]\nGlobal selector: wolfpack --machine <short-name-or-fqdn> kill <session-or-id> [--json]");
     return 0;
   }
   const name = args[0];
@@ -132,13 +139,13 @@ export async function killSession(argv: readonly string[]): Promise<number> {
 
   let resp: Response;
   try {
-    resp = await call("/api/kill", { method: "POST", body: JSON.stringify({ session: name }) });
+    resp = await call("/api/kill", { method: "POST", body: JSON.stringify({ session: name }) }, target);
   } catch (error: unknown) {
     return emitFailure(jsonOutput, {
       code: "SERVER_UNREACHABLE",
       message: "could not reach the wolfpack server",
       human: [
-        red(`  Could not reach the wolfpack server at ${baseUrl()}.`),
+        red(`  Could not reach the wolfpack server at ${baseUrl(target)}.`),
         dim(`  Error: ${error instanceof Error ? error.message : String(error)}`),
       ],
       exitCode: 1,
@@ -181,7 +188,7 @@ export async function killSession(argv: readonly string[]): Promise<number> {
       exitCode: 1,
     });
   }
-  if (jsonOutput) printJson(data);
+  if (jsonOutput) printApiJson(data, target);
   else print(green(`  Killed session "${data.session}".`));
   return 0;
 }

--- a/src/tailnet-machine-contract.ts
+++ b/src/tailnet-machine-contract.ts
@@ -201,37 +201,41 @@ export function enumerateTailnetCandidates(status: unknown): TailnetCandidateEnu
   };
 }
 
-function hasRequiredCapabilities(value: unknown): value is readonly string[] {
+function hasRequiredCapabilities(
+  value: unknown,
+  requiredCapabilities: readonly MachineCapability[],
+): value is readonly string[] {
   return Array.isArray(value)
     && value.length <= MACHINE_MAX_CAPABILITIES
     && value.every((capability) => typeof capability === "string" && capability.length > 0)
     && new Set(value).size === value.length
-    && MACHINE_CAPABILITIES.every((capability) => value.includes(capability));
+    && requiredCapabilities.every((capability) => value.includes(capability));
 }
 
-/** Strictly classifies a peer's handshake against the candidate facts that authorized its origin. */
-export function classifyMachineHandshake(
-  candidate: TailnetMachineCandidate,
+function classifyHandshakeForExpectedMachine(
+  origin: string,
+  tailnetNodeId: string | undefined,
+  requiredCapabilities: readonly MachineCapability[],
   value: unknown,
 ): MachineHandshakeClassification {
   if (!isRecord(value) || !isRecord(value.protocol) || value.protocol.name !== MACHINE_PROTOCOL.NAME) {
     return { kind: "non-wolfpack" };
   }
   if (
-    value.protocol.major !== MACHINE_PROTOCOL.MAJOR
+    !TAILNET_ORIGIN_REGEXP.test(origin)
+    || value.protocol.major !== MACHINE_PROTOCOL.MAJOR
     || !Number.isInteger(value.protocol.minor)
     || (value.protocol.minor as number) < 0
     || !isRecord(value.machine)
-    || value.machine.tailnetNodeId !== candidate.tailnetNodeId
-    || value.machine.origin !== candidate.origin
+    || (tailnetNodeId !== undefined && value.machine.tailnetNodeId !== tailnetNodeId)
+    || value.machine.origin !== origin
     || !isTailnetNodeId(value.machine.tailnetNodeId)
-    || canonicalTailnetOrigin(candidate.hostname) !== candidate.origin
     || typeof value.machine.installationId !== "string"
     || !UUID_PATTERN.test(value.machine.installationId)
     || !isBoundedVisibleString(value.machine.displayName, MAX_DISPLAY_NAME_LENGTH)
     || !isRecord(value.wolfpack)
     || !isBoundedVisibleString(value.wolfpack.version, MAX_VERSION_LENGTH)
-    || !hasRequiredCapabilities(value.capabilities)
+    || !hasRequiredCapabilities(value.capabilities, requiredCapabilities)
   ) {
     return { kind: "incompatible" };
   }
@@ -254,4 +258,26 @@ export function classifyMachineHandshake(
       capabilities: value.capabilities.filter((capability): capability is MachineCapability => MACHINE_CAPABILITY_SET.has(capability)),
     },
   };
+}
+
+/** Strictly classifies a peer's handshake against one explicitly selected canonical origin. */
+export function classifyMachineHandshakeForOrigin(
+  origin: string,
+  value: unknown,
+): MachineHandshakeClassification {
+  return classifyHandshakeForExpectedMachine(origin, undefined, [MACHINE_CAPABILITY.SESSIONS], value);
+}
+
+/** Strictly classifies a peer's handshake against the candidate facts that authorized its origin. */
+export function classifyMachineHandshake(
+  candidate: TailnetMachineCandidate,
+  value: unknown,
+): MachineHandshakeClassification {
+  if (canonicalTailnetOrigin(candidate.hostname) !== candidate.origin) return { kind: "incompatible" };
+  return classifyHandshakeForExpectedMachine(
+    candidate.origin,
+    candidate.tailnetNodeId,
+    MACHINE_CAPABILITIES,
+    value,
+  );
 }

--- a/src/tailnet-machine-contract.ts
+++ b/src/tailnet-machine-contract.ts
@@ -201,41 +201,37 @@ export function enumerateTailnetCandidates(status: unknown): TailnetCandidateEnu
   };
 }
 
-function hasRequiredCapabilities(
-  value: unknown,
-  requiredCapabilities: readonly MachineCapability[],
-): value is readonly string[] {
+function hasRequiredCapabilities(value: unknown): value is readonly string[] {
   return Array.isArray(value)
     && value.length <= MACHINE_MAX_CAPABILITIES
     && value.every((capability) => typeof capability === "string" && capability.length > 0)
     && new Set(value).size === value.length
-    && requiredCapabilities.every((capability) => value.includes(capability));
+    && MACHINE_CAPABILITIES.every((capability) => value.includes(capability));
 }
 
-function classifyHandshakeForExpectedMachine(
-  origin: string,
-  tailnetNodeId: string | undefined,
-  requiredCapabilities: readonly MachineCapability[],
+/** Strictly classifies a peer's handshake against the candidate facts that authorized its origin. */
+export function classifyMachineHandshake(
+  candidate: TailnetMachineCandidate,
   value: unknown,
 ): MachineHandshakeClassification {
   if (!isRecord(value) || !isRecord(value.protocol) || value.protocol.name !== MACHINE_PROTOCOL.NAME) {
     return { kind: "non-wolfpack" };
   }
   if (
-    !TAILNET_ORIGIN_REGEXP.test(origin)
-    || value.protocol.major !== MACHINE_PROTOCOL.MAJOR
+    value.protocol.major !== MACHINE_PROTOCOL.MAJOR
     || !Number.isInteger(value.protocol.minor)
     || (value.protocol.minor as number) < 0
     || !isRecord(value.machine)
-    || (tailnetNodeId !== undefined && value.machine.tailnetNodeId !== tailnetNodeId)
-    || value.machine.origin !== origin
+    || value.machine.tailnetNodeId !== candidate.tailnetNodeId
+    || value.machine.origin !== candidate.origin
     || !isTailnetNodeId(value.machine.tailnetNodeId)
+    || canonicalTailnetOrigin(candidate.hostname) !== candidate.origin
     || typeof value.machine.installationId !== "string"
     || !UUID_PATTERN.test(value.machine.installationId)
     || !isBoundedVisibleString(value.machine.displayName, MAX_DISPLAY_NAME_LENGTH)
     || !isRecord(value.wolfpack)
     || !isBoundedVisibleString(value.wolfpack.version, MAX_VERSION_LENGTH)
-    || !hasRequiredCapabilities(value.capabilities, requiredCapabilities)
+    || !hasRequiredCapabilities(value.capabilities)
   ) {
     return { kind: "incompatible" };
   }
@@ -260,24 +256,57 @@ function classifyHandshakeForExpectedMachine(
   };
 }
 
+// Keep CLI-only validation separate: classifyMachineHandshake is browser-bundled.
+function hasRequiredCapabilitiesForOrigin(value: unknown): value is readonly string[] {
+  return Array.isArray(value)
+    && value.length <= MACHINE_MAX_CAPABILITIES
+    && value.every((capability) => typeof capability === "string" && capability.length > 0)
+    && new Set(value).size === value.length
+    && value.includes(MACHINE_CAPABILITY.SESSIONS);
+}
+
 /** Strictly classifies a peer's handshake against one explicitly selected canonical origin. */
 export function classifyMachineHandshakeForOrigin(
   origin: string,
   value: unknown,
 ): MachineHandshakeClassification {
-  return classifyHandshakeForExpectedMachine(origin, undefined, [MACHINE_CAPABILITY.SESSIONS], value);
-}
+  if (!isRecord(value) || !isRecord(value.protocol) || value.protocol.name !== MACHINE_PROTOCOL.NAME) {
+    return { kind: "non-wolfpack" };
+  }
+  if (
+    !TAILNET_ORIGIN_REGEXP.test(origin)
+    || value.protocol.major !== MACHINE_PROTOCOL.MAJOR
+    || !Number.isInteger(value.protocol.minor)
+    || (value.protocol.minor as number) < 0
+    || !isRecord(value.machine)
+    || value.machine.origin !== origin
+    || !isTailnetNodeId(value.machine.tailnetNodeId)
+    || typeof value.machine.installationId !== "string"
+    || !UUID_PATTERN.test(value.machine.installationId)
+    || !isBoundedVisibleString(value.machine.displayName, MAX_DISPLAY_NAME_LENGTH)
+    || !isRecord(value.wolfpack)
+    || !isBoundedVisibleString(value.wolfpack.version, MAX_VERSION_LENGTH)
+    || !hasRequiredCapabilitiesForOrigin(value.capabilities)
+  ) {
+    return { kind: "incompatible" };
+  }
 
-/** Strictly classifies a peer's handshake against the candidate facts that authorized its origin. */
-export function classifyMachineHandshake(
-  candidate: TailnetMachineCandidate,
-  value: unknown,
-): MachineHandshakeClassification {
-  if (canonicalTailnetOrigin(candidate.hostname) !== candidate.origin) return { kind: "incompatible" };
-  return classifyHandshakeForExpectedMachine(
-    candidate.origin,
-    candidate.tailnetNodeId,
-    MACHINE_CAPABILITIES,
-    value,
-  );
+  return {
+    kind: "ready",
+    handshake: {
+      protocol: {
+        name: MACHINE_PROTOCOL.NAME,
+        major: MACHINE_PROTOCOL.MAJOR,
+        minor: value.protocol.minor as number,
+      },
+      machine: {
+        tailnetNodeId: value.machine.tailnetNodeId,
+        installationId: value.machine.installationId,
+        displayName: value.machine.displayName,
+        origin: value.machine.origin,
+      },
+      wolfpack: { version: value.wolfpack.version },
+      capabilities: value.capabilities.filter((capability): capability is MachineCapability => MACHINE_CAPABILITY_SET.has(capability)),
+    },
+  };
 }

--- a/tests/integration/cli-machine-routing.test.ts
+++ b/tests/integration/cli-machine-routing.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { MACHINE_CAPABILITY } from "../../src/tailnet-machine-contract.ts";
+import type { Subprocess } from "bun";
+
+const root = process.cwd();
+const cliEntry = join(root, "src/cli/index.ts");
+const ORIGIN = "https://peer.example.ts.net";
+const JWT_SECRET = "remote-cli-test-secret-that-is-at-least-32-bytes";
+const tempHomes: string[] = [];
+
+function handshake(origin = ORIGIN): object {
+  return {
+    protocol: { name: "wolfpack-machine", major: 1, minor: 0 },
+    machine: {
+      tailnetNodeId: "n-peer",
+      installationId: "2af8af29-c4fe-44f9-9a99-9a0e35952d74",
+      displayName: "peer",
+      origin,
+    },
+    wolfpack: { version: "1.7.0" },
+    capabilities: [MACHINE_CAPABILITY.SESSIONS],
+  };
+}
+
+function spawnCli(args: readonly string[], fixtureUrl: string): Subprocess<"ignore", "pipe", "pipe"> {
+  const home = mkdtempSync(join(tmpdir(), "wolfpack-remote-cli-"));
+  tempHomes.push(home);
+  mkdirSync(join(home, ".wolfpack"), { recursive: true });
+  writeFileSync(join(home, ".wolfpack", "config.json"), JSON.stringify({
+    devDir: root,
+    port: 18790,
+    tailscaleHostname: "local.example.ts.net",
+  }));
+  const preload = join(home, "remote-fetch-preload.ts");
+  writeFileSync(preload, `
+    const nativeFetch = globalThis.fetch;
+    globalThis.fetch = async (input, init) => {
+      const url = new URL(String(input));
+      if (url.origin !== ${JSON.stringify(ORIGIN)}) {
+        throw new Error("unexpected non-remote request: " + String(input));
+      }
+      return nativeFetch(${JSON.stringify(fixtureUrl)} + url.pathname + url.search, init);
+    };
+  `);
+  return Bun.spawn([process.execPath, "--preload", preload, cliEntry, ...args], {
+    cwd: root,
+    env: {
+      ...process.env,
+      HOME: home,
+      NO_COLOR: "1",
+      WOLFPACK_JWT_SECRET: JWT_SECRET,
+    },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+afterEach(() => {
+  for (const home of tempHomes.splice(0)) rmSync(home, { recursive: true, force: true });
+});
+
+describe("remote machine cli network boundary", () => {
+  test("authenticates the handshake and mutation, preserves sessionId, and emits canonical machine identity", async () => {
+    const requests: Array<{ readonly path: string; readonly authorization: string | null }> = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        requests.push({ path: url.pathname, authorization: request.headers.get("authorization") });
+        if (url.pathname === "/api/machine") return Response.json(handshake());
+        if (url.pathname === "/api/session-create") {
+          return Response.json({
+            ok: true,
+            session: "project",
+            sessionId: "server-owned-session-id",
+            project: "project",
+            harness: "pi",
+          });
+        }
+        return new Response("unexpected", { status: 500 });
+      },
+    });
+
+    try {
+      const child = spawnCli([
+        "--machine", "peer", "session", "create", "project", "--harness", "pi", "--json",
+      ], `http://127.0.0.1:${server.port}`);
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(requests.map(({ path }) => path)).toEqual(["/api/machine", "/api/session-create"]);
+      expect(requests.every(({ authorization }) => authorization?.startsWith("Bearer ") === true)).toBe(true);
+      const output = JSON.parse(stdout);
+      expect(output.sessionId).toBe("server-owned-session-id");
+      expect(output.machine).toEqual((handshake() as { readonly machine: object }).machine);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  for (const command of ["list", "ls"] as const) {
+    test(`routes the ${command} alias through handshake verification`, async () => {
+      const paths: string[] = [];
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch(request) {
+          const path = new URL(request.url).pathname;
+          paths.push(path);
+          if (path === "/api/machine") return Response.json(handshake());
+          if (path === "/api/session-control/list") return Response.json({ sessions: [] });
+          return new Response("unexpected", { status: 500 });
+        },
+      });
+
+      try {
+        const child = spawnCli(["--machine", "peer", command, "--json"], `http://127.0.0.1:${server.port}`);
+        const [exitCode, stdout] = await Promise.all([
+          child.exited,
+          new Response(child.stdout).text(),
+        ]);
+
+        expect(exitCode).toBe(0);
+        expect(paths).toEqual(["/api/machine", "/api/session-control/list"]);
+        expect(JSON.parse(stdout).machine).toEqual((handshake() as { readonly machine: object }).machine);
+      } finally {
+        server.stop(true);
+      }
+    });
+  }
+
+  test("origin mismatch fails before mutation without localhost fallback", async () => {
+    const paths: string[] = [];
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        const path = new URL(request.url).pathname;
+        paths.push(path);
+        if (path === "/api/machine") {
+          return Response.json(handshake("https://other.example.ts.net"));
+        }
+        return Response.json({ ok: true });
+      },
+    });
+
+    try {
+      const child = spawnCli([
+        "--machine", "peer", "kill", "server-owned-session-id", "--json",
+      ], `http://127.0.0.1:${server.port}`);
+      const [exitCode, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(stderr).toBe("");
+      expect(paths).toEqual(["/api/machine"]);
+      expect(JSON.parse(stdout)).toEqual({
+        ok: false,
+        error: {
+          code: "INCOMPATIBLE_MACHINE",
+          message: "machine handshake is incompatible with session control",
+        },
+      });
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/tests/unit/agent-skills.test.ts
+++ b/tests/unit/agent-skills.test.ts
@@ -93,6 +93,22 @@ describe("agent skills", () => {
     expect(identityDocs).toContain("server derives the child harness");
   });
 
+  test("documents explicit fail-closed remote machine control", () => {
+    const skill = readRepoFile("skills/wolfpack-tailnet-control/SKILL.md");
+    const readme = readRepoFile("README.md");
+    const controlDocs = readRepoFile("docs/session-control.md");
+
+    for (const content of [skill, readme, controlDocs]) {
+      expect(content).toContain("wolfpack --machine <short-name-or-fqdn>");
+      expect(content).toContain("tailscaleHostname");
+      expect(content.toLowerCase()).toContain("fail closed");
+    }
+    expect(controlDocs).toContain("GET /api/machine");
+    expect(controlDocs).toContain("JWT");
+    expect(controlDocs).toContain('"machine"');
+    expect(controlDocs).toContain("selected machine");
+  });
+
   test("skill docs point at existing repo references", () => {
     const skill = readRepoFile("skills/wolfpack-tailnet-control/SKILL.md");
     const references = [

--- a/tests/unit/cli-help.test.ts
+++ b/tests/unit/cli-help.test.ts
@@ -150,6 +150,41 @@ describe("cli help dispatch", () => {
     });
   }
 
+  test("global machine help is side-effect-free and documents the selector", () => {
+    for (const args of [
+      ["--machine", "peer", "--help"],
+      ["--machine", "peer", "session", "--help"],
+      ["--machine", "peer", "session", "status", "--help"],
+      ["--machine", "peer", "session", "prompt", "--help"],
+      ["--machine", "peer", "agent", "spawn", "--help"],
+      ["--machine", "peer", "list", "--help"],
+    ]) {
+      const child = runCli(args);
+      expect(child.exitCode, args.join(" ")).toBe(0);
+      expect(child.stdout).toContain("--machine <short-name-or-fqdn>");
+      expect(child.stderr).toBe("");
+    }
+  });
+
+  test("rejects malformed and unsupported global machine combinations before any probe", () => {
+    for (const args of [
+      ["--machine"],
+      ["--machine", "peer", "--machine", "other", "list"],
+      ["list", "--machine", "peer"],
+      ["session", "send", "local-session", "--machine", "peer"],
+      ["session", "send", "local-session", "--machine=peer"],
+      ["--machine", "peer", "session", "send", "remote-session", "--machine", "other"],
+      ["--machine", "peer", "session", "send", "remote-session", "--machine=other"],
+      ["--machine", "peer", "doctor", "--json"],
+      ["--machine", "peer", "agent", "notify-parent", "--json"],
+      ["--machine", "peer", "session", "current-context", "--json"],
+    ]) {
+      const child = runCli(args);
+      expect(child.exitCode, args.join(" ")).toBe(2);
+      expect(child.stderr, args.join(" ")).not.toContain("No valid config found");
+    }
+  });
+
   test("session open help needs no parent context and performs no HTTP request", async () => {
     let requestCount = 0;
     const server = Bun.serve({

--- a/tests/unit/cli-machine-routing.test.ts
+++ b/tests/unit/cli-machine-routing.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+
+const ORIGIN = "https://peer.example.ts.net";
+const TARGET = {
+  kind: "remote",
+  origin: ORIGIN,
+  machine: {
+    tailnetNodeId: "n-peer",
+    installationId: "2af8af29-c4fe-44f9-9a99-9a0e35952d74",
+    displayName: "peer",
+    origin: ORIGIN,
+  },
+} as const;
+
+function run(script: string) {
+  return Bun.spawnSync([process.execPath, "-e", script], {
+    cwd: process.cwd(),
+    env: { ...process.env, NO_COLOR: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+describe("remote machine control routing", () => {
+  test("routes every planned command family and enriches json once without rewriting session ids", () => {
+    const script = `
+      process.env.WOLFPACK_SESSION_NAME = "parent";
+      process.env.WOLFPACK_AGENT_KIND = "pi";
+      const target = ${JSON.stringify(TARGET)};
+      const calls = [];
+      globalThis.fetch = async (input, init) => {
+        const url = new URL(String(input));
+        calls.push({ url: String(input), method: init?.method ?? "GET" });
+        if (url.pathname === "/api/session-control/list") return Response.json({ sessions: [{ session: "alpha", sessionId: "id-list" }] });
+        if (url.pathname === "/api/session-create") return Response.json({ ok: true, session: "created", sessionId: "id-create", project: "project", harness: "pi" });
+        if (url.pathname === "/api/session-open") return Response.json({ ok: true, session: "child", sessionId: "id-open", project: "project", harness: "pi" });
+        if (url.pathname === "/api/session-control/status") return Response.json({ ok: true, selector: "alpha", session: "alpha", sessionId: "id-status", state: "active", project: "project", projectPath: "/tmp/project", projectDir: "/tmp/project", harness: "pi", terminal: { exists: true, alive: true, status: "ready" } });
+        if (url.pathname === "/api/session-control/read") return Response.json({ session: "alpha", sessionId: "id-read", output: "ready" });
+        if (url.pathname === "/api/session-control/send") return Response.json({ ok: true, session: "alpha", sessionId: "id-send" });
+        if (url.pathname === "/api/session-control/wait") return Response.json({ ok: true, session: "alpha", sessionId: "id-wait", matched: true });
+        if (url.pathname === "/api/session-control/prompt") return Response.json({ ok: true, session: "alpha", sessionId: "id-prompt", outcome: "matched", outputBoundarySeq: "12" });
+        if (url.pathname === "/api/kill") return Response.json({ ok: true, session: "alpha", sessionId: "id-kill" });
+        return new Response("unexpected", { status: 500 });
+      };
+      const { lsSessions, killSession } = await import("./src/cli/sessions.ts");
+      const { runAgentCommand, runSessionCommand } = await import("./src/cli/session-control.ts");
+      const codes = [];
+      codes.push(await lsSessions(["--json"], target));
+      codes.push(await runSessionCommand(["create", "project", "--harness", "pi", "--json"], target));
+      codes.push(await runSessionCommand(["open", "project", "--json"], target));
+      codes.push(await runAgentCommand(["spawn", "project", "--json"], target));
+      codes.push(await runSessionCommand(["status", "alpha", "--json"], target));
+      codes.push(await runSessionCommand(["read", "alpha", "--json"], target));
+      codes.push(await runSessionCommand(["send", "alpha", "hello", "--json"], target));
+      codes.push(await runSessionCommand(["wait", "alpha", "ready", "--json"], target));
+      codes.push(await runSessionCommand(["prompt", "alpha", "run", "--until", "ready", "--json"], target));
+      codes.push(await killSession(["alpha", "--json"], target));
+      if (codes.some(code => code !== 0)) process.exit(97);
+      console.error(JSON.stringify(calls));
+    `;
+    const child = run(script);
+
+    expect(child.exitCode).toBe(0);
+    const calls = JSON.parse(child.stderr.toString()) as Array<{ readonly url: string; readonly method: string }>;
+    expect(calls).toHaveLength(10);
+    expect(calls.every(({ url }) => url.startsWith(`${ORIGIN}/api/`))).toBe(true);
+    expect(calls.map(({ url }) => new URL(url).pathname)).toEqual([
+      "/api/session-control/list",
+      "/api/session-create",
+      "/api/session-open",
+      "/api/session-open",
+      "/api/session-control/status",
+      "/api/session-control/read",
+      "/api/session-control/send",
+      "/api/session-control/wait",
+      "/api/session-control/prompt",
+      "/api/kill",
+    ]);
+
+    const envelopes = child.stdout.toString().trim().split("\n").map((line) => JSON.parse(line));
+    expect(envelopes).toHaveLength(10);
+    for (const envelope of envelopes) expect(envelope.machine).toEqual(TARGET.machine);
+    expect(envelopes.map((envelope) => envelope.sessionId ?? envelope.sessions?.[0]?.sessionId)).toEqual([
+      "id-list",
+      "id-create",
+      "id-open",
+      "id-open",
+      "id-status",
+      "id-read",
+      "id-send",
+      "id-wait",
+      "id-prompt",
+      "id-kill",
+    ]);
+  });
+
+  test("keeps local request urls and json byte shape unchanged without a target", () => {
+    const child = run(`
+      globalThis.fetch = async (input) => {
+        if (String(input) !== "http://127.0.0.1:18790/api/session-control/list") process.exit(98);
+        return Response.json({ sessions: [{ session: "alpha", sessionId: "id-alpha" }] });
+      };
+      const { lsSessions } = await import("./src/cli/sessions.ts");
+      process.exit(await lsSessions(["--json"]));
+    `);
+
+    expect(child.exitCode).toBe(0);
+    expect(child.stdout.toString()).toBe('{"sessions":[{"session":"alpha","sessionId":"id-alpha"}]}\n');
+  });
+});

--- a/tests/unit/cli-machine-target.test.ts
+++ b/tests/unit/cli-machine-target.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+import {
+  extractMachineSelector,
+  resolveMachineOrigin,
+  verifyMachineTarget,
+} from "../../src/cli/machine-target.ts";
+import { MACHINE_CAPABILITY } from "../../src/tailnet-machine-contract.ts";
+import type { MachineHandshake } from "../../src/tailnet-machine-contract.ts";
+
+const ORIGIN = "https://peer.example.ts.net";
+const CONFIGURED_HOSTNAME = "local.example.ts.net";
+const HANDSHAKE_LIMIT = 32 * 1024;
+
+function handshake(origin = ORIGIN): MachineHandshake {
+  return {
+    protocol: { name: "wolfpack-machine", major: 1, minor: 0 },
+    machine: {
+      tailnetNodeId: "n-peer",
+      installationId: "2af8af29-c4fe-44f9-9a99-9a0e35952d74",
+      displayName: "peer",
+      origin,
+    },
+    wolfpack: { version: "1.7.0" },
+    capabilities: [MACHINE_CAPABILITY.SESSIONS],
+  };
+}
+
+function successfulResponse(value: unknown = handshake()): Response {
+  return Response.json(value);
+}
+
+describe("global machine selector", () => {
+  test("extracts exactly one leading global selector", () => {
+    expect(extractMachineSelector(["--machine", "peer", "session", "status", "id", "--json"])).toEqual({
+      ok: true,
+      selector: "peer",
+      argv: ["session", "status", "id", "--json"],
+    });
+    expect(extractMachineSelector(["list", "--json"])).toEqual({
+      ok: true,
+      selector: undefined,
+      argv: ["list", "--json"],
+    });
+  });
+
+  test.each([
+    ["missing value", ["--machine"]],
+    ["flag-shaped value", ["--machine", "--json", "list"]],
+    ["duplicate selector", ["--machine", "peer", "--machine", "other", "list"]],
+    ["equals form", ["--machine=peer", "list"]],
+  ] as const)("rejects %s", (_name, argv) => {
+    const parsed = extractMachineSelector(argv);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) expect(parsed.error.code).toBe("INVALID_MACHINE_SELECTOR");
+  });
+
+  test.each([
+    ["non-leading pair", ["session", "send", "local-session", "--machine", "peer"]],
+    ["non-leading equals form", ["session", "send", "local-session", "--machine=peer"]],
+    ["later duplicate pair", ["--machine", "peer", "session", "send", "remote-session", "--machine", "other"]],
+    ["later duplicate equals form", ["--machine", "peer", "session", "send", "remote-session", "--machine=other"]],
+  ] as const)("rejects a %s anywhere outside the sole leading selector pair", (_name, argv) => {
+    const parsed = extractMachineSelector(argv);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) expect(parsed.error.code).toBe("INVALID_MACHINE_SELECTOR");
+  });
+});
+
+describe("machine origin resolution", () => {
+  test("resolves a short name and a canonical same-tailnet fqdn", () => {
+    expect(resolveMachineOrigin("peer", CONFIGURED_HOSTNAME)).toEqual({ ok: true, origin: ORIGIN });
+    expect(resolveMachineOrigin("peer.example.ts.net", CONFIGURED_HOSTNAME)).toEqual({ ok: true, origin: ORIGIN });
+  });
+
+  test("derives the exact namespace from the configured hostname", () => {
+    expect(resolveMachineOrigin("peer", "local.team-name.ts.net")).toEqual({
+      ok: true,
+      origin: "https://peer.team-name.ts.net",
+    });
+    expect(resolveMachineOrigin("peer.example.ts.net", "local.team-name.ts.net").ok).toBe(false);
+  });
+
+  test.each([
+    ["url", "https://peer.example.ts.net"],
+    ["port", "peer.example.ts.net:443"],
+    ["path", "peer.example.ts.net/api"],
+    ["malformed label", "bad_name"],
+    ["empty label", "peer..example.ts.net"],
+    ["foreign tailnet", "peer.foreign.ts.net"],
+    ["non-canonical fqdn", "Peer.example.ts.net"],
+  ] as const)("rejects a %s", (_name, selector) => {
+    expect(resolveMachineOrigin(selector, CONFIGURED_HOSTNAME).ok).toBe(false);
+  });
+
+  test("rejects missing or invalid tailnet configuration", () => {
+    expect(resolveMachineOrigin("peer", undefined).ok).toBe(false);
+    expect(resolveMachineOrigin("peer", "local.ts.net").ok).toBe(false);
+    expect(resolveMachineOrigin("peer", "https://local.example.ts.net").ok).toBe(false);
+  });
+});
+
+describe("machine handshake verification", () => {
+  test("probes the exact endpoint with jwt, redirects disabled, and returns structured identity", async () => {
+    const calls: Array<{ readonly input: string; readonly init: RequestInit }> = [];
+    const result = await verifyMachineTarget("peer", {
+      tailscaleHostname: CONFIGURED_HOSTNAME,
+      jwt: "signed-token",
+      fetcher: async (input, init) => {
+        calls.push({ input, init });
+        return successfulResponse();
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      target: {
+        kind: "remote",
+        origin: ORIGIN,
+        machine: handshake().machine,
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(new Headers(calls[0]?.init.headers).get("authorization")).toBe("Bearer signed-token");
+    expect(calls[0]).toMatchObject({
+      input: `${ORIGIN}/api/machine`,
+      init: {
+        method: "GET",
+        redirect: "error",
+        headers: expect.any(Headers),
+      },
+    });
+  });
+
+  test.each([
+    ["mismatched origin", handshake("https://other.example.ts.net")],
+    ["incompatible protocol", { ...handshake(), protocol: { name: "wolfpack-machine", major: 2, minor: 0 } }],
+    ["missing session capability", { ...handshake(), capabilities: [MACHINE_CAPABILITY.PUSH_SUBSCRIPTION] }],
+    ["display prose", { name: "peer", url: ORIGIN }],
+  ] as const)("rejects %s", async (_name, value) => {
+    const result = await verifyMachineTarget("peer", {
+      tailscaleHostname: CONFIGURED_HOSTNAME,
+      fetcher: async () => successfulResponse(value),
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("INCOMPATIBLE_MACHINE");
+  });
+
+  test("rejects an oversized declared body without reading it", async () => {
+    const response = new Response("x", {
+      headers: { "content-length": String(HANDSHAKE_LIMIT + 1) },
+    });
+    const result = await verifyMachineTarget("peer", {
+      tailscaleHostname: CONFIGURED_HOSTNAME,
+      fetcher: async () => response,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe("INVALID_MACHINE_RESPONSE");
+    expect(response.bodyUsed).toBe(false);
+  });
+
+  test("rejects and cancels an oversized chunked body", async () => {
+    let cancelled = false;
+    const response = new Response(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(HANDSHAKE_LIMIT + 1));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    }));
+    const result = await verifyMachineTarget("peer", {
+      tailscaleHostname: CONFIGURED_HOSTNAME,
+      fetcher: async () => response,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(cancelled).toBe(true);
+  });
+
+  test("fails closed on redirects, timeouts, and unreachable peers", async () => {
+    const redirect = await verifyMachineTarget("peer", {
+      tailscaleHostname: CONFIGURED_HOSTNAME,
+      fetcher: async () => new Response("", { status: 302, headers: { location: "http://127.0.0.1" } }),
+    });
+    const timeout = await verifyMachineTarget("peer", {
+      tailscaleHostname: CONFIGURED_HOSTNAME,
+      timeoutMs: 10,
+      fetcher: async () => new Promise<Response>(() => {}),
+    });
+    const unreachable = await verifyMachineTarget("peer", {
+      tailscaleHostname: CONFIGURED_HOSTNAME,
+      fetcher: async () => { throw new Error("connection refused"); },
+    });
+
+    expect(redirect.ok).toBe(false);
+    expect(timeout.ok).toBe(false);
+    expect(unreachable.ok).toBe(false);
+  });
+
+  test("never attempts localhost when explicit target verification fails", async () => {
+    const urls: string[] = [];
+    const result = await verifyMachineTarget("peer", {
+      tailscaleHostname: CONFIGURED_HOSTNAME,
+      fetcher: async (input) => {
+        urls.push(input);
+        throw new Error("unreachable");
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(urls).toEqual([`${ORIGIN}/api/machine`]);
+    expect(urls.every((url) => !url.includes("127.0.0.1") && !url.includes("localhost"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## summary
- add global `--machine <short-name-or-fqdn>` routing for the supported session-control commands
- verify canonical same-tailnet machine identity with bounded, authenticated, redirect-free handshakes and no localhost fallback
- preserve stable session IDs and enrich remote JSON responses with verified machine identity
- document the contract and add unit/integration regression coverage

## verification
- `bun test` — 1887 passed, 22 existing broker-binary skips, 0 failed
- `bun run typecheck`
- `git diff --check`
- independent delivery/security/quality/antipattern review; correction re-reviewed clean

Closes #286