### PR TITLE
fix: prioritize homepage product media

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -63,16 +63,9 @@
       </div>
     </section>
 
-    <section class="proof wrap"><span class="proof-label">BUILT FOR THE MOMENT BETWEEN MACHINES</span><div class="proof-line"></div><span class="mono">NO ACCOUNT · NO HOSTED RELAY · MIT LICENSE</span></section>
-
-    <section class="section wrap" id="how">
-      <div class="section-head"><div><div class="eyebrow">01 / THE WORKFLOW</div><h2>Start here.<br><span>Finish anywhere.</span></h2></div><p>Wolfpack is the missing control layer between your agents and the machines they run on.</p></div>
-      <div class="steps"><article class="step"><div class="step-num">01</div><div class="step-icon">⌘</div><h3>Run it where the work is</h3><p>Install beside your existing tools. Your projects, credentials, terminals, and agents stay on your machine.</p></article><article class="step"><div class="step-num">02</div><div class="step-icon">↔</div><h3>Connect over your tailnet</h3><p>Tailscale gives your machines a private route. No Wolfpack account. No Wolfpack-hosted relay or prompt upload service.</p></article><article class="step"><div class="step-num">03</div><div class="step-icon">◉</div><h3>Take the session with you</h3><p>Open the PWA from another machine or your phone. Read output, send input, and keep the loop moving.</p></article></div>
-    </section>
-
     <section class="section wrap mobile-showcase" id="mobile">
       <div class="mobile-story">
-        <div class="eyebrow">02 / MOBILE CONTROL</div>
+        <div class="eyebrow">01 / MOBILE CONTROL</div>
         <h2>The control room<br><span>in your pocket.</span></h2>
         <p class="mobile-intro">Wolfpack turns each coding-agent session into a simple two-step loop: see what needs you, then jump straight into its live terminal.</p>
         <ol class="mobile-flow">
@@ -84,6 +77,13 @@
         <figure class="phone-shot"><div class="phone-screen"><img src="assets/mobile-sessions.png" alt="Wolfpack mobile dashboard listing agent sessions and their status" loading="lazy"></div><figcaption><span>01</span> SESSIONS</figcaption></figure>
         <figure class="phone-shot phone-shot-terminal"><div class="phone-screen"><img src="assets/mobile-terminal.png" alt="Wolfpack mobile live terminal with coding-agent output and touch controls" loading="lazy"></div><figcaption><span>02</span> LIVE TERMINAL</figcaption></figure>
       </div>
+    </section>
+
+    <section class="proof wrap"><span class="proof-label">BUILT FOR THE MOMENT BETWEEN MACHINES</span><div class="proof-line"></div><span class="mono">NO ACCOUNT · NO HOSTED RELAY · MIT LICENSE</span></section>
+
+    <section class="section wrap" id="how">
+      <div class="section-head"><div><div class="eyebrow">02 / THE WORKFLOW</div><h2>Start here.<br><span>Finish anywhere.</span></h2></div><p>Wolfpack is the missing control layer between your agents and the machines they run on.</p></div>
+      <div class="steps"><article class="step"><div class="step-num">01</div><div class="step-icon">⌘</div><h3>Run it where the work is</h3><p>Install beside your existing tools. Your projects, credentials, terminals, and agents stay on your machine.</p></article><article class="step"><div class="step-num">02</div><div class="step-icon">↔</div><h3>Connect over your tailnet</h3><p>Tailscale gives your machines a private route. No Wolfpack account. No Wolfpack-hosted relay or prompt upload service.</p></article><article class="step"><div class="step-num">03</div><div class="step-icon">◉</div><h3>Take the session with you</h3><p>Open the PWA from another machine or your phone. Read output, send input, and keep the loop moving.</p></article></div>
     </section>
 
     <section class="feature-band" id="privacy"><div class="wrap feature-grid"><div class="feature-art"><div class="radar"><span class="orbit one"></span><span class="orbit two"></span><span class="node n1">your phone</span><span class="node n2">laptop</span><span class="node n3">workstation</span><span class="center">W</span></div></div><div class="feature-copy"><div class="eyebrow">03 / YOUR INFRASTRUCTURE</div><h2>Private by<br><span>construction.</span></h2><p>Wolfpack is self-hosted software for machines you control. Remote access normally travels through your Tailscale network—not through us.</p><ul class="checks"><li><strong>Direct connections</strong><span>Use your tailnet as the trust boundary.</span></li><li><strong>Persistent PTY sessions</strong><span>Keep agents alive through tabs, drops, and context switches.</span></li><li><strong>Auditable surface</strong><span>Open source, local config, explicit service lifecycle.</span></li></ul><a class="text-link" href="https://github.com/almogdepaz/wolfpack#trust-and-security-model">Read the security model <span>↗</span></a></div></div></section>

--- a/tests/integration/task-gateway.test.ts
+++ b/tests/integration/task-gateway.test.ts
@@ -27,6 +27,8 @@ const { RELAY_ID, RELAY_PROTOCOL_VERSION } = await import("../../src/task-relay/
 const { TASK_LEDGER_ROLE, TaskStore } = await import("../../src/tasks/store.ts");
 const { TaskGateway, __resetTaskGatewayForTests } = await import("../../src/tasks/gateway.ts");
 
+__resetTaskGatewayForTests();
+
 class PiBackend extends MockBackend {
   override async listIdentities() {
     const now = new Date(0).toISOString();

--- a/tests/unit/readme-onboarding.test.ts
+++ b/tests/unit/readme-onboarding.test.ts
@@ -66,17 +66,23 @@ describe("README onboarding", () => {
     expect(hero?.match(/<img src="([^"]+)"/)?.[1]).toBe("assets/wolfpack-usage-demo.gif");
   });
 
-  test("explains the mobile dashboard-to-terminal workflow without displacing later previews", () => {
+  test("places the mobile dashboard and terminal directly after the homepage demo", () => {
     const site = readFileSync(SITE_PATH, "utf-8");
-    const workflowPosition = site.indexOf('id="how"');
+    const demoPosition = site.indexOf("assets/wolfpack-usage-demo.gif");
     const mobilePosition = site.indexOf('id="mobile"');
+    const proofPosition = site.indexOf("BUILT FOR THE MOMENT BETWEEN MACHINES");
+    const workflowPosition = site.indexOf('id="how"');
     const privacyPosition = site.indexOf('id="privacy"');
+    const desktopPosition = site.indexOf("assets/desktop-terminal.png");
 
-    expect(mobilePosition).toBeGreaterThan(workflowPosition);
+    expect(mobilePosition).toBeGreaterThan(demoPosition);
+    expect(proofPosition).toBeGreaterThan(mobilePosition);
+    expect(workflowPosition).toBeGreaterThan(mobilePosition);
     expect(privacyPosition).toBeGreaterThan(mobilePosition);
+    expect(desktopPosition).toBeGreaterThan(mobilePosition);
     for (const screenshot of SITE_MOBILE_SCREENSHOTS) {
       expect(existsSync(screenshot)).toBe(true);
-      expect(site).toContain(screenshot.replace("site/", ""));
+      expect(site.indexOf(screenshot.replace("site/", ""))).toBeGreaterThan(mobilePosition);
     }
     expect(site).toContain("Scan the dashboard");
     expect(site).toContain("Open the live terminal");


### PR DESCRIPTION
## summary

- move the mobile dashboard and terminal showcase directly below the animated hero demo
- keep the remaining workflow, privacy, and desktop preview sections afterward
- renumber the first two homepage sections and lock the media order with focused coverage

## verification

- `bun test tests/unit/readme-onboarding.test.ts` — 5 passed, 0 failed
- `bun run typecheck` — passed
- `bun test` — 1,892 passed, 22 broker-binary-dependent skips, 0 failed
- browser checks at 1440×1000 and 390×844 — media loaded in the intended order with no horizontal overflow
- independent review — approved with no actionable findings
