### PR TITLE
fix: resolve edc correctness findings

### DIFF
--- a/broker/src/codec.rs
+++ b/broker/src/codec.rs
@@ -72,10 +72,17 @@ pub enum Frame {
     Event(Event),
 }
 
-fn output_frame_header(out: &OutputFrame) -> Result<[u8; 29]> {
-    let payload_len = 24usize.saturating_add(out.data.len());
-    let payload_len = u32::try_from(payload_len).unwrap_or(u32::MAX);
+fn checked_output_payload_len(data_len: usize) -> Result<u32> {
+    let payload_len = 24usize
+        .checked_add(data_len)
+        .and_then(|length| u32::try_from(length).ok())
+        .ok_or(CodecError::FrameTooLarge(u32::MAX))?;
     validate_payload_len(FRAME_KIND_OUTPUT_BINARY, payload_len)?;
+    Ok(payload_len)
+}
+
+fn output_frame_header(out: &OutputFrame) -> Result<[u8; 29]> {
+    let payload_len = checked_output_payload_len(out.data.len())?;
     let mut header = [0u8; 29];
     header[0] = FRAME_KIND_OUTPUT_BINARY;
     header[1..5].copy_from_slice(&payload_len.to_be_bytes());
@@ -105,12 +112,8 @@ where
 
 pub fn write_frame<W: Write>(w: &mut W, frame: &Frame) -> Result<()> {
     if let Frame::OutputBinary(out) = frame {
-        let payload_len = 24usize.saturating_add(out.data.len());
-        validate_payload_len(FRAME_KIND_OUTPUT_BINARY, payload_len as u32)?;
-        w.write_all(&[FRAME_KIND_OUTPUT_BINARY])?;
-        w.write_all(&(payload_len as u32).to_be_bytes())?;
-        w.write_all(out.session_id.as_bytes())?;
-        w.write_all(&out.seq.to_be_bytes())?;
+        let header = output_frame_header(out)?;
+        w.write_all(&header)?;
         w.write_all(out.data.as_slice())?;
         return Ok(());
     }
@@ -334,6 +337,31 @@ mod tests {
             Frame::OutputBinary(b) => assert_eq!(b, out),
             other => panic!("wrong kind: {other:?}"),
         }
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn output_payload_length_rejects_values_above_u32_without_allocation() {
+        assert!(matches!(
+            checked_output_payload_len(u32::MAX as usize + 1),
+            Err(CodecError::FrameTooLarge(u32::MAX))
+        ));
+    }
+
+    #[test]
+    fn sync_output_binary_rejects_oversized_payload_before_writing() {
+        let frame = Frame::OutputBinary(OutputFrame {
+            session_id: nil(),
+            seq: 42,
+            data: Arc::new(vec![0; MAX_OUTPUT_BINARY_PAYLOAD as usize - 24 + 1]),
+        });
+        let mut writer = Vec::new();
+
+        assert!(matches!(
+            write_frame(&mut writer, &frame),
+            Err(CodecError::FrameTooLarge(length)) if length == MAX_OUTPUT_BINARY_PAYLOAD + 1
+        ));
+        assert!(writer.is_empty());
     }
 
     #[tokio::test]

--- a/broker/src/server.rs
+++ b/broker/src/server.rs
@@ -3,7 +3,7 @@ use std::io;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{broadcast, mpsc, watch, OwnedSemaphorePermit, Semaphore};
@@ -34,6 +34,8 @@ const CONTROL_QUEUE_CAPACITY: usize =
     CONTROL_QUEUE_MAX_BYTES / crate::codec::MAX_CONTROL_RESPONSE_PAYLOAD as usize;
 const MAX_CONNECTIONS: usize = 128;
 const MAX_SUBSCRIPTIONS_PER_CONNECTION: usize = 32;
+const OWNER_ONLY_SOCKET_UMASK: libc::mode_t = 0o077;
+static SOCKET_BIND_UMASK_MUTEX: Mutex<()> = Mutex::new(());
 static CONTROL_QUEUE_HIGH_WATER: AtomicUsize = AtomicUsize::new(0);
 static OUTPUT_QUEUE_HIGH_WATER: AtomicUsize = AtomicUsize::new(0);
 /// Merge adjacent PTY reads before crossing the broker socket without raising
@@ -47,6 +49,31 @@ const OUTPUT_FORWARD_BUFFER_MAX_BYTES: usize = 8 * 1024 * 1024;
 /// frame and this depth caps queued data before socket backpressure applies.
 const INPUT_QUEUE_MAX_BYTES: usize = 4 * 1024 * 1024;
 const INPUT_QUEUE_CAPACITY: usize = INPUT_QUEUE_MAX_BYTES / MAX_INPUT_BINARY_PAYLOAD as usize;
+
+struct SocketBindUmaskGuard {
+    previous_umask: libc::mode_t,
+    _mutex_guard: MutexGuard<'static, ()>,
+}
+
+impl SocketBindUmaskGuard {
+    fn acquire() -> Self {
+        let mutex_guard = match SOCKET_BIND_UMASK_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let previous_umask = unsafe { libc::umask(OWNER_ONLY_SOCKET_UMASK) };
+        Self {
+            previous_umask,
+            _mutex_guard: mutex_guard,
+        }
+    }
+}
+
+impl Drop for SocketBindUmaskGuard {
+    fn drop(&mut self) {
+        unsafe { libc::umask(self.previous_umask) };
+    }
+}
 
 pub struct ServerConfig {
     pub socket_path: PathBuf,
@@ -130,9 +157,9 @@ pub async fn start(config: ServerConfig) -> io::Result<Server> {
     // Set umask to 0o077 before bind so the kernel creates the socket file
     // with mode 0o600 directly, eliminating the TOCTOU window between bind
     // and the chmod below. Restore umask immediately after bind.
-    let old_umask = unsafe { libc::umask(0o077) };
+    let umask_guard = SocketBindUmaskGuard::acquire();
     let bind_result = UnixListener::bind(&socket_path);
-    unsafe { libc::umask(old_umask) };
+    drop(umask_guard);
     let listener = bind_result?;
     // Belt-and-suspenders: also chmod in case of an unusual kernel that does
     // not honour umask for Unix sockets.
@@ -891,6 +918,51 @@ mod tests {
     use crate::protocol::Status;
     use crate::registry::{CreateOptions, MAX_CONCURRENT_SNAPSHOTS};
     use serde_json::json;
+
+    const TEST_BASELINE_UMASK: libc::mode_t = 0o022;
+
+    struct TestUmaskRestore(libc::mode_t);
+
+    fn lock_umask_for_test() -> MutexGuard<'static, ()> {
+        match SOCKET_BIND_UMASK_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    impl TestUmaskRestore {
+        fn set(umask: libc::mode_t) -> Self {
+            let _guard = lock_umask_for_test();
+            Self(unsafe { libc::umask(umask) })
+        }
+    }
+
+    impl Drop for TestUmaskRestore {
+        fn drop(&mut self) {
+            let _guard = lock_umask_for_test();
+            unsafe { libc::umask(self.0) };
+        }
+    }
+
+    fn current_process_umask() -> libc::mode_t {
+        let _guard = lock_umask_for_test();
+        let current = unsafe { libc::umask(OWNER_ONLY_SOCKET_UMASK) };
+        unsafe { libc::umask(current) };
+        current
+    }
+
+    #[test]
+    fn socket_bind_umask_guard_serializes_and_restores_process_umask() {
+        let _restore_test_umask = TestUmaskRestore::set(TEST_BASELINE_UMASK);
+        {
+            let _guard = SocketBindUmaskGuard::acquire();
+            assert!(matches!(
+                SOCKET_BIND_UMASK_MUTEX.try_lock(),
+                Err(std::sync::TryLockError::WouldBlock)
+            ));
+        }
+        assert_eq!(current_process_umask(), TEST_BASELINE_UMASK);
+    }
 
     #[tokio::test]
     async fn snapshot_subscribe_shares_the_process_snapshot_limit() {

--- a/broker/src/session_router.rs
+++ b/broker/src/session_router.rs
@@ -217,6 +217,10 @@ impl SessionRouter {
         if let Err(message) = validate_snapshot_target_cols(p.target_cols) {
             return invalid_request(id, format!("snapshot params: {message}"));
         }
+        let session = match self.registry.get(p.session_id) {
+            Some(session) => session,
+            None => return unknown_session(id, p.session_id),
+        };
         let _permit = match self.registry.try_acquire_snapshot() {
             Some(permit) => permit,
             None => return ControlResponse::err(
@@ -227,12 +231,9 @@ impl SessionRouter {
                 },
             ),
         };
-        match self.registry.get(p.session_id) {
-            Some(s) => match s.snapshot_terminal(p.scrollback_lines, p.target_cols) {
-                Ok(snapshot) => ControlResponse::ok(id, ResponsePayload::Snapshot { snapshot }),
-                Err(error) => terminal_snapshot_error(id, error),
-            },
-            None => unknown_session(id, p.session_id),
+        match session.snapshot_terminal(p.scrollback_lines, p.target_cols) {
+            Ok(snapshot) => ControlResponse::ok(id, ResponsePayload::Snapshot { snapshot }),
+            Err(error) => terminal_snapshot_error(id, error),
         }
     }
 
@@ -333,6 +334,7 @@ fn unknown_session(id: u64, sid: Uuid) -> ControlResponse {
 mod tests {
     use super::*;
     use crate::protocol::Status;
+    use crate::registry::MAX_CONCURRENT_SNAPSHOTS;
     use serde_json::json;
     use std::time::Duration;
 
@@ -698,6 +700,32 @@ mod tests {
         ));
         assert_eq!(still_usable.status, Status::Ok);
         cleanup(&reg);
+    }
+
+    #[test]
+    fn saturated_snapshot_limit_preserves_validation_and_unknown_session_precedence() {
+        let (router, reg) = router();
+        let permits: Vec<_> = (0..MAX_CONCURRENT_SNAPSHOTS)
+            .map(|_| reg.try_acquire_snapshot().expect("snapshot permit"))
+            .collect();
+
+        let invalid = router.handle(req(
+            1,
+            methods::SNAPSHOT,
+            json!({ "session_id": Uuid::nil(), "target_cols": 301 }),
+        ));
+        assert_eq!(invalid.status, Status::Error);
+        assert_eq!(invalid.error.expect("error").code, ErrorCode::InvalidRequest);
+
+        let unknown = router.handle(req(
+            2,
+            methods::SNAPSHOT,
+            json!({ "session_id": Uuid::nil() }),
+        ));
+        assert_eq!(unknown.status, Status::Error);
+        assert_eq!(unknown.error.expect("error").code, ErrorCode::UnknownSession);
+
+        drop(permits);
     }
 
     #[test]

--- a/edc-context/index.md
+++ b/edc-context/index.md
@@ -17,13 +17,13 @@ Do not treat generated bundles, staged EDC artifacts, screenshots, or prior test
 | Path or task | Read first | Notes |
 | --- | --- | --- |
 | `broker/**` | `modules/broker.md` | Broker owns PTY children, registry, output sequence/replay, snapshots, resize transaction, socket codec/server, and Ghostty VT FFI bounds. |
-| `src/**`, `public/**`, `bin/**`, `scripts/**` | `modules/wolfpack.md` | Covers server HTTP/WS auth, session/project APIs, broker client/backend, browser terminal hydration, Tailnet peers, tasks/relay/push, setup/service/build. |
+| `src/**`, `public/**`, `bin/**`, `scripts/**` | `modules/wolfpack.md` | Covers server HTTP/WS auth, session/project APIs, broker client/backend, browser terminal hydration, Tailnet peers, tasks/relay/push, setup/service/install/build. |
 | `tests/**` | `modules/tests.md` | Use for harness behavior and regression intent; production modules remain semantic authority. |
 | `docs/**`, `site/**` | `modules/docs.md` | Docs/site publish user contracts but do not override runtime validation, auth, broker, service, or installer behavior. |
 | `skills/**` | `modules/skills.md` | Skill is a policy wrapper over public Wolfpack CLI/API, not an independent protocol/auth authority. |
 | Broker protocol or terminal attach/reconnect changes | `modules/broker.md` + `modules/wolfpack.md` + relevant `modules/tests.md` sections | Highest coupling: Rust protocol/session sequencing, TS broker client/backend, WS attach, browser hydration, and real-broker tests must stay aligned. |
 | Auth, Tailnet, remote machine, or browser peer changes | `modules/wolfpack.md` + `modules/docs.md` + `modules/skills.md` as needed | Stable machine identity/canonical origin are routing authority; labels and forwarded headers are not. |
-| Tasks, relay, notification, or Pi integration changes | `modules/wolfpack.md` + `modules/docs.md` + `modules/skills.md` + task tests in `modules/tests.md` | Wolfpack owns durable task/relay stores; Pi skills/extensions are clients over public surfaces. |
+| Tasks, relay, notification, Pi integration, or child-agent model selection changes | `modules/wolfpack.md` + `modules/docs.md` + `modules/skills.md` + task/API tests in `modules/tests.md` | Wolfpack owns durable task/relay stores and the `agent spawn`/`session-open` launch contract; Pi skills/extensions are clients over public surfaces. |
 | Install, release, service, or broker artifact changes | `modules/wolfpack.md` + `modules/broker.md` + `modules/docs.md` + `modules/tests.md` | Preserve server-only vs broker restart blast-radius warnings and artifact provenance checks. |
 
 ## Critical global invariants
@@ -36,6 +36,7 @@ Do not treat generated bundles, staged EDC artifacts, screenshots, or prior test
 - Generated/staged artifacts, public bundles, generated schemas, media, and test results are not source truth; route back to owning source/contracts.
 - Slow terminal consumers are shed rather than buffered indefinitely because broker snapshots/replay are the recovery mechanism.
 - Durable task/relay serialization and hashes are migration-sensitive; canonical JSON ordering changes can invalidate stored ledgers or digests.
+- Child-agent launch remains same-harness and parent-identity pinned; model override is a bounded Pi-only option, not a generic client-owned command/harness override.
 
 ## Cross-module coupling / blast radius
 
@@ -45,7 +46,7 @@ Do not treat generated bundles, staged EDC artifacts, screenshots, or prior test
 - **Terminal hydration/resize changes** jointly affect server WS handling, browser socket/controller/order logic, broker snapshot/resize behavior, and tests for replay, prefill, takeover, slow viewers, and reconnect.
 - **Auth/Tailnet changes** affect server routes/upgrades, browser peer registry/fetch behavior, CLI remote control, Pi skill guidance, docs/site exposure wording, and integration/e2e fixtures.
 - **Task/relay changes** affect durable server stores/gateways, generated Control API schema/docs, Pi skill expectations, Tailnet federation tests, and notification/session-target routing.
-- **Build/install changes** affect scripts, optional broker artifacts, service staging paths, docs/site install guidance, and release/install policy tests; broker binary provenance must remain aligned.
+- **Build/install changes** affect scripts, optional broker artifacts, service staging paths, setup/service restart handoff, docs/site install guidance, and release/install policy tests; broker binary provenance and server-only vs broker restart claims must remain aligned.
 
 ## Architecture overview
 

--- a/edc-context/manifest.json
+++ b/edc-context/manifest.json
@@ -142,8 +142,8 @@
       "patches/**"
     ]
   },
-  "generatedAt": "2026-08-24T21:31:50Z",
-  "sourceCommit": "aaee44a882319d07f80e4885de1f7d862dbabe54",
+  "generatedAt": "2026-08-25T18:16:38Z",
+  "sourceCommit": "9d1d2d87c10ac32d6b88a52261f1885d04f1e887",
   "coverage": {
     "contextMappedFileCount": 442,
     "contextlessFileCount": 31,

--- a/edc-context/modules/wolfpack.md
+++ b/edc-context/modules/wolfpack.md
@@ -3,7 +3,7 @@
 
 ## When To Read This
 
-Read this before changing session creation/control, terminal attach/reconnect behavior, Tailnet peer discovery, browser terminal hydration, service install/startup, task relay, push notification routing, or release packaging. Do not use `public/app.bundle.js`, `public/ghostty-web.bundle.js`, `src/public-assets.ts`, or `bin/wolfpack` as source truth; they are generated/staged artifacts. For broker internals, this module owns only the TypeScript client/backend boundary; the Rust broker source is outside this module scope and must be inspected separately before relying on broker implementation details.
+Read this before changing session creation/control, child-agent spawning, terminal attach/reconnect behavior, Tailnet peer discovery, browser terminal hydration, service install/startup/update, task relay, push notification routing, or release packaging. Do not use `public/app.bundle.js`, `public/ghostty-web.bundle.js`, `src/public-assets.ts`, or `bin/wolfpack` as source truth; they are generated/staged artifacts. For broker internals, this module owns only the TypeScript client/backend boundary; the Rust broker source is outside this module scope and must be inspected separately before relying on broker implementation details.
 
 ## Authority Boundaries
 
@@ -15,14 +15,16 @@ Read this before changing session creation/control, terminal attach/reconnect be
 ## Core Runtime Model
 
 1. CLI/service setup writes config and starts two user services: broker first, then server. The server refuses useful session operations without a reachable broker socket/handshake (`src/cli/service.ts`, `src/server/backend.ts`, `src/server/index.ts`). Server-only restarts intentionally preserve broker-owned PTYs.
-2. Browser and CLI call HTTP session APIs. Top-level and child sessions validate project selection, command/harness, names, and optional prompts before calling `backend.createSession` (`src/server/project-settings-routes.ts`, `src/server/session-create.ts`, `src/server/session-open.ts`).
-3. `BrokerBackend.createSession` converts a safe harness command into `SHELL -lic ...`, injects Wolfpack identity env vars, then asks broker `create_session`. It captures durable session identity after broker returns a UUID (`src/server/broker-backend.ts`).
+2. Browser and CLI call HTTP session APIs. Top-level and child sessions validate project selection, command/harness, names, optional prompts, and child-only model selection before calling `backend.createSession` (`src/cli/session-control.ts`, `src/server/project-settings-routes.ts`, `src/server/session-create.ts`, `src/server/session-open.ts`).
+3. `BrokerBackend.createSession` converts a safe harness command into `SHELL -lic ...`, injects Wolfpack identity env vars, and passes startup prompt/model values as opaque argv entries after the shell `-c` script; it captures durable session identity after broker returns a UUID (`src/server/broker-backend.ts`).
 4. Terminal viewing is a separate `/ws/pty` protocol over raw PTY bytes plus JSON control messages. A browser sends `attach`, the server settles geometry, snapshots broker state, subscribes to live output, gates pending input until the subscription boundary is established, then sends `pty_ready` (`src/server/websocket.ts`, `public/pty-socket-client.ts`).
 
 ## Session/Project Contracts That Are Easy To Break
 
 - `project` and `projectDir` are mutually exclusive selectors for existing sessions. `newProject` cannot be combined with `projectDir`; `newProjectParent` only makes sense with `newProject` (`src/server/project-settings-routes.ts`). Keep this exclusivity or the path validation authority becomes ambiguous.
-- `CMD_REGEX` is not the only command boundary: the backend also validates non-shell commands and uses `SHELL -lic` with identity env vars. Shell sessions reject `initialPrompt`; agent harnesses accept it via an argument appended after `wolfpack-agent` (`src/validation.ts`, `src/server/broker-backend.ts`).
+- `CMD_REGEX` is not the only command boundary: the backend also validates non-shell commands and uses `SHELL -lic` with identity env vars. Shell sessions reject `initialPrompt`; agent harnesses accept it via argv after `wolfpack-agent` (`src/validation.ts`, `src/server/broker-backend.ts`).
+- Child spawning is same-harness by design. `session-open` / `agent spawn` derives the child command from the active parent’s structured `agentKind`; clients cannot override `cmd` or `harness` (`src/server/session-open.ts`, `src/server/project-settings-routes.ts`).
+- Optional `--model` / request `model` is child-only and Pi-only. CLI and API validate it as nonblank and bounded by `SESSION_OPEN_MAX_MODEL_LENGTH`; `openSubSession` rejects model selection when the parent harness is not Pi, and `BrokerBackend` rejects model options for non-Pi commands before the broker call (`src/session-open-contract.ts`, `src/cli/session-control.ts`, `src/server/session-open.ts`, `src/server/broker-backend.ts`). Omission must preserve same-harness launch behavior for every provider.
 - Parent/child session creation re-reads parent state after duplicate-name races and verifies the parent UUID has not changed. Do not replace this with name-only checks; names can be reused after kill/recreate (`src/server/session-open.ts`).
 - `listIdentities()` must remain available and coherent with `list()` for session-control routes. Several APIs intentionally return 503 if identities are missing rather than falling back to name-only state (`src/server/session-control-routes.ts`).
 
@@ -58,11 +60,13 @@ This is the highest-coupling area. The server, `public/pty-socket-client.ts`, an
 - Dashboard session state is sampled from broker facts plus bounded snapshot fingerprints and optional project-local `.wolfpack/agent-status.json`. Runtime state is persisted/acknowledged by session UUID when available; when broker is unavailable the last known summaries are used with degraded liveness (`src/server/session-observation.ts`, `src/server/agent-status.ts`).
 - Push subscriptions are local persistent state under `~/.wolfpack`; endpoints are exact-host allowlisted push services, VAPID keys are generated locally, and `/api/notify` optionally embeds bounded session-target routes (`src/server/push.ts`, `src/server/push-routes.ts`, `src/push-subscription-origin.ts`).
 
-## Build/Packaging Contracts
+## Setup, Service, Install, and Packaging Contracts
 
 - `scripts/build.ts` always regenerates embedded public assets before compiling. Release/package-all mode requires clean tracked source and validates prebuilt broker artifacts by target, broker version, source revision, binary header architecture, and sha256 (`scripts/build.ts`, `scripts/broker-artifacts.ts`).
 - `bin/install.cjs` and `bin/run.cjs` copy/resolve platform optional packages and prepare macOS binaries with xattr/codesign. The service layer also stages stable copies under `~/.wolfpack/bin`; keep these paths aligned or service install will not find `wolfpack-broker`.
-- `scripts/gen-control-api-schema.ts` generates `docs/generated/control-api.schema.json` from `src/control-api/schema.ts`. The schema imports runtime constants from this module; update schema source when changing stable API messages/routes rather than hand-editing generated output.
+- The curl installer stages and verifies both server and broker assets, installs the managed pair, runs setup from the exact managed binary, and on existing services performs a final `service restart --server-only` so the broker is not intentionally restarted during upgrades (`install.sh`, `src/cli/index.ts`, `src/cli/service.ts`). If the final server restart fails, install exits nonzero rather than silently claiming success.
+- `wolfpack setup --defer-service-restart` is installer-facing. It may refresh installed server descriptors without activation and then leaves service handoff to the installer’s final restart; ordinary setup restarts only the server when remote-origin policy changes and preserves broker PTYs (`src/cli/index.ts`, `src/cli/setup.ts`, `src/cli/service.ts`).
+- `scripts/gen-control-api-schema.ts` generates `docs/generated/control-api.schema.json` from `src/control-api/schema.ts`. The schema imports runtime constants such as session-open model bounds from this module; update schema source when changing stable API messages/routes rather than hand-editing generated output.
 
 ## Read/Change Gotchas
 
@@ -71,13 +75,14 @@ This is the highest-coupling area. The server, `public/pty-socket-client.ts`, an
 - `src/server/http.ts` uses login-shell invocation for Tailscale status on macOS App Store installs; direct `execFile` is a known regression footgun.
 - Directory browsing is intentionally globally concurrency-limited and symlink-averse; broadening it affects remote browser ability to scan host files (`src/server/directory-browser.ts`).
 - Stopping/restarting broker is session-destructive; server-only restart is the safe default for code/config updates that do not require broker reset (`src/cli/service.ts`).
+- Performance harnesses should drive visible controls when measuring browser flows; direct `window.openSession` / `addToGrid` calls can bypass UI event path timing (`scripts/terminal-load-perf.ts`).
 
 ## Source Pointers
 
 - Server/auth/CORS/rate limits/WS upgrade: `src/server/index.ts`, `src/server/http.ts`, `src/auth.ts`, `src/server/tailnet-origin-policy.ts`, `src/server/ws-ticket.ts`.
-- Session/project APIs: `src/server/project-settings-routes.ts`, `src/server/session-create.ts`, `src/server/session-open.ts`, `src/server/session-control-routes.ts`, `src/server/project-selection.ts`, `src/server/validate-project-dir.ts`.
+- Session/project APIs: `src/cli/session-control.ts`, `src/server/project-settings-routes.ts`, `src/server/session-create.ts`, `src/server/session-open.ts`, `src/session-open-contract.ts`, `src/server/session-control-routes.ts`, `src/server/project-selection.ts`, `src/server/validate-project-dir.ts`.
 - Broker boundary: `src/server/backend.ts`, `src/server/broker-backend.ts`, `src/broker/client.ts`, `src/broker/codec.ts`, `src/broker/snapshot-render.ts`.
 - Browser terminal protocol: `src/server/websocket.ts`, `public/pty-socket-client.ts`, `public/pty-terminal-controller.ts`, `public/ordered-resize.ts`, `src/ws-constants.ts`.
 - Browser app/peer UI: `public/app.ts`, `public/app-state.ts`, `public/app-grid.ts`, `public/browser-auth.ts`, `src/tailnet-machine-contract.ts`, `src/tailnet-peer-registry.ts`.
 - Tasks/relay/notifications/status: `src/tasks/*`, `src/task-relay/*`, `src/canonical-json.ts`, `src/server/push*.ts`, `src/server/session-observation.ts`, `src/server/agent-status.ts`.
-- CLI/service/build: `src/cli/index.ts`, `src/cli/setup.ts`, `src/cli/service.ts`, `bin/*.cjs`, `scripts/build.ts`, `scripts/broker-artifacts.ts`, `scripts/gen-control-api-schema.ts`.
+- CLI/service/install/build: `src/cli/index.ts`, `src/cli/setup.ts`, `src/cli/service.ts`, `install.sh`, `bin/*.cjs`, `scripts/build.ts`, `scripts/broker-artifacts.ts`, `scripts/gen-control-api-schema.ts`, `scripts/terminal-load-perf.ts`.

--- a/tests/integration/machine-contract-api.test.ts
+++ b/tests/integration/machine-contract-api.test.ts
@@ -1,19 +1,28 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+
+const PRIOR_ENV = {
+  WOLFPACK_TEST: process.env.WOLFPACK_TEST,
+  WOLFPACK_JWT_SECRET: process.env.WOLFPACK_JWT_SECRET,
+  WOLFPACK_DEV_DIR: process.env.WOLFPACK_DEV_DIR,
+  WOLFPACK_SETTINGS_PATH: process.env.WOLFPACK_SETTINGS_PATH,
+  WOLFPACK_MACHINE_ID_PATH: process.env.WOLFPACK_MACHINE_ID_PATH,
+  WOLFPACK_TAILSCALE_STATUS_JSON: process.env.WOLFPACK_TAILSCALE_STATUS_JSON,
+} as const;
+const { DEV_DIR: PRIOR_CACHED_DEV_DIR } = await import("../../src/server/dev-dir.ts");
 
 process.env.WOLFPACK_TEST = "1";
 delete process.env.WOLFPACK_JWT_SECRET;
 
-const testRoot = join(tmpdir(), `wolfpack-machine-contract-${process.pid}`);
-mkdirSync(testRoot, { recursive: true });
+const rawTestRoot = mkdtempSync(join(tmpdir(), "wolfpack-machine-contract-"));
+const testRoot = realpathSync(rawTestRoot);
 process.env.WOLFPACK_DEV_DIR = testRoot;
 process.env.WOLFPACK_SETTINGS_PATH = join(testRoot, "bridge-settings.json");
 process.env.WOLFPACK_MACHINE_ID_PATH = join(testRoot, "machine-id");
-const priorTailscaleStatus = process.env.WOLFPACK_TAILSCALE_STATUS_JSON;
 const defaultTailscaleStatus = JSON.stringify({
   Self: {
     ID: "n-local",
@@ -40,9 +49,13 @@ const defaultTailscaleStatus = JSON.stringify({
 });
 process.env.WOLFPACK_TAILSCALE_STATUS_JSON = defaultTailscaleStatus;
 
-const { __resetJwtAuthConfig, __setDevDir } = await import("../../src/test-hooks.ts");
-const { __setTestBackend } = await import("../../src/server/backend.ts");
-const { MockBackend } = await import("../../src/server/mock-backend.ts");
+const {
+  __resetBackend,
+  __resetJwtAuthConfig,
+  __setDevDir,
+  __setTestBackend,
+  MockBackend,
+} = await import("../../src/test-hooks.ts");
 __resetJwtAuthConfig();
 __setDevDir(testRoot);
 __setTestBackend(new MockBackend({ sessions: [] }));
@@ -71,9 +84,17 @@ afterAll(() => {
   (server as Server).close();
   __pollRateLimiter._map.clear();
   __globalRateLimiter._map.clear();
-  if (priorTailscaleStatus === undefined) delete process.env.WOLFPACK_TAILSCALE_STATUS_JSON;
-  else process.env.WOLFPACK_TAILSCALE_STATUS_JSON = priorTailscaleStatus;
   rmSync(testRoot, { recursive: true, force: true });
+  __resetBackend();
+  __setDevDir(PRIOR_CACHED_DEV_DIR);
+  for (const [key, value] of Object.entries(PRIOR_ENV)) {
+    if (key === "WOLFPACK_TEST") continue;
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  __resetJwtAuthConfig();
+  if (PRIOR_ENV.WOLFPACK_TEST === undefined) delete process.env.WOLFPACK_TEST;
+  else process.env.WOLFPACK_TEST = PRIOR_ENV.WOLFPACK_TEST;
 });
 
 describe("direct machine contract routes", () => {

--- a/tests/integration/task-gateway.test.ts
+++ b/tests/integration/task-gateway.test.ts
@@ -9,6 +9,13 @@ import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync
 import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
+const PRIOR_ENV = {
+  WOLFPACK_TEST: process.env.WOLFPACK_TEST,
+  WOLFPACK_TAILNET_SUFFIX: process.env.WOLFPACK_TAILNET_SUFFIX,
+  WOLFPACK_JWT_SECRET: process.env.WOLFPACK_JWT_SECRET,
+  WOLFPACK_TASK_ROOT: process.env.WOLFPACK_TASK_ROOT,
+} as const;
+
 process.env.WOLFPACK_TEST = "1";
 process.env.WOLFPACK_TAILNET_SUFFIX = "example.ts.net";
 delete process.env.WOLFPACK_JWT_SECRET;
@@ -19,9 +26,18 @@ process.env.WOLFPACK_TASK_ROOT = join(root, "tasks");
 mkdirSync(parentProject, { recursive: true });
 mkdirSync(receiverProject, { recursive: true });
 
-const { __setTestBackend } = await import("../../src/server/backend.ts");
-const { MockBackend } = await import("../../src/server/mock-backend.ts");
-const { createServerInstance } = await import("../../src/server/index.ts");
+const {
+  __resetBackend,
+  __resetJwtAuthConfig,
+  __setTestBackend,
+  MockBackend,
+} = await import("../../src/test-hooks.ts");
+__resetJwtAuthConfig();
+const {
+  createServerInstance,
+  __globalRateLimiter,
+  __pollRateLimiter,
+} = await import("../../src/server/index.ts");
 const { TASK_EVENT_TYPE, TASK_LIMITS, hashImmutableAssignment } = await import("../../src/tasks/domain.ts");
 const { RELAY_ID, RELAY_PROTOCOL_VERSION } = await import("../../src/task-relay/domain.ts");
 const { TASK_LEDGER_ROLE, TaskStore } = await import("../../src/tasks/store.ts");
@@ -44,6 +60,8 @@ const { server } = createServerInstance();
 let base = "";
 
 beforeAll(async () => {
+  __pollRateLimiter._map.clear();
+  __globalRateLimiter._map.clear();
   await new Promise<void>((resolve) => (server as Server).listen(0, "127.0.0.1", () => {
     base = `http://127.0.0.1:${((server as Server).address() as AddressInfo).port}`;
     resolve();
@@ -52,7 +70,19 @@ beforeAll(async () => {
 
 afterAll(() => {
   (server as Server).close();
+  __pollRateLimiter._map.clear();
+  __globalRateLimiter._map.clear();
+  __resetTaskGatewayForTests();
   rmSync(root, { recursive: true, force: true });
+  __resetBackend();
+  for (const [key, value] of Object.entries(PRIOR_ENV)) {
+    if (key === "WOLFPACK_TEST") continue;
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  __resetJwtAuthConfig();
+  if (PRIOR_ENV.WOLFPACK_TEST === undefined) delete process.env.WOLFPACK_TEST;
+  else process.env.WOLFPACK_TEST = PRIOR_ENV.WOLFPACK_TEST;
 });
 
 async function request(path: string, method: "GET" | "POST", body?: unknown, headers: Record<string, string> = {}) {

--- a/tests/unit/audit-regressions.test.ts
+++ b/tests/unit/audit-regressions.test.ts
@@ -2,50 +2,58 @@
  * Regression tests for fixes from the security/correctness audit.
  * Each test targets a specific finding that was fixed in the fix/audit-findings branch.
  */
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
+import { lstatSync, mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const PRIOR_ENV = {
+  WOLFPACK_TEST: process.env.WOLFPACK_TEST,
+  WOLFPACK_DEV_DIR: process.env.WOLFPACK_DEV_DIR,
+} as const;
+const { DEV_DIR: PRIOR_CACHED_DEV_DIR } = await import("../../src/server/dev-dir.ts");
+
+process.env.WOLFPACK_TEST = "1";
+const RAW_TEST_DEV_DIR = mkdtempSync(join(tmpdir(), "wolfpack-audit-devdir-"));
+const TEST_DEV_DIR = realpathSync(RAW_TEST_DEV_DIR);
+process.env.WOLFPACK_DEV_DIR = TEST_DEV_DIR;
+const { __setDevDir } = await import("../../src/test-hooks.ts");
+const { isUnderDevDir } = await import("../../src/server/dev-dir.js");
+__setDevDir(TEST_DEV_DIR);
 
 // ── 1. Path containment boundary (audit finding: prefix check too weak) ──
-// Set DEV_DIR before importing so the module-level constant picks it up.
-// Use trailing slash to verify boundary logic handles normalized equivalence.
-process.env.WOLFPACK_DEV_DIR = "/Users/home/Dev/";
-const { isUnderDevDir } = await import("../../src/server/dev-dir.js");
 
 describe("isUnderDevDir — path containment boundary", () => {
   test("exact match on DEV_DIR itself", () => {
-    expect(isUnderDevDir("/Users/home/Dev/")).toBe(true);
-    expect(isUnderDevDir("/Users/home/Dev")).toBe(true);
+    expect(isUnderDevDir(`${TEST_DEV_DIR}/`)).toBe(true);
+    expect(isUnderDevDir(TEST_DEV_DIR)).toBe(true);
   });
 
   test("child directory matches", () => {
-    expect(isUnderDevDir("/Users/home/Dev/wolfpack")).toBe(true);
-    expect(isUnderDevDir("/Users/home/Dev/foo/bar/baz")).toBe(true);
+    expect(isUnderDevDir(join(TEST_DEV_DIR, "wolfpack"))).toBe(true);
+    expect(isUnderDevDir(join(TEST_DEV_DIR, "foo", "bar", "baz"))).toBe(true);
   });
 
   test("rejects sibling path that shares string prefix", () => {
-    // This was the original bug — /Users/home/Developer matched /Users/home/Dev
-    expect(isUnderDevDir("/Users/home/Developer")).toBe(false);
-    expect(isUnderDevDir("/Users/home/DevOps")).toBe(false);
-    expect(isUnderDevDir("/Users/home/Dev2")).toBe(false);
+    expect(isUnderDevDir(`${TEST_DEV_DIR}eloper`)).toBe(false);
+    expect(isUnderDevDir(`${TEST_DEV_DIR}Ops`)).toBe(false);
+    expect(isUnderDevDir(`${TEST_DEV_DIR}2`)).toBe(false);
   });
 
   test("rejects unrelated paths", () => {
-    expect(isUnderDevDir("/tmp/something")).toBe(false);
-    expect(isUnderDevDir("/Users/other/Dev/project")).toBe(false);
+    expect(isUnderDevDir(join(tmpdir(), "something"))).toBe(false);
+    expect(isUnderDevDir(join(dirname(TEST_DEV_DIR), "other", "project"))).toBe(false);
   });
 
   test("rejects partial prefix with no separator", () => {
-    expect(isUnderDevDir("/Users/home/Devious")).toBe(false);
+    expect(isUnderDevDir(`${TEST_DEV_DIR}ious`)).toBe(false);
   });
 });
 
 // ── 1b. validateProjectDir realpath containment ──
 // Imports the real `validateProjectDir` from src/ so this test cannot drift
-// from production. `isUnderDevDir` resolves DEV_DIR from process.env.WOLFPACK_DEV_DIR
-// at call time (set at top of file to /Users/home/Dev/).
+// from production.
 
-import { lstatSync, mkdtempSync, mkdirSync, symlinkSync, rmSync, realpathSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
 const { validateExplicitProjectDir, validateProjectDir } = await import("../../src/server/validate-project-dir.js");
 
 describe("validateProjectDir — realpath containment", () => {
@@ -53,8 +61,7 @@ describe("validateProjectDir — realpath containment", () => {
     const testDevDir = mkdtempSync(join(tmpdir(), "wolfpack-devdir-"));
     const project = join(testDevDir, "legit-project");
     mkdirSync(project);
-    // testDevDir is under /tmp (or macOS equivalent), not under DEV_DIR (/Users/home/Dev/),
-    // so containment must fail.
+    // testDevDir is a sibling temp root, not under TEST_DEV_DIR.
     const real = realpathSync(project);
     expect(isUnderDevDir(real)).toBe(false);
     const result = validateProjectDir(project);
@@ -165,6 +172,15 @@ describe("validateExplicitProjectDir — explicit arbitrary directory boundary",
       rmSync(root, { recursive: true, force: true });
     }
   });
+});
+
+afterAll(() => {
+  rmSync(TEST_DEV_DIR, { recursive: true, force: true });
+  __setDevDir(PRIOR_CACHED_DEV_DIR);
+  if (PRIOR_ENV.WOLFPACK_DEV_DIR === undefined) delete process.env.WOLFPACK_DEV_DIR;
+  else process.env.WOLFPACK_DEV_DIR = PRIOR_ENV.WOLFPACK_DEV_DIR;
+  if (PRIOR_ENV.WOLFPACK_TEST === undefined) delete process.env.WOLFPACK_TEST;
+  else process.env.WOLFPACK_TEST = PRIOR_ENV.WOLFPACK_TEST;
 });
 
 // ── 2. killPortHolder process verification ──


### PR DESCRIPTION
## summary
- serialize process-global umask changes around broker socket binding
- reject oversized synchronous output frames before writing
- restore mutable test globals and preserve snapshot error precedence
- refresh generated EDC context

## verification
- `git diff --check`
- `cargo check --manifest-path broker/Cargo.toml`
- `bun run typecheck`
- final read-only review: no actionable findings