### PR TITLE
refactor: improve CLI structural quality

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -256,12 +256,110 @@ function emitMachineFailure(
   process.exit(failure.exitCode);
 }
 
-async function main() {
+function runServiceCommand(argv: readonly string[]): void {
+  if (argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
+    print(SERVICE_USAGE);
+    return;
+  }
+  const serviceCommand = parseServiceCommand(argv.slice(1));
+  if (!serviceCommand) {
+    printError(`  ${SERVICE_USAGE}`);
+    process.exit(1);
+  }
+  if (serviceCommand.action === "install") serviceInstall();
+  else if (serviceCommand.action === "uninstall") serviceUninstall();
+  else if (serviceCommand.action === "stop") serviceStop(serviceCommand.broker ? { broker: true } : {});
+  else if (serviceCommand.action === "start") serviceStart();
+  else if (serviceCommand.action === "restart") {
+    const restarted = serviceCommand.serverOnly
+      ? serviceRestart({ broker: false, skipBrokerSessionWarning: true })
+      : serviceRestart(serviceCommand.broker ? { broker: true } : {});
+    if (!restarted) process.exitCode = 1;
+  } else if (serviceCommand.action === "status") serviceStatus();
+}
+
+async function runDoctorCommand(argv: readonly string[]): Promise<void> {
+  if (argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
+    print("Usage: wolfpack doctor [--json] [--fix]");
+    return;
+  }
+  const flags = argv.slice(1);
+  if (flags.some(flag => flag !== "--json" && flag !== "--fix")) throw new Error("Usage: wolfpack doctor [--json] [--fix]");
+  process.exit(await doctor({ fix: flags.includes("--fix"), json: flags.includes("--json") }));
+}
+
+function runUninstallCommand(argv: readonly string[]): void {
+  if (argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
+    print("Usage: wolfpack uninstall --yes");
+    return;
+  }
+  if (!hasUninstallConfirmationFlag(argv.slice(1))) {
+    printError(red("  Refusing to uninstall without confirmation."));
+    printError(dim("  This will recursively delete ~/.wolfpack/ (keys, secrets, config)."));
+    printError(dim("  Re-run with: wolfpack uninstall --yes"));
+    process.exit(1);
+  }
+  uninstall();
+}
+
+async function dispatchCommand(
+  argv: readonly string[],
+  target: VerifiedMachineTarget | undefined,
+): Promise<void> {
+  const [cmd] = argv;
+  if (argv.length === 1 && HELP_ALIASES.has(cmd)) {
+    print(topLevelUsage());
+    return;
+  }
+  if (argv.length === 1 && (cmd === "--version" || cmd === "-V")) {
+    print(pkg.version);
+    return;
+  }
+  if (shouldStartDashboard(argv)) {
+    await start();
+    return;
+  }
+  if (cmd === "setup") {
+    if (argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) print(setupUsage());
+    else await runSetup(argv.slice(1));
+    return;
+  }
+  if (cmd === "service") {
+    runServiceCommand(argv);
+    return;
+  }
+  if (cmd === "doctor") {
+    await runDoctorCommand(argv);
+    return;
+  }
+  if (cmd === "ls" || cmd === "list") process.exit(await lsSessions(argv.slice(1), target));
+  if (cmd === "session") process.exit(await runSessionCommand(argv.slice(1), target));
+  if (cmd === "agent") process.exit(await runAgentCommand(argv.slice(1), target));
+  if (cmd === "kill") process.exit(await killSession(argv.slice(1), target));
+  if (cmd === "logs") {
+    if (argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) print("Usage: wolfpack logs [--follow] [--json] [--broker]");
+    else process.exit(await logsCommand(argv.slice(1)));
+    return;
+  }
+  if (cmd === "attach") {
+    if (argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) print("Usage: wolfpack attach [session] [--take-control] [--prefill full|none]");
+    else process.exit(await attachCommand(argv.slice(1)));
+    return;
+  }
+  if (cmd === "uninstall") {
+    runUninstallCommand(argv);
+    return;
+  }
+  printError(red(`  Unknown command: ${cmd}`));
+  printError(dim("  Run 'wolfpack --help' for available commands."));
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
   const rawArgv = process.argv.slice(2);
   const extracted = extractMachineSelector(rawArgv);
   if (!extracted.ok) emitMachineFailure(extracted.error, rawArgv.includes("--json"));
   const argv = [...extracted.argv];
-  const [cmd] = argv;
   let target: VerifiedMachineTarget | undefined;
   if (extracted.selector !== undefined && !isMachineHelpRequest(argv)) {
     if (!isMachineCommandSupported(argv)) {
@@ -278,72 +376,7 @@ async function main() {
     if (!verified.ok) emitMachineFailure(verified.error, argv.includes("--json"));
     target = verified.target;
   }
-
-  if (argv.length === 1 && HELP_ALIASES.has(cmd)) {
-    print(topLevelUsage());
-  } else if (argv.length === 1 && (cmd === "--version" || cmd === "-V")) {
-    print(pkg.version);
-  } else if (shouldStartDashboard(argv)) {
-    await start();
-  } else if (cmd === "setup" && argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
-    print(setupUsage());
-  } else if (cmd === "setup") {
-    await runSetup(argv.slice(1));
-  } else if (cmd === "service" && argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
-    print(SERVICE_USAGE);
-  } else if (cmd === "service") {
-    const serviceCommand = parseServiceCommand(argv.slice(1));
-    if (!serviceCommand) {
-      printError(`  ${SERVICE_USAGE}`);
-      process.exit(1);
-    }
-    if (serviceCommand.action === "install") serviceInstall();
-    else if (serviceCommand.action === "uninstall") serviceUninstall();
-    else if (serviceCommand.action === "stop") serviceStop(serviceCommand.broker ? { broker: true } : {});
-    else if (serviceCommand.action === "start") serviceStart();
-    else if (serviceCommand.action === "restart") {
-      const restarted = serviceCommand.serverOnly
-        ? serviceRestart({ broker: false, skipBrokerSessionWarning: true })
-        : serviceRestart(serviceCommand.broker ? { broker: true } : {});
-      if (!restarted) process.exitCode = 1;
-    } else if (serviceCommand.action === "status") serviceStatus();
-  } else if (cmd === "doctor" && argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
-    print("Usage: wolfpack doctor [--json] [--fix]");
-  } else if (cmd === "doctor") {
-    const flags = argv.slice(1);
-    if (flags.some(flag => flag !== "--json" && flag !== "--fix")) throw new Error("Usage: wolfpack doctor [--json] [--fix]");
-    process.exit(await doctor({ fix: flags.includes("--fix"), json: flags.includes("--json") }));
-  } else if (cmd === "ls" || cmd === "list") {
-    process.exit(await lsSessions(argv.slice(1), target));
-  } else if (cmd === "session") {
-    process.exit(await runSessionCommand(argv.slice(1), target));
-  } else if (cmd === "agent") {
-    process.exit(await runAgentCommand(argv.slice(1), target));
-  } else if (cmd === "kill") {
-    process.exit(await killSession(argv.slice(1), target));
-  } else if (cmd === "logs" && argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
-    print("Usage: wolfpack logs [--follow] [--json] [--broker]");
-  } else if (cmd === "logs") {
-    process.exit(await logsCommand(argv.slice(1)));
-  } else if (cmd === "attach" && argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
-    print("Usage: wolfpack attach [session] [--take-control] [--prefill full|none]");
-  } else if (cmd === "attach") {
-    process.exit(await attachCommand(argv.slice(1)));
-  } else if (cmd === "uninstall" && argv.length === 2 && HELP_ALIASES.has(argv[1] ?? "")) {
-    print("Usage: wolfpack uninstall --yes");
-  } else if (cmd === "uninstall") {
-    if (!hasUninstallConfirmationFlag(argv.slice(1))) {
-      printError(red("  Refusing to uninstall without confirmation."));
-      printError(dim("  This will recursively delete ~/.wolfpack/ (keys, secrets, config)."));
-      printError(dim("  Re-run with: wolfpack uninstall --yes"));
-      process.exit(1);
-    }
-    uninstall();
-  } else {
-    printError(red(`  Unknown command: ${cmd}`));
-    printError(dim("  Run 'wolfpack --help' for available commands."));
-    process.exit(1);
-  }
+  await dispatchCommand(argv, target);
 }
 
 // only run when executed directly, not when imported for tests

--- a/src/cli/session-control.ts
+++ b/src/cli/session-control.ts
@@ -286,92 +286,91 @@ function parseExistingProjectSelector(
   return null;
 }
 
-export function parseSessionCommand(argv: readonly string[]): ParsedSessionCommand {
-  const args = [...argv];
-  const action = args.shift() as SessionAction | undefined;
-  if (!action) return { ok: false, message: "Usage: wolfpack session <create|status|read|send|wait|prompt|current-context> ..." };
-  if (!["create", "open", "status", "read", "send", "wait", "prompt", "current-context"].includes(action)) {
-    return { ok: false, message: `Unknown session command: ${action}` };
-  }
-  const isLaunch = action === "create" || action === "open";
-  const promptValue = isLaunch ? consumeLaunchValue(args, "--prompt") : null;
-  const promptFileValue = isLaunch ? consumeLaunchValue(args, "--prompt-file") : null;
-  const planValue = isLaunch ? consumeLaunchValue(args, "--plan") : null;
-  const projectDirValue = isLaunch ? consumeLaunchValue(args, "--project-dir") : null;
+type LaunchSessionAction = "create" | "open";
+type TargetSessionAction = "status" | "read" | "send" | "wait" | "prompt";
+
+function isSessionAction(action: string): action is SessionAction {
+  return ["create", "open", "status", "read", "send", "wait", "prompt", "current-context"].includes(action);
+}
+
+function parseLaunchSessionCommand(action: LaunchSessionAction, args: string[]): ParsedSessionCommand {
+  const promptValue = consumeLaunchValue(args, "--prompt");
+  const promptFileValue = consumeLaunchValue(args, "--prompt-file");
+  const planValue = consumeLaunchValue(args, "--plan");
+  const projectDirValue = consumeLaunchValue(args, "--project-dir");
   const nameValue = action === "open" ? (consumeLaunchValue(args, "--name") ?? consumeLaunchValue(args, "--session-name")) : null;
   const modelValue = action === "open" ? consumeLaunchValue(args, "--model") : null;
-  const notifyParent = isLaunch ? consumeFlag(args, "--notify-parent") : false;
+  const notifyParent = consumeFlag(args, "--notify-parent");
   const harnessValue = action === "create" ? consumeValue(args, "--harness") : null;
   const { mode: output, shellRequested } = parseOutputMode(args);
-  if (isLaunch) {
-    if (shellRequested) return { ok: false, message: "--shell is only valid for current-context" };
-    const prompt = promptValue ?? undefined;
-    const promptFile = promptFileValue ?? undefined;
-    const plan = planValue ?? undefined;
-    const sessionName = nameValue ?? undefined;
-    const model = modelValue ?? undefined;
-    const project = args.shift();
-    const projectDir = projectDirValue ?? undefined;
-    const harness = harnessValue !== null && isCreatableHarness(harnessValue)
-      ? harnessValue
-      : undefined;
-    const promptSources = [promptValue, promptFileValue, planValue].filter(value => value !== null);
-    const validPrompt = prompt === undefined
-      || (prompt.trim().length > 0
-        && unicodeCodePointLength(prompt) <= MAX_INITIAL_PROMPT_LENGTH);
-    const validPromptFile = promptFileValue === null || Boolean(promptFileValue.trim());
-    const validPlan = planValue === null || Boolean(planValue.trim());
-    const validSessionName = action !== "open"
-      || nameValue === null
-      || (Boolean(nameValue.trim()) && isValidSessionName(nameValue));
-    const validModel = action !== "open"
-      || modelValue === null
-      || (Boolean(modelValue.trim())
-        && unicodeCodePointLength(modelValue) <= SESSION_OPEN_MAX_MODEL_LENGTH);
-    const validPromptSources = promptSources.length <= 1 && validPromptFile && validPlan;
-    const validHarness = action !== "create"
-      || harnessValue === null
-      || harness !== undefined;
-    const validNotify = action !== "create" || !notifyParent;
-    const selector = parseExistingProjectSelector(project, projectDir);
-    if (selector === null || args.length > 0 || !validPrompt || !validPromptSources || !validSessionName || !validModel || !validHarness || !validNotify) {
-      return {
-        ok: false,
-        message: action === "create" ? sessionCreateUsage().split("\n")[0] : sessionOpenUsage().split("\n")[0],
-      };
-    }
-    if (action === "create") {
-      return {
-        ok: true,
-        action,
-        selector,
-        harness,
-        prompt,
-        ...(promptFile !== undefined && { promptFile }),
-        ...(plan !== undefined && { plan }),
-        output,
-      };
-    }
+  if (shellRequested) return { ok: false, message: "--shell is only valid for current-context" };
+
+  const prompt = promptValue ?? undefined;
+  const promptFile = promptFileValue ?? undefined;
+  const plan = planValue ?? undefined;
+  const sessionName = nameValue ?? undefined;
+  const model = modelValue ?? undefined;
+  const project = args.shift();
+  const projectDir = projectDirValue ?? undefined;
+  const harness = harnessValue !== null && isCreatableHarness(harnessValue)
+    ? harnessValue
+    : undefined;
+  const promptSources = [promptValue, promptFileValue, planValue].filter(value => value !== null);
+  const validPrompt = prompt === undefined
+    || (prompt.trim().length > 0
+      && unicodeCodePointLength(prompt) <= MAX_INITIAL_PROMPT_LENGTH);
+  const validPromptFile = promptFileValue === null || Boolean(promptFileValue.trim());
+  const validPlan = planValue === null || Boolean(planValue.trim());
+  const validSessionName = action !== "open"
+    || nameValue === null
+    || (Boolean(nameValue.trim()) && isValidSessionName(nameValue));
+  const validModel = action !== "open"
+    || modelValue === null
+    || (Boolean(modelValue.trim())
+      && unicodeCodePointLength(modelValue) <= SESSION_OPEN_MAX_MODEL_LENGTH);
+  const validPromptSources = promptSources.length <= 1 && validPromptFile && validPlan;
+  const validHarness = action !== "create"
+    || harnessValue === null
+    || harness !== undefined;
+  const validNotify = action !== "create" || !notifyParent;
+  const selector = parseExistingProjectSelector(project, projectDir);
+  if (selector === null || args.length > 0 || !validPrompt || !validPromptSources || !validSessionName || !validModel || !validHarness || !validNotify) {
+    return {
+      ok: false,
+      message: action === "create" ? sessionCreateUsage().split("\n")[0] : sessionOpenUsage().split("\n")[0],
+    };
+  }
+  if (action === "create") {
     return {
       ok: true,
       action,
       selector,
-      ...(sessionName !== undefined && { sessionName }),
-      ...(model !== undefined && { model }),
+      harness,
       prompt,
       ...(promptFile !== undefined && { promptFile }),
       ...(plan !== undefined && { plan }),
-      ...(notifyParent && { notifyParent: true }),
       output,
     };
   }
-  if (action === "current-context") {
-    if (args.length > 0) return { ok: false, message: "Usage: wolfpack session current-context [--json|--shell]" };
-    return { ok: true, action, output };
-  }
-  if (shellRequested) {
-    return { ok: false, message: "--shell is only valid for current-context" };
-  }
+  return {
+    ok: true,
+    action,
+    selector,
+    ...(sessionName !== undefined && { sessionName }),
+    ...(model !== undefined && { model }),
+    prompt,
+    ...(promptFile !== undefined && { promptFile }),
+    ...(plan !== undefined && { plan }),
+    ...(notifyParent && { notifyParent: true }),
+    output,
+  };
+}
+
+function parseTargetSessionCommand(
+  action: TargetSessionAction,
+  args: string[],
+  output: OutputMode,
+): ParsedSessionCommand {
   const session = args.shift();
   if (!session) return { ok: false, message: `Usage: wolfpack session ${action} <session> ...` };
   if (action === "status" || action === "read") {
@@ -422,6 +421,22 @@ export function parseSessionCommand(argv: readonly string[]): ParsedSessionComma
     return { ok: false, message: "Usage: wolfpack session wait <session> <text> [--timeout-ms <1..600000>] [--json]" };
   }
   return { ok: true, action, session, text, timeoutMs, output };
+}
+
+export function parseSessionCommand(argv: readonly string[]): ParsedSessionCommand {
+  const args = [...argv];
+  const action = args.shift();
+  if (!action) return { ok: false, message: "Usage: wolfpack session <create|status|read|send|wait|prompt|current-context> ..." };
+  if (!isSessionAction(action)) return { ok: false, message: `Unknown session command: ${action}` };
+  if (action === "create" || action === "open") return parseLaunchSessionCommand(action, args);
+
+  const { mode: output, shellRequested } = parseOutputMode(args);
+  if (action === "current-context") {
+    if (args.length > 0) return { ok: false, message: "Usage: wolfpack session current-context [--json|--shell]" };
+    return { ok: true, action, output };
+  }
+  if (shellRequested) return { ok: false, message: "--shell is only valid for current-context" };
+  return parseTargetSessionCommand(action, args, output);
 }
 
 export function parseAgentCommand(argv: readonly string[]): ParsedAgentCommand {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -122,6 +122,151 @@ function installPackages(pkgs: string[]) {
   }
 }
 
+function configureInteractiveTailscaleRemoteAccess(options: {
+  readonly interactive: boolean;
+  readonly hasTailscale: boolean;
+  readonly binary: string | null;
+  readonly port: number;
+}): string | undefined {
+  const binary = options.binary;
+  if (!options.interactive || !options.hasTailscale || !binary) return undefined;
+
+  const runTailscale = (args: readonly string[]): string => {
+    const [file, fileArgs] = IS_LINUX
+      ? ["sudo", [binary, ...args]]
+      : [binary, [...args]];
+    return execFileSync(file, fileArgs, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+  };
+  const inspectSelf = () => {
+    try { return inspectTailscaleSelf(runTailscale(["status", "--self", "--json"])); }
+    catch { return { status: "unavailable" } as const; }
+  };
+  let self = inspectSelf();
+  if (self.status !== "ready" && (self.status === "logged-out" || self.status === "unavailable")) {
+    if (IS_MACOS) {
+      print(dim("  Launching Tailscale.app for sign-in..."));
+      try { execSync("open /Applications/Tailscale.app", { stdio: "ignore" }); } catch (e: unknown) {
+        log.warn("setup: failed to launch Tailscale.app", { error: e instanceof Error ? e.message : String(e) });
+      }
+    } else if (IS_LINUX) {
+      print(dim("  Run 'sudo tailscale up' in another terminal to sign in."));
+    }
+    while (self.status !== "ready" && options.interactive) {
+      const retry = ask("  Sign in, then press Enter to retry (or type skip): ");
+      if (retry.toLowerCase() === "skip") break;
+      self = inspectSelf();
+    }
+  }
+  if (self.status === "ready") {
+    const configured = configureTailscaleRemoteAccess({
+      binary,
+      port: options.port,
+      run: (_file, args) => runTailscale(args),
+    });
+    if (configured.status === "verified") {
+      print(green(`  Tailscale serving at ${configured.origin}/`));
+      return configured.hostname;
+    }
+    print(red("  Tailscale Serve could not be structurally verified; no phone QR will be shown."));
+    print(dim(`  Retry: ${IS_LINUX ? "sudo " : ""}${binary} serve --bg ${options.port}`));
+  } else if (self.status === "logged-out") {
+    print(yellow("  Tailscale is not signed in; phone and remote access remain unavailable."));
+  } else if (self.status === "malformed-status") {
+    print(red("  Tailscale returned malformed identity data; remote access remains unavailable."));
+  } else {
+    print(yellow("  Tailscale is unavailable; phone and remote access remain unavailable."));
+  }
+  return undefined;
+}
+
+function reconcileSetupService(
+  previousConfig: Config | null,
+  config: Config,
+  deferServiceRestart: boolean | undefined,
+): { readonly serviceInstalled: boolean; readonly serviceRunning: boolean } {
+  const serviceInstalled = isServiceInstalled();
+  let serviceRunning = serviceInstalled && isServiceRunning();
+  const descriptorSettingsChanged = previousConfig?.devDir !== config.devDir
+    || previousConfig?.port !== config.port;
+  const remotePolicyChanged = previousConfig?.tailscaleHostname !== config.tailscaleHostname;
+  if (descriptorSettingsChanged && serviceInstalled) {
+    refreshInstalledServerService({ reload: !deferServiceRestart });
+    if (!deferServiceRestart) serviceRunning = isServiceRunning();
+  } else if (remotePolicyChanged && serviceRunning && !deferServiceRestart) {
+    if (!serviceRestart({ broker: false, skipBrokerSessionWarning: true })) {
+      throw new Error("failed to restart server service after setup changes");
+    }
+    serviceRunning = isServiceRunning();
+  }
+  return { serviceInstalled, serviceRunning };
+}
+
+function handleOptionalPiIntegration(interactive: boolean): void {
+  const piIntegrationMode = planPiIntegrationSetup(process.env.PATH, interactive);
+  if (piIntegrationMode === "prompt") {
+    print("");
+    print(bold("  Optional Pi integration:"));
+    for (const line of piIntegrationDisclosureLines()) {
+      print(dim(line));
+    }
+    const installPi = ask("  Install Wolfpack's control skill and Pi Tasks? [y/N] ");
+    if (acceptsPiIntegrationInstall(installPi)) {
+      const installResult = installPiIntegration({ pathValue: process.env.PATH });
+      if (installResult.status === "installed") {
+        print(green("  Installed the Wolfpack control skill and Pi Tasks."));
+        print(dim("  Start a fresh Pi session, or run /reload in an existing session."));
+      } else if (installResult.status === "skill_exists") {
+        print(red("  Pi integration stopped: Wolfpack's control skill already exists."));
+        print(dim(`  Review the existing skill before removing or replacing ${installResult.skillPath}.`));
+      } else if (installResult.status === "skill_write_failed") {
+        print(red("  Pi integration stopped: could not install Wolfpack's control skill."));
+        if (installResult.canRetry) {
+          print(dim(`  Check write access to ${installResult.skillPath} and rerun 'wolfpack setup'.`));
+        } else {
+          print(dim(`  Wolfpack could not clean the partial skill at ${installResult.skillPath}; review and remove it before rerunning setup.`));
+        }
+      } else {
+        print(red(`  Pi integration install stopped at ${installResult.failedSource}.`));
+        print(dim(`  Retry: ${installResult.retryCommand}`));
+        print(dim("  Wolfpack's control skill was installed; Pi Tasks remains unavailable until the retry succeeds."));
+      }
+    } else {
+      print(dim("  Skipped optional Pi integration."));
+    }
+  } else if (piIntegrationMode === "guidance") {
+    print("");
+    print(dim("  Pi detected; non-interactive mode skipped the optional Pi integration."));
+    print(dim("  Run 'wolfpack setup' interactively to install the control skill and Pi Tasks."));
+  }
+}
+
+function installSetupService(options: {
+  readonly serviceInstalled: boolean;
+  readonly serviceRunning: boolean;
+  readonly interactive: boolean;
+  readonly deferServiceRestart: boolean | undefined;
+}): { readonly serviceInstalled: boolean; readonly serviceRunning: boolean } {
+  if (options.serviceInstalled) return options;
+  if (options.deferServiceRestart) {
+    print(dim("  Service activation deferred."));
+    return options;
+  }
+  if (!options.interactive) {
+    print(dim("  Non-interactive mode — skipping service install."));
+    print(dim("  Run 'wolfpack service install' to start automatically on login."));
+    return options;
+  }
+  const installService = ask("  Start wolfpack automatically on login? [Y/n] ");
+  if (installService.toLowerCase() === "n") return options;
+  try {
+    serviceInstall();
+    return { serviceInstalled: true, serviceRunning: true };
+  } catch (e) {
+    print(red(`  Service install failed: ${e}`));
+    return options;
+  }
+}
+
 export interface SetupOptions {
   readonly nonInteractive?: boolean;
   readonly deferServiceRestart?: boolean;
@@ -220,51 +365,12 @@ export async function setup(options: SetupOptions = {}) {
 
   // Tailscale readiness is persisted only after `serve status --json` proves
   // this exact canonical HTTPS origin proxies to Wolfpack's loopback port.
-    let verifiedRemoteHostname: string | undefined;
-  if (interactive && hasTailscale && tsBin) {
-    const runTailscale = (args: readonly string[]): string => {
-      const [file, fileArgs] = IS_LINUX
-        ? ["sudo", [tsBin, ...args]]
-        : [tsBin, [...args]];
-      return execFileSync(file, fileArgs, { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
-    };
-    const inspectSelf = () => {
-      try { return inspectTailscaleSelf(runTailscale(["status", "--self", "--json"])); }
-      catch { return { status: "unavailable" } as const; }
-    };
-    let self = inspectSelf();
-    if (self.status !== "ready" && (self.status === "logged-out" || self.status === "unavailable")) {
-      if (IS_MACOS) {
-        print(dim("  Launching Tailscale.app for sign-in..."));
-        try { execSync("open /Applications/Tailscale.app", { stdio: "ignore" }); } catch (e: unknown) {
-          log.warn("setup: failed to launch Tailscale.app", { error: e instanceof Error ? e.message : String(e) });
-        }
-      } else if (IS_LINUX) {
-        print(dim("  Run 'sudo tailscale up' in another terminal to sign in."));
-      }
-      while (self.status !== "ready" && interactive) {
-        const retry = ask("  Sign in, then press Enter to retry (or type skip): ");
-        if (retry.toLowerCase() === "skip") break;
-        self = inspectSelf();
-      }
-    }
-    if (self.status === "ready") {
-      const configured = configureTailscaleRemoteAccess({ binary: tsBin, port, run: (_file, args) => runTailscale(args) });
-      if (configured.status === "verified") {
-        verifiedRemoteHostname = configured.hostname;
-        print(green(`  Tailscale serving at ${configured.origin}/`));
-      } else {
-        print(red("  Tailscale Serve could not be structurally verified; no phone QR will be shown."));
-        print(dim(`  Retry: ${IS_LINUX ? "sudo " : ""}${tsBin} serve --bg ${port}`));
-      }
-    } else if (self.status === "logged-out") {
-      print(yellow("  Tailscale is not signed in; phone and remote access remain unavailable."));
-    } else if (self.status === "malformed-status") {
-      print(red("  Tailscale returned malformed identity data; remote access remains unavailable."));
-    } else {
-      print(yellow("  Tailscale is unavailable; phone and remote access remain unavailable."));
-    }
-  }
+  const verifiedRemoteHostname = configureInteractiveTailscaleRemoteAccess({
+    interactive,
+    hasTailscale,
+    binary: tsBin,
+    port,
+  });
 
   const config: Config = {
     devDir,
@@ -274,85 +380,27 @@ export async function setup(options: SetupOptions = {}) {
     }),
   };
   saveConfig(config);
-  let serviceInstalled = isServiceInstalled();
-  let serviceRunning = serviceInstalled && isServiceRunning();
-  const descriptorSettingsChanged = previousConfig?.devDir !== config.devDir
-    || previousConfig?.port !== config.port;
-  const remotePolicyChanged = previousConfig?.tailscaleHostname !== config.tailscaleHostname;
-  if (descriptorSettingsChanged && serviceInstalled) {
-    // The plist/unit embeds these values; a plain restart would reload stale
-    // environment. Installer-managed setup writes the descriptor now and
-    // leaves activation to the installer's final server-only restart.
-    refreshInstalledServerService({ reload: !options.deferServiceRestart });
-    if (!options.deferServiceRestart) serviceRunning = isServiceRunning();
-  } else if (remotePolicyChanged && serviceRunning && !options.deferServiceRestart) {
-    // CORS policy is loaded at server startup. A running broker remains
-    // untouched, so its PTYs and sessions survive the server restart.
-    if (!serviceRestart({ broker: false, skipBrokerSessionWarning: true })) {
-      throw new Error("failed to restart server service after setup changes");
-    }
-    serviceRunning = isServiceRunning();
-  }
+  // The plist/unit embeds config values, while the remote-origin policy is
+  // loaded by the server. Both paths must preserve broker-owned PTYs.
+  let { serviceInstalled, serviceRunning } = reconcileSetupService(
+    previousConfig,
+    config,
+    options.deferServiceRestart,
+  );
 
   initializeProviderSettingsFile({
     settingsPath: join(WOLFPACK_DIR, "bridge-settings.json"),
     pathValue: process.env.PATH,
   });
 
-  const piIntegrationMode = planPiIntegrationSetup(process.env.PATH, interactive);
-  if (piIntegrationMode === "prompt") {
-    print("");
-    print(bold("  Optional Pi integration:"));
-    for (const line of piIntegrationDisclosureLines()) {
-      print(dim(line));
-    }
-    const installPi = ask("  Install Wolfpack's control skill and Pi Tasks? [y/N] ");
-    if (acceptsPiIntegrationInstall(installPi)) {
-      const installResult = installPiIntegration({ pathValue: process.env.PATH });
-      if (installResult.status === "installed") {
-        print(green("  Installed the Wolfpack control skill and Pi Tasks."));
-        print(dim("  Start a fresh Pi session, or run /reload in an existing session."));
-      } else if (installResult.status === "skill_exists") {
-        print(red("  Pi integration stopped: Wolfpack's control skill already exists."));
-        print(dim(`  Review the existing skill before removing or replacing ${installResult.skillPath}.`));
-      } else if (installResult.status === "skill_write_failed") {
-        print(red("  Pi integration stopped: could not install Wolfpack's control skill."));
-        if (installResult.canRetry) {
-          print(dim(`  Check write access to ${installResult.skillPath} and rerun 'wolfpack setup'.`));
-        } else {
-          print(dim(`  Wolfpack could not clean the partial skill at ${installResult.skillPath}; review and remove it before rerunning setup.`));
-        }
-      } else {
-        print(red(`  Pi integration install stopped at ${installResult.failedSource}.`));
-        print(dim(`  Retry: ${installResult.retryCommand}`));
-        print(dim("  Wolfpack's control skill was installed; Pi Tasks remains unavailable until the retry succeeds."));
-      }
-    } else {
-      print(dim("  Skipped optional Pi integration."));
-    }
-  } else if (piIntegrationMode === "guidance") {
-    print("");
-    print(dim("  Pi detected; non-interactive mode skipped the optional Pi integration."));
-    print(dim("  Run 'wolfpack setup' interactively to install the control skill and Pi Tasks."));
-  }
+  handleOptionalPiIntegration(interactive);
 
-  if (!serviceInstalled && options.deferServiceRestart) {
-    print(dim("  Service activation deferred."));
-  } else if (!serviceInstalled && !interactive) {
-    print(dim("  Non-interactive mode — skipping service install."));
-    print(dim("  Run 'wolfpack service install' to start automatically on login."));
-  } else if (!serviceInstalled) {
-    const installService = ask("  Start wolfpack automatically on login? [Y/n] ");
-    if (installService.toLowerCase() !== "n") {
-      try {
-        serviceInstall();
-        serviceInstalled = true;
-        serviceRunning = true;
-      } catch (e) {
-        print(red(`  Service install failed: ${e}`));
-      }
-    }
-  }
+  ({ serviceInstalled, serviceRunning } = installSetupService({
+    serviceInstalled,
+    serviceRunning,
+    interactive,
+    deferServiceRestart: options.deferServiceRestart,
+  }));
 
   printSetupCompletion({
     port: config.port,


### PR DESCRIPTION
## summary

- split session command parsing into typed launch and target-session paths
- isolate Tailscale, service reconciliation, Pi integration, and activation setup phases
- separate local CLI command dispatch from verified remote-machine selection

## sentrux evidence

| step | signal | equality | acyclicity |
| --- | ---: | ---: | ---: |
| main baseline | 6231 | 4653 | 10000 |
| session parser | 6233 | 4659 | 10000 |
| setup orchestration | 6236 | 4671 | 10000 |
| CLI dispatch | 6240 | 4683 | 10000 |

Cumulative signal improvement: **+9**. Dependency depth stayed at 9 and no cycles were introduced. No scanner exclusions, generated churn, fake modules, test padding, new dependencies, or public API changes.

## verification

- `bun test`: 1972 passed, 23 expected skips, 0 failed
- focused changed-surface tests: 79 passed
- `bun run typecheck`
- `bun run check:bundle-budgets`
- `git diff --check edb026c...HEAD`
- independent Sol review: approved with zero actionable security, delivery, quality, or antipattern findings
