### PR TITLE
fix ci timeout and server-only deploy builds

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -55,6 +55,7 @@ function run(cmd: string) {
 // read version from main package.json
 const mainPkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf-8"));
 const version: string = mainPkg.version;
+const BUILD_SERVER_ONLY = process.env.WOLFPACK_BUILD_SERVER_ONLY === "1";
 
 // sync optionalDependencies versions in main package.json
 let pkgDirty = false;
@@ -93,10 +94,10 @@ mkdirSync(DIST, { recursive: true });
 //      `bun run scripts/build.ts` is for testing/dev-deploy on the host
 //      — not for publishing artifacts. Tests + `deploy-local.sh` only ever
 //      consume the host-arch broker, so this is safe.
+const brokerStaged: Record<string, string> = {};
+if (!BUILD_SERVER_ONLY) {
 console.log("\n=== staging wolfpack-broker for each platform target ===");
 mkdirSync(BROKER_DIR, { recursive: true });
-
-const brokerStaged: Record<string, string> = {};
 const missingStaged: string[] = [];
 for (const target of TARGETS) {
   const staged = join(BROKER_DIR, target, "wolfpack-broker");
@@ -148,6 +149,7 @@ if (hostTarget && brokerStaged[hostTarget]) {
   chmodSync(hostDest, 0o755);
   console.log(`  copied ${brokerStaged[hostTarget]} → ${hostDest} (host arch — used by deploy-local.sh)`);
 }
+}
 
 // step 4: compile wolfpack itself for each target
 console.log("\n=== compiling binaries ===");
@@ -158,6 +160,7 @@ for (const target of TARGETS) {
 }
 
 // step 4: generate per-platform npm package dirs
+if (!BUILD_SERVER_ONLY) {
 console.log("\n=== generating platform packages ===");
 mkdirSync(NPM_DIR, { recursive: true });
 
@@ -199,6 +202,7 @@ for (const target of TARGETS) {
 
   console.log(`  ${meta.name}/  (wolfpack + wolfpack-broker)`);
 }
+}
 
 // step 5: copy current platform binary to bin/ for local dev
 const currentBin = join(DIST, `wolfpack-${platform()}-${arch()}`);
@@ -208,4 +212,4 @@ console.log(`\ncopied ${currentBin} → bin/wolfpack`);
 
 console.log("\n=== build complete ===");
 console.log(`binaries in ${DIST}/`);
-console.log(`platform packages in ${NPM_DIR}/`);
+if (!BUILD_SERVER_ONLY) console.log(`platform packages in ${NPM_DIR}/`);

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -306,7 +306,7 @@ verify_service_pid() {
 if [ "$DEPLOY_BROKER" = "0" ]; then
   WOLFPACK_BUILD_SERVER_ONLY=1 bun run scripts/build.ts
 else
-  bun run scripts/build.ts
+  WOLFPACK_BUILD_SERVER_ONLY=0 bun run scripts/build.ts
 fi
 
 ARCH="$(uname -m)"

--- a/scripts/deploy-local.sh
+++ b/scripts/deploy-local.sh
@@ -303,7 +303,11 @@ verify_service_pid() {
   fi
 }
 
-bun run scripts/build.ts
+if [ "$DEPLOY_BROKER" = "0" ]; then
+  WOLFPACK_BUILD_SERVER_ONLY=1 bun run scripts/build.ts
+else
+  bun run scripts/build.ts
+fi
 
 ARCH="$(uname -m)"
 if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then

--- a/tests/integration/task-gateway.test.ts
+++ b/tests/integration/task-gateway.test.ts
@@ -1151,7 +1151,7 @@ describe("local task gateway", () => {
     const secondPage = await second.json() as { events: Array<{ taskId: string }> };
     const returnedTaskIds = [...firstPage.events, ...secondPage.events].map((event) => event.taskId).filter((taskId) => taskIds.includes(taskId));
     expect(returnedTaskIds).toEqual(taskIds);
-  });
+  }, 15_000);
 
   test("keeps canonical terminal ordering stable under concurrent cancellation and completion", async () => {
     const sent = await request("/api/tasks/v1/send", "POST", { callerSession: "parent", to: { machine: "local", sessionId: "receiver" }, task: "race terminal" });

--- a/tests/unit/build-script.test.ts
+++ b/tests/unit/build-script.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let fixtureRoot = "";
+
+afterEach(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+function writeExecutable(path: string, content: string): void {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+function prepareFixture(): { readonly root: string; readonly bin: string; readonly log: string } {
+  fixtureRoot = mkdtempSync(join(tmpdir(), "wolfpack-build-script-"));
+  const bin = join(fixtureRoot, "test-bin");
+  const log = join(fixtureRoot, "commands.log");
+  mkdirSync(join(fixtureRoot, "scripts"), { recursive: true });
+  mkdirSync(join(fixtureRoot, "src", "cli"), { recursive: true });
+  mkdirSync(join(fixtureRoot, "bin"), { recursive: true });
+  mkdirSync(bin, { recursive: true });
+  cpSync(join(process.cwd(), "scripts", "build.ts"), join(fixtureRoot, "scripts", "build.ts"));
+  writeFileSync(join(fixtureRoot, "package.json"), JSON.stringify({ version: "1.0.0" }));
+  writeFileSync(join(fixtureRoot, "THIRD_PARTY_NOTICES"), "notices\n");
+  writeFileSync(join(fixtureRoot, "src", "cli", "index.ts"), "console.log('fixture');\n");
+  writeFileSync(log, "");
+
+  writeExecutable(join(bin, "bun"), `#!/bin/sh
+printf 'bun %s\\n' "$*" >> "$BUILD_TEST_LOG"
+outfile=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '--outfile' ]; then
+    shift
+    outfile="$1"
+    break
+  fi
+  shift
+done
+if [ -n "$outfile" ]; then
+  mkdir -p "$(dirname "$outfile")"
+  printf 'binary\\n' > "$outfile"
+  chmod +x "$outfile"
+fi
+`);
+  writeExecutable(join(bin, "cargo"), `#!/bin/sh
+printf 'cargo %s\\n' "$*" >> "$BUILD_TEST_LOG"
+mkdir -p "$PWD/broker/target/release"
+printf 'broker\\n' > "$PWD/broker/target/release/wolfpack-broker"
+chmod +x "$PWD/broker/target/release/wolfpack-broker"
+`);
+  return { root: fixtureRoot, bin, log };
+}
+
+function runBuild(fixture: { readonly root: string; readonly bin: string; readonly log: string }, serverOnly: boolean): string {
+  execFileSync(process.execPath, [join(fixture.root, "scripts", "build.ts")], {
+    cwd: fixture.root,
+    env: {
+      ...process.env,
+      PATH: `${fixture.bin}:${process.env.PATH ?? ""}`,
+      BUILD_TEST_LOG: fixture.log,
+      WOLFPACK_BUILD_SERVER_ONLY: serverOnly ? "1" : "0",
+    },
+    stdio: "pipe",
+  });
+  return readFileSync(fixture.log, "utf-8");
+}
+
+describe("scripts/build.ts modes", () => {
+  test("server-only mode compiles the cli without broker staging or platform packages", () => {
+    const fixture = prepareFixture();
+
+    const commands = runBuild(fixture, true);
+
+    expect(commands).not.toContain("cargo ");
+    expect(existsSync(join(fixture.root, "dist", "broker"))).toBe(false);
+    expect(existsSync(join(fixture.root, "dist", "npm"))).toBe(false);
+    expect(existsSync(join(fixture.root, "bin", "wolfpack"))).toBe(true);
+  });
+
+  test("normal mode stages the broker and generates platform packages", () => {
+    const fixture = prepareFixture();
+
+    const commands = runBuild(fixture, false);
+
+    expect(commands).toContain("cargo build --release --manifest-path broker/Cargo.toml --bin wolfpack-broker");
+    expect(existsSync(join(fixture.root, "dist", "wolfpack-broker"))).toBe(true);
+    expect(existsSync(join(fixture.root, "dist", "npm", "wolfpack-bridge-darwin-arm64", "wolfpack-broker"))).toBe(true);
+  });
+});

--- a/tests/unit/deploy-local.test.ts
+++ b/tests/unit/deploy-local.test.ts
@@ -51,7 +51,7 @@ case "$1" in
   -m) printf 'arm64\\n' ;;
 esac
 `);
-  writeExecutable(join(bin, "bun"), "#!/bin/sh\necho \"bun $*\" >> \"$DEPLOY_TEST_LOG\"\nexit 0\n");
+  writeExecutable(join(bin, "bun"), "#!/bin/sh\necho \"bun $* build-server-only=${WOLFPACK_BUILD_SERVER_ONLY:-}\" >> \"$DEPLOY_TEST_LOG\"\nexit 0\n");
   writeExecutable(join(bin, "codesign"), "#!/bin/sh\necho \"codesign $*\" >> \"$DEPLOY_TEST_LOG\"\nexit 0\n");
   writeExecutable(join(bin, "mv"), `#!/bin/sh
 echo "mv $*" >> "$DEPLOY_TEST_LOG"
@@ -277,6 +277,7 @@ describe("scripts/deploy-local.sh", () => {
     const commands = readFileSync(fixture.log, "utf-8");
 
     expect(readFileSync(join(fixture.home, ".wolfpack", "bin", "wolfpack-broker"), "utf-8")).toBe("installed-broker\n");
+    expect(commands).toContain("build-server-only=1");
     expect(commands).not.toContain("com.wolfpack.broker");
     expect(output).toContain("\"brokerDeployed\":false");
   });
@@ -322,6 +323,8 @@ describe("scripts/deploy-local.sh", () => {
     const output = runDeploy(fixture, "yes");
     const commands = readFileSync(fixture.log, "utf-8");
 
+    expect(commands).toContain("build-server-only=");
+    expect(commands).not.toContain("build-server-only=1");
     expect(readFileSync(join(fixture.home, ".wolfpack", "bin", "wolfpack-broker"), "utf-8")).toBe("broker\n");
     expect(output).toContain("broker restarted");
     expect(output).toContain("server restarted");


### PR DESCRIPTION
## summary

- give the durable 51-event inbox boundary test a scoped CI-safe timeout without changing production behavior
- restore broker-free builds for `deploy-local.sh --broker=no`
- force broker-inclusive mode for `--broker=yes`, even with an ambient server-only environment variable
- exercise the real build script in both modes

## verification

- `bun test` — 1889 passed, 22 existing broker skips, 0 failed
- `bun run typecheck`
- generated asset sync check
- `WOLFPACK_BUILD_SERVER_ONLY=1 bun test tests/unit/deploy-local.test.ts --test-name-pattern 'restarts broker before restarting server when broker binary is deployed'`
- live `./scripts/deploy-local.sh --broker=no` — server pid changed, broker pid stayed `1357`, 7 session identities preserved
- independent read-only correction review: clean

## remote peer note

`oldsgt` is reachable but still runs 1.6.17 and has no `/api/machine` handshake route, so the new remote CLI correctly fails closed until that server is upgraded.
