### PR TITLE
perf: cache indexed relay snapshots and skip idle outbox scans

### DIFF
--- a/scripts/task-relay-store-perf.ts
+++ b/scripts/task-relay-store-perf.ts
@@ -5,6 +5,7 @@ import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { canonicalJson } from "../src/canonical-json.ts";
 import { RELAY_ID, RELAY_PROTOCOL_VERSION } from "../src/task-relay/domain.ts";
+import { TaskRelayGateway } from "../src/task-relay/gateway.ts";
 
 const storeModule = resolve(process.argv[2] ?? "src/task-relay/store.ts");
 const { TaskRelayStore } = await import(pathToFileURL(storeModule).href) as typeof import("../src/task-relay/store.ts");
@@ -96,6 +97,33 @@ try {
     ));
     await warmStore.acknowledge(endpoint.id, envelopes[0]!.envelope.envelopeId, now.toISOString());
     const duplicateAcknowledgementMs = await measure(() => warmStore.acknowledge(endpoint.id, envelopes[0]!.envelope.envelopeId, now.toISOString()));
+    let terminalOutboxFlushMs: number | undefined;
+    if (storeModule === resolve("src/task-relay/store.ts")) {
+      const route = { id: `${RELAY_ID}:peer:${randomUUID()}`, origin: "https://receiver.example.ts.net" };
+      const terminalOutbox = envelopes.map((item, index) => {
+        const envelope = { ...item.envelope, envelopeId: `terminal-${index}`, target: { relay: route.id, id: endpoint.id } };
+        return {
+          envelope,
+          peerOrigin: route.origin,
+          digest: createHash("sha256").update(canonicalJson(envelope)).digest("hex"),
+          acceptanceId: randomUUID(),
+          queuedAt: now.toISOString(),
+          attempts: 1,
+          lastAttemptAt: now.toISOString(),
+          forwardedAt: now.toISOString(),
+          exhaustedAt: undefined,
+          lastError: undefined,
+        };
+      });
+      writeFileSync(warmStore.path, canonicalJson({ ...JSON.parse(state), peerRoutes: [route], outbox: terminalOutbox }));
+      const gateway = new TaskRelayGateway({ root, inspectSession: async () => ({ ok: false as const, code: "NOT_FOUND" as const }) });
+      try {
+        await gateway.flushPeerOutbox();
+        terminalOutboxFlushMs = await measure(() => gateway.flushPeerOutbox());
+      } finally {
+        gateway.close();
+      }
+    }
     console.log(JSON.stringify({
       kind: "relay-store-perf-result",
       envelopes: count,
@@ -105,6 +133,7 @@ try {
       emptyOutboxTwoReadsMs,
       twentyWarmLookupsMs,
       duplicateAcknowledgementMs,
+      terminalOutboxFlushMs,
     }));
   }
 } finally {

--- a/scripts/task-relay-store-perf.ts
+++ b/scripts/task-relay-store-perf.ts
@@ -1,0 +1,112 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { canonicalJson } from "../src/canonical-json.ts";
+import { RELAY_ID, RELAY_PROTOCOL_VERSION } from "../src/task-relay/domain.ts";
+
+const storeModule = resolve(process.argv[2] ?? "src/task-relay/store.ts");
+const { TaskRelayStore } = await import(pathToFileURL(storeModule).href) as typeof import("../src/task-relay/store.ts");
+const repeats = 5;
+const median = (values: number[]) => values.sort((left, right) => left - right)[Math.floor(values.length / 2)]!;
+
+async function measure(operation: () => unknown): Promise<number> {
+  await operation();
+  const values: number[] = [];
+  for (let index = 0; index < repeats; index += 1) {
+    const start = performance.now();
+    await operation();
+    values.push(performance.now() - start);
+  }
+  return Number(median(values).toFixed(3));
+}
+
+const root = mkdtempSync(join(tmpdir(), "wolfpack-relay-store-perf-"));
+try {
+  console.log(JSON.stringify({
+    kind: "relay-store-perf",
+    module: storeModule,
+    runtime: Bun.version,
+    platform: process.platform,
+    arch: process.arch,
+    repeats,
+    note: "Synthetic warm-filesystem medians in milliseconds; no live relay data or services.",
+  }));
+  const now = new Date("2026-08-09T00:00:00.000Z");
+  const endpoint = { relay: RELAY_ID, id: randomUUID() };
+  const registration = {
+    endpoint,
+    sessionId: "synthetic-session",
+    generation: "synthetic-generation",
+    protocolVersions: [RELAY_PROTOCOL_VERSION],
+    leaseExpiresAt: new Date(now.getTime() + 60 * 60 * 1000).toISOString(),
+  };
+  for (const count of [1_000, 5_000]) {
+    const envelopes = Array.from({ length: count }, (_, index) => {
+      const envelope = {
+        envelopeId: `synthetic-${index}`,
+        protocolVersion: RELAY_PROTOCOL_VERSION,
+        source: endpoint,
+        target: endpoint,
+        payload: { text: "x".repeat(1024) },
+        createdAt: now.toISOString(),
+      };
+      return {
+        envelope,
+        digest: createHash("sha256").update(canonicalJson(envelope)).digest("hex"),
+        acceptedAt: now.toISOString(),
+        acceptanceId: randomUUID(),
+      };
+    });
+    const mailbox = envelopes.map((item, index) => ({
+      endpointId: endpoint.id,
+      envelopeId: item.envelope.envelopeId,
+      cursor: String(index + 1),
+      acknowledgedAt: now.toISOString(),
+    }));
+    const state = canonicalJson({
+      version: 2,
+      registrations: [registration],
+      envelopes,
+      mailbox,
+      mailboxCursors: [{ endpointId: endpoint.id, cursor: String(count) }],
+      peerRoutes: [],
+      outbox: [],
+    });
+    const seed = () => {
+      const store = new TaskRelayStore(root);
+      writeFileSync(store.path, state);
+      return store;
+    };
+
+    const coldLookupMs = await measure(() => {
+      const store = seed();
+      return store.registrationForSession(registration.sessionId, now);
+    });
+    const warmStore = seed();
+    await warmStore.registrationForSession(registration.sessionId, now);
+    const warmLookupMs = await measure(() => warmStore.registrationForSession(registration.sessionId, now));
+    const emptyOutboxTwoReadsMs = await measure(async () => {
+      await warmStore.outbox();
+      await warmStore.outbox();
+    });
+    const twentyWarmLookupsMs = await measure(() => Promise.all(
+      Array.from({ length: 20 }, (_, index) => warmStore.registrationForSession(`missing-${index}`, now)),
+    ));
+    await warmStore.acknowledge(endpoint.id, envelopes[0]!.envelope.envelopeId, now.toISOString());
+    const duplicateAcknowledgementMs = await measure(() => warmStore.acknowledge(endpoint.id, envelopes[0]!.envelope.envelopeId, now.toISOString()));
+    console.log(JSON.stringify({
+      kind: "relay-store-perf-result",
+      envelopes: count,
+      storeBytes: statSync(warmStore.path).size,
+      coldLookupMs,
+      warmLookupMs,
+      emptyOutboxTwoReadsMs,
+      twentyWarmLookupsMs,
+      duplicateAcknowledgementMs,
+    }));
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/src/server/session-control-routes.ts
+++ b/src/server/session-control-routes.ts
@@ -243,10 +243,12 @@ export const sessionControlRoutes: Record<string, RouteHandler> = {
       if (!identities || names.some(name => !identities[name])) {
         return json(res, { error: "session identity unavailable" }, 503);
       }
-      const sessions = (await Promise.all(names.map(async (name) => {
+      const relay = getTaskRelayGateway();
+      const endpoints = await relay.endpointsForSessions(names.map(name => identities[name]!.wolfpackSessionId));
+      const sessions = names.map((name) => {
         const identity = identities[name]!;
-        return sessionStatusPayload(name, identity, await getTaskRelayGateway().endpointForSession(identity.wolfpackSessionId));
-      }))).sort((left, right) => left.session.localeCompare(right.session));
+        return sessionStatusPayload(name, identity, endpoints.get(identity.wolfpackSessionId));
+      }).sort((left, right) => left.session.localeCompare(right.session));
       json(res, { sessions });
     } catch (error: unknown) {
       log.warn("session-control list failed", { error: errMsg(error) });

--- a/src/task-relay/gateway.ts
+++ b/src/task-relay/gateway.ts
@@ -309,11 +309,10 @@ export class TaskRelayGateway {
   }
 
   async flushPeerOutbox(recoverImmediately = false): Promise<{ readonly forwarded: number; readonly pending: number }> {
-    const outbox = await this.#store.outbox();
-    if (outbox.length === 0) return { forwarded: 0, pending: 0 };
+    const pendingOutbox = await this.#store.pendingOutbox();
+    if (pendingOutbox.length === 0) return { forwarded: 0, pending: 0 };
     let forwarded = 0;
-    for (const item of outbox) {
-      if (item.forwardedAt !== undefined || item.exhaustedAt !== undefined) continue;
+    for (const item of pendingOutbox) {
       if (await this.#forwardEnvelope(item.envelope.envelopeId, recoverImmediately)) forwarded += 1;
     }
     return { forwarded, pending: await this.#store.pendingOutboxCount() };

--- a/src/task-relay/gateway.ts
+++ b/src/task-relay/gateway.ts
@@ -183,6 +183,14 @@ export class TaskRelayGateway {
     return (await this.#store.registrationForSession(sessionId, this.#now()))?.endpoint;
   }
 
+  async endpointsForSessions(sessionIds: readonly string[]): Promise<ReadonlyMap<string, RelayEndpoint>> {
+    const endpoints = new Map<string, RelayEndpoint>();
+    for (const [sessionId, registration] of await this.#store.registrationsForSessions(sessionIds, this.#now())) {
+      endpoints.set(sessionId, registration.endpoint);
+    }
+    return endpoints;
+  }
+
   async disconnect(input: { readonly callerSession: string; readonly endpoint: RelayEndpoint }): Promise<RelayResult<Record<never, never>>> {
     if (!isRelayEndpoint(input.endpoint)) return relayFailure(RELAY_ERROR.INVALID_REQUEST, "invalid relay endpoint");
     const caller = await this.#caller(input.callerSession);
@@ -301,13 +309,14 @@ export class TaskRelayGateway {
   }
 
   async flushPeerOutbox(recoverImmediately = false): Promise<{ readonly forwarded: number; readonly pending: number }> {
+    const outbox = await this.#store.outbox();
+    if (outbox.length === 0) return { forwarded: 0, pending: 0 };
     let forwarded = 0;
-    for (const item of await this.#store.outbox()) {
+    for (const item of outbox) {
       if (item.forwardedAt !== undefined || item.exhaustedAt !== undefined) continue;
       if (await this.#forwardEnvelope(item.envelope.envelopeId, recoverImmediately)) forwarded += 1;
     }
-    const pending = (await this.#store.outbox()).filter((item) => item.forwardedAt === undefined && item.exhaustedAt === undefined).length;
-    return { forwarded, pending };
+    return { forwarded, pending: await this.#store.pendingOutboxCount() };
   }
 
   async cleanup(before: Date): Promise<number> {
@@ -330,7 +339,7 @@ export class TaskRelayGateway {
   }
 
   async #forwardEnvelopeOnce(envelopeId: string, recoverImmediately = false): Promise<boolean> {
-    const item = (await this.#store.outbox()).find((candidate) => candidate.envelope.envelopeId === envelopeId);
+    const item = await this.#store.outboxItem(envelopeId);
     if (!item || item.forwardedAt !== undefined || item.exhaustedAt !== undefined) return item?.forwardedAt !== undefined;
     if (item.attempts >= RELAY_LIMITS.MAX_FORWARD_ATTEMPTS) {
       await this.#store.updateOutbox(envelopeId, (current) => current.exhaustedAt === undefined

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -338,11 +338,23 @@ function immutableCopy<T>(value: T): T {
   return copy;
 }
 
+function firstBy<T>(values: readonly T[], key: (value: T) => string): Map<string, T> {
+  const index = new Map<string, T>();
+  for (const value of values) {
+    const id = key(value);
+    if (!index.has(id)) index.set(id, value);
+  }
+  return index;
+}
+
 function snapshot(state: RelayState, version: FileVersion | undefined): RelaySnapshot {
   freeze(state);
-  const registrationBySession = new Map(state.registrations.map(item => [item.sessionId, item]));
-  const registrationByEndpoint = new Map(state.registrations.map(item => [item.endpoint.id, item]));
-  const peerOriginByRoute = new Map(state.peerRoutes.map(item => [item.id, item.origin]));
+  // Persisted validation permits duplicate registrations, routes, and outbox
+  // IDs. Array callers historically use find(), so indexes deliberately retain
+  // the first entry instead of introducing last-write-wins behavior.
+  const registrationBySession = firstBy(state.registrations, item => item.sessionId);
+  const registrationByEndpoint = firstBy(state.registrations, item => item.endpoint.id);
+  const peerOriginByRoute = new Map([...firstBy(state.peerRoutes, item => item.id)].map(([id, route]) => [id, route.origin]));
   const envelopeById = new Map(state.envelopes.map(item => [item.envelope.envelopeId, item]));
   const mailboxByEndpoint = new Map<string, StoredMailboxItem[]>();
   for (const item of state.mailbox) {
@@ -359,7 +371,7 @@ function snapshot(state: RelayState, version: FileVersion | undefined): RelaySna
     peerOriginByRoute,
     envelopeById,
     mailboxByEndpoint,
-    outboxByEnvelopeId: new Map(state.outbox.map(item => [item.envelope.envelopeId, item])),
+    outboxByEnvelopeId: firstBy(state.outbox, item => item.envelope.envelopeId),
     pendingOutboxCount: state.outbox.filter(item => item.forwardedAt === undefined && item.exhaustedAt === undefined).length,
   };
 }
@@ -532,14 +544,15 @@ export class TaskRelayStore {
 
   async updateOutbox(envelopeId: string, update: (item: PeerOutboxItem) => PeerOutboxItem): Promise<void> {
     await this.#mutate((state) => {
-      const index = state.outbox.findIndex(item => item.envelope.envelopeId === envelopeId);
-      if (index === -1) return { state, value: undefined };
-      const previous = state.outbox[index]!;
-      const next = update(previous);
-      if (next === previous || canonicalJson(next) === canonicalJson(previous)) return { state, value: undefined };
-      const outbox = [...state.outbox];
-      outbox[index] = next;
-      return { state: { ...state, outbox }, value: undefined };
+      let changed = false;
+      const outbox = state.outbox.map((item) => {
+        if (item.envelope.envelopeId !== envelopeId) return item;
+        const next = update(item);
+        if (next === item || canonicalJson(next) === canonicalJson(item)) return item;
+        changed = true;
+        return next;
+      });
+      return { state: changed ? { ...state, outbox } : state, value: undefined };
     });
   }
 

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -90,6 +90,8 @@ const DECIMAL_CURSOR_PATTERN = /^[1-9][0-9]*$/;
  * independent processes must coordinate a single writer because this JSON store
  * has no cross-process compare-and-swap. Direct in-place edits are unsupported:
  * they can defeat file identity checks and were never a safe mutation protocol.
+ * An idle second instance may retain its prior immutable snapshot until its next
+ * access or collection; there is no process-global strong cache/eager invalidator.
  */
 interface FileVersion {
   readonly dev: bigint;

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -86,9 +86,10 @@ const DECIMAL_CURSOR_PATTERN = /^[1-9][0-9]*$/;
 
 /**
  * A store instance observes external writers only when they atomically replace or
- * remove/recreate relay-state.json. Same-process writers are serialized below.
- * Direct in-place edits are unsupported: they can defeat file identity checks
- * and were never a safe concurrent mutation protocol for this JSON store.
+ * remove/recreate relay-state.json. Same-process writers are serialized below;
+ * independent processes must coordinate a single writer because this JSON store
+ * has no cross-process compare-and-swap. Direct in-place edits are unsupported:
+ * they can defeat file identity checks and were never a safe mutation protocol.
  */
 interface FileVersion {
   readonly dev: number;
@@ -635,16 +636,11 @@ export class TaskRelayStore {
       this.#snapshot = undefined;
       throw cause;
     }
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(source);
-    } catch (cause) {
-      throw new MalformedRelayStoreError(cause);
-    }
-    const persisted = parsePersistedRelayState(parsed);
-    if (!persisted || persisted === "reset") throw new MalformedRelayStoreError();
-    const version = fileVersion(this.path);
-    return this.#snapshot = snapshot(version === undefined ? EMPTY : persisted, version);
+    // Do not pair our serialized bytes with a later path stat: another atomic
+    // replacement could win after rename. Reload through #read's stable
+    // before/read/after identity check so cache authority always matches bytes.
+    this.#snapshot = undefined;
+    return this.#read();
   }
 
   async #mutate<T>(operation: (state: RelayState) => { readonly state: RelayState; readonly value: T }): Promise<T> {

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -331,6 +331,12 @@ function freeze(value: unknown): void {
   Object.freeze(value);
 }
 
+function immutableCopy<T>(value: T): T {
+  const copy = JSON.parse(canonicalJson(value)) as T;
+  freeze(copy);
+  return copy;
+}
+
 function snapshot(state: RelayState, version: FileVersion | undefined): RelaySnapshot {
   freeze(state);
   const registrationBySession = new Map(state.registrations.map(item => [item.sessionId, item]));
@@ -381,7 +387,7 @@ export class TaskRelayStore {
   }
 
   async register(input: Omit<RelayRegistration, "endpoint" | "leaseExpiresAt"> & { readonly endpoint: RelayEndpoint; readonly leaseExpiresAt: string }): Promise<RelayRegistration> {
-    return this.#mutate((state) => {
+    const registered = await this.#mutate((state) => {
       const existing = state.registrations.find((item) => item.sessionId === input.sessionId && item.generation === input.generation);
       const registration = existing
         ? { ...existing, protocolVersions: input.protocolVersions, leaseExpiresAt: input.leaseExpiresAt }
@@ -389,6 +395,8 @@ export class TaskRelayStore {
       if (existing && canonicalJson(existing) === canonicalJson(registration)) return { state, value: existing };
       return { state: { ...state, registrations: [...state.registrations.filter((item) => item.sessionId !== input.sessionId), registration] }, value: registration };
     });
+    // Return the owned, persisted snapshot rather than an input alias.
+    return this.#read().registrationBySession.get(registered.sessionId) ?? immutableCopy(registered);
   }
 
   async registrationForSession(sessionId: string, now: Date): Promise<RelayRegistration | undefined> {
@@ -619,7 +627,14 @@ export class TaskRelayStore {
 
   #write(state: RelayState): RelaySnapshot {
     const source = canonicalJson(state);
-    atomicWrite(this.path, source);
+    try {
+      atomicWrite(this.path, source);
+    } catch (cause) {
+      // A failure can happen before rename or after it during directory fsync.
+      // Re-read durable authority on the next operation in either case.
+      this.#snapshot = undefined;
+      throw cause;
+    }
     let parsed: unknown;
     try {
       parsed = JSON.parse(source);

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { closeSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { closeSync, fstatSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { canonicalJson } from "../canonical-json.ts";
@@ -104,12 +104,13 @@ interface FileVersion {
 interface RelaySnapshot {
   readonly state: RelayState;
   readonly version: FileVersion | undefined;
-  readonly registrationBySession: ReadonlyMap<string, RelayRegistration>;
-  readonly registrationByEndpoint: ReadonlyMap<string, RelayRegistration>;
+  readonly registrationsBySession: ReadonlyMap<string, readonly RelayRegistration[]>;
+  readonly registrationsByEndpoint: ReadonlyMap<string, readonly RelayRegistration[]>;
   readonly peerOriginByRoute: ReadonlyMap<string, string>;
   readonly envelopeById: ReadonlyMap<string, StoredEnvelope>;
   readonly mailboxByEndpoint: ReadonlyMap<string, readonly StoredMailboxItem[]>;
   readonly outboxByEnvelopeId: ReadonlyMap<string, PeerOutboxItem>;
+  readonly pendingOutbox: readonly PeerOutboxItem[];
   readonly pendingOutboxCount: number;
 }
 
@@ -312,10 +313,13 @@ function atomicWrite(path: string, source: string): void {
   try { fsyncSync(directory); } finally { closeSync(directory); }
 }
 
+function versionFromStat(stat: { readonly dev: bigint; readonly ino: bigint; readonly size: bigint; readonly mtimeNs: bigint; readonly ctimeNs: bigint }): FileVersion {
+  return { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeNs: stat.mtimeNs, ctimeNs: stat.ctimeNs };
+}
+
 function fileVersion(path: string): FileVersion | undefined {
   try {
-    const stat = statSync(path, { bigint: true });
-    return { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeNs: stat.mtimeNs, ctimeNs: stat.ctimeNs };
+    return versionFromStat(statSync(path, { bigint: true }));
   } catch (cause: unknown) {
     if ((cause as NodeJS.ErrnoException).code === "ENOENT") return undefined;
     throw cause;
@@ -349,13 +353,28 @@ function firstBy<T>(values: readonly T[], key: (value: T) => string): Map<string
   return index;
 }
 
+function groupBy<T>(values: readonly T[], key: (value: T) => string): Map<string, readonly T[]> {
+  const index = new Map<string, T[]>();
+  for (const value of values) {
+    const id = key(value);
+    const group = index.get(id) ?? [];
+    group.push(value);
+    index.set(id, group);
+  }
+  return index;
+}
+
+function activeRegistration(registrations: readonly RelayRegistration[] | undefined, now: Date): RelayRegistration | undefined {
+  return registrations?.find(registration => Date.parse(registration.leaseExpiresAt) > now.getTime());
+}
+
 function snapshot(state: RelayState, version: FileVersion | undefined): RelaySnapshot {
   freeze(state);
   // Persisted validation permits duplicate registrations, routes, and outbox
   // IDs. Array callers historically use find(), so indexes deliberately retain
   // the first entry instead of introducing last-write-wins behavior.
-  const registrationBySession = firstBy(state.registrations, item => item.sessionId);
-  const registrationByEndpoint = firstBy(state.registrations, item => item.endpoint.id);
+  const registrationsBySession = groupBy(state.registrations, item => item.sessionId);
+  const registrationsByEndpoint = groupBy(state.registrations, item => item.endpoint.id);
   const peerOriginByRoute = new Map([...firstBy(state.peerRoutes, item => item.id)].map(([id, route]) => [id, route.origin]));
   const envelopeById = new Map(state.envelopes.map(item => [item.envelope.envelopeId, item]));
   const mailboxByEndpoint = new Map<string, StoredMailboxItem[]>();
@@ -368,12 +387,13 @@ function snapshot(state: RelayState, version: FileVersion | undefined): RelaySna
   return {
     state,
     version,
-    registrationBySession,
-    registrationByEndpoint,
+    registrationsBySession,
+    registrationsByEndpoint,
     peerOriginByRoute,
     envelopeById,
     mailboxByEndpoint,
     outboxByEnvelopeId: firstBy(state.outbox, item => item.envelope.envelopeId),
+    pendingOutbox: state.outbox.filter(item => item.forwardedAt === undefined && item.exhaustedAt === undefined),
     pendingOutboxCount: state.outbox.filter(item => item.forwardedAt === undefined && item.exhaustedAt === undefined).length,
   };
 }
@@ -410,31 +430,30 @@ export class TaskRelayStore {
       const registration = existing
         ? { ...existing, protocolVersions: ownedInput.protocolVersions, leaseExpiresAt: ownedInput.leaseExpiresAt }
         : ownedInput;
-      if (existing && canonicalJson(existing) === canonicalJson(registration)) return { state, value: existing };
+      if (existing && canonicalJson(existing) === canonicalJson(registration)
+        && state.registrations.filter(item => item.sessionId === ownedInput.sessionId).length === 1) return { state, value: existing };
       return { state: { ...state, registrations: [...state.registrations.filter((item) => item.sessionId !== ownedInput.sessionId), registration] }, value: registration };
     });
     // Return the owned, persisted snapshot rather than an input alias.
-    return this.#read().registrationBySession.get(registered.sessionId) ?? immutableCopy(registered);
+    return this.#read().registrationsBySession.get(registered.sessionId)?.[0] ?? immutableCopy(registered);
   }
 
   async registrationForSession(sessionId: string, now: Date): Promise<RelayRegistration | undefined> {
-    const registration = this.#read().registrationBySession.get(sessionId);
-    return registration && Date.parse(registration.leaseExpiresAt) > now.getTime() ? registration : undefined;
+    return activeRegistration(this.#read().registrationsBySession.get(sessionId), now);
   }
 
   async registrationsForSessions(sessionIds: readonly string[], now: Date): Promise<ReadonlyMap<string, RelayRegistration>> {
     const registrations = new Map<string, RelayRegistration>();
     const snapshot = this.#read();
     for (const sessionId of sessionIds) {
-      const registration = snapshot.registrationBySession.get(sessionId);
-      if (registration && Date.parse(registration.leaseExpiresAt) > now.getTime()) registrations.set(sessionId, registration);
+      const registration = activeRegistration(snapshot.registrationsBySession.get(sessionId), now);
+      if (registration) registrations.set(sessionId, registration);
     }
     return registrations;
   }
 
   async registration(endpointId: string, now: Date): Promise<RelayRegistration | undefined> {
-    const registration = this.#read().registrationByEndpoint.get(endpointId);
-    return registration && Date.parse(registration.leaseExpiresAt) > now.getTime() ? registration : undefined;
+    return activeRegistration(this.#read().registrationsByEndpoint.get(endpointId), now);
   }
 
   async deactivateRegistration(sessionId: string, endpointId: string, leaseExpiresAt: string): Promise<boolean> {
@@ -545,6 +564,10 @@ export class TaskRelayStore {
     return this.#read().outboxByEnvelopeId.get(envelopeId);
   }
 
+  async pendingOutbox(): Promise<readonly PeerOutboxItem[]> {
+    return this.#read().pendingOutbox;
+  }
+
   async pendingOutboxCount(): Promise<number> {
     return this.#read().pendingOutboxCount;
   }
@@ -615,41 +638,61 @@ export class TaskRelayStore {
     });
   }
 
-  #read(): RelaySnapshot {
+  #read(resetAttempted = false): RelaySnapshot {
     const currentVersion = fileVersion(this.path);
     if (this.#snapshot && sameFileVersion(this.#snapshot.version, currentVersion)) return this.#snapshot;
     if (currentVersion === undefined) return this.#snapshot = snapshot(EMPTY, undefined);
 
-    // Read a stable file identity. An external atomic replacement between stat
-    // and read is retried rather than publishing a snapshot for the old file.
+    // Bind source bytes to one descriptor identity, then verify the path still
+    // names that descriptor. Atomic replacements during either read phase retry.
     for (let attempts = 0; attempts < 3; attempts += 1) {
-      const before = fileVersion(this.path);
-      if (before === undefined) return this.#snapshot = snapshot(EMPTY, undefined);
-      let source: string;
+      let descriptor: number;
       try {
-        source = readFileSync(this.path, "utf8");
+        descriptor = openSync(this.path, "r");
       } catch (cause: unknown) {
         if ((cause as NodeJS.ErrnoException).code === "ENOENT") continue;
         throw cause;
       }
-      const after = fileVersion(this.path);
-      if (!sameFileVersion(before, after)) continue;
+      let source: string;
+      let descriptorVersion: FileVersion;
+      try {
+        const before = versionFromStat(fstatSync(descriptor, { bigint: true }));
+        source = readFileSync(descriptor, "utf8");
+        const after = versionFromStat(fstatSync(descriptor, { bigint: true }));
+        if (!sameFileVersion(before, after)) continue;
+        descriptorVersion = after;
+      } finally {
+        closeSync(descriptor);
+      }
+      if (!sameFileVersion(descriptorVersion!, fileVersion(this.path))) continue;
       let parsed: unknown;
       try {
-        parsed = JSON.parse(source);
+        parsed = JSON.parse(source!);
       } catch (cause) {
         throw new MalformedRelayStoreError(cause);
       }
       const state = parsePersistedRelayState(parsed);
       if (!state) throw new MalformedRelayStoreError();
-      if (state === "reset") return this.#write(EMPTY);
-      return this.#snapshot = snapshot(state, after);
+      if (state === "reset") {
+        if (resetAttempted) throw new MalformedRelayStoreError(new Error("relay store changed during v1 reset"));
+        return this.#write(EMPTY, true);
+      }
+      return this.#snapshot = snapshot(state, descriptorVersion!);
     }
     throw new MalformedRelayStoreError(new Error("relay store changed while loading"));
   }
 
-  #write(state: RelayState): RelaySnapshot {
+  #write(state: RelayState, resetAttempted = false): RelaySnapshot {
     const source = canonicalJson(state);
+    // Reject malformed updater output before it can cross the rename boundary.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(source);
+    } catch (cause) {
+      throw new MalformedRelayStoreError(cause);
+    }
+    const prepared = parsePersistedRelayState(parsed);
+    if (!prepared || prepared === "reset") throw new MalformedRelayStoreError();
     try {
       atomicWrite(this.path, source);
     } catch (cause) {
@@ -659,10 +702,9 @@ export class TaskRelayStore {
       throw cause;
     }
     // Do not pair our serialized bytes with a later path stat: another atomic
-    // replacement could win after rename. Reload through #read's stable
-    // before/read/after identity check so cache authority always matches bytes.
+    // replacement could win after rename. Reload through descriptor-bound read.
     this.#snapshot = undefined;
-    return this.#read();
+    return this.#read(resetAttempted);
   }
 
   async #mutate<T>(operation: (state: RelayState) => { readonly state: RelayState; readonly value: T }): Promise<T> {

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { closeSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { canonicalJson } from "../canonical-json.ts";
@@ -83,6 +83,32 @@ const PEER_RELAY_PREFIX = `${RELAY_ID}:peer:`;
 const locks = new Map<string, Promise<void>>();
 const DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 const DECIMAL_CURSOR_PATTERN = /^[1-9][0-9]*$/;
+
+/**
+ * A store instance observes external writers only when they atomically replace or
+ * remove/recreate relay-state.json. Same-process writers are serialized below.
+ * Direct in-place edits are unsupported: they can defeat file identity checks
+ * and were never a safe concurrent mutation protocol for this JSON store.
+ */
+interface FileVersion {
+  readonly dev: number;
+  readonly ino: number;
+  readonly size: number;
+  readonly mtimeMs: number;
+  readonly ctimeMs: number;
+}
+
+interface RelaySnapshot {
+  readonly state: RelayState;
+  readonly version: FileVersion | undefined;
+  readonly registrationBySession: ReadonlyMap<string, RelayRegistration>;
+  readonly registrationByEndpoint: ReadonlyMap<string, RelayRegistration>;
+  readonly peerOriginByRoute: ReadonlyMap<string, string>;
+  readonly envelopeById: ReadonlyMap<string, StoredEnvelope>;
+  readonly mailboxByEndpoint: ReadonlyMap<string, readonly StoredMailboxItem[]>;
+  readonly outboxByEnvelopeId: ReadonlyMap<string, PeerOutboxItem>;
+  readonly pendingOutboxCount: number;
+}
 
 function digestJson(value: string): string {
   return createHash("sha256").update(value, "utf8").digest("hex");
@@ -268,12 +294,12 @@ export class MalformedRelayStoreError extends TypeError {
   }
 }
 
-function atomicWrite(path: string, state: RelayState): void {
+function atomicWrite(path: string, source: string): void {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const temporary = `${path}.${randomUUID()}.tmp`;
   const descriptor = openSync(temporary, "w", 0o600);
   try {
-    writeFileSync(descriptor, canonicalJson(state), "utf8");
+    writeFileSync(descriptor, source, "utf8");
     fsyncSync(descriptor);
   } finally {
     closeSync(descriptor);
@@ -281,6 +307,54 @@ function atomicWrite(path: string, state: RelayState): void {
   renameSync(temporary, path);
   const directory = openSync(dirname(path), "r");
   try { fsyncSync(directory); } finally { closeSync(directory); }
+}
+
+function fileVersion(path: string): FileVersion | undefined {
+  try {
+    const stat = statSync(path);
+    return { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeMs: stat.mtimeMs, ctimeMs: stat.ctimeMs };
+  } catch (cause: unknown) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw cause;
+  }
+}
+
+function sameFileVersion(left: FileVersion | undefined, right: FileVersion | undefined): boolean {
+  if (left === undefined || right === undefined) return left === right;
+  return left.dev === right.dev && left.ino === right.ino && left.size === right.size
+    && left.mtimeMs === right.mtimeMs && left.ctimeMs === right.ctimeMs;
+}
+
+function freeze(value: unknown): void {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return;
+  for (const item of Object.values(value)) freeze(item);
+  Object.freeze(value);
+}
+
+function snapshot(state: RelayState, version: FileVersion | undefined): RelaySnapshot {
+  freeze(state);
+  const registrationBySession = new Map(state.registrations.map(item => [item.sessionId, item]));
+  const registrationByEndpoint = new Map(state.registrations.map(item => [item.endpoint.id, item]));
+  const peerOriginByRoute = new Map(state.peerRoutes.map(item => [item.id, item.origin]));
+  const envelopeById = new Map(state.envelopes.map(item => [item.envelope.envelopeId, item]));
+  const mailboxByEndpoint = new Map<string, StoredMailboxItem[]>();
+  for (const item of state.mailbox) {
+    const mailbox = mailboxByEndpoint.get(item.endpointId) ?? [];
+    mailbox.push(item);
+    mailboxByEndpoint.set(item.endpointId, mailbox);
+  }
+  for (const mailbox of mailboxByEndpoint.values()) mailbox.sort((left, right) => BigInt(left.cursor) < BigInt(right.cursor) ? -1 : 1);
+  return {
+    state,
+    version,
+    registrationBySession,
+    registrationByEndpoint,
+    peerOriginByRoute,
+    envelopeById,
+    mailboxByEndpoint,
+    outboxByEnvelopeId: new Map(state.outbox.map(item => [item.envelope.envelopeId, item])),
+    pendingOutboxCount: state.outbox.filter(item => item.forwardedAt === undefined && item.exhaustedAt === undefined).length,
+  };
 }
 
 async function serialized<T>(path: string, operation: () => Promise<T>): Promise<T> {
@@ -299,6 +373,7 @@ async function serialized<T>(path: string, operation: () => Promise<T>): Promise
 export class TaskRelayStore {
   readonly root: string;
   readonly path: string;
+  #snapshot: RelaySnapshot | undefined;
 
   constructor(root: string | undefined = undefined) {
     this.root = resolve(root ?? join(homedir(), ".wolfpack", "pi-tasks-relay-v2"));
@@ -311,23 +386,36 @@ export class TaskRelayStore {
       const registration = existing
         ? { ...existing, protocolVersions: input.protocolVersions, leaseExpiresAt: input.leaseExpiresAt }
         : input;
+      if (existing && canonicalJson(existing) === canonicalJson(registration)) return { state, value: existing };
       return { state: { ...state, registrations: [...state.registrations.filter((item) => item.sessionId !== input.sessionId), registration] }, value: registration };
     });
   }
 
   async registrationForSession(sessionId: string, now: Date): Promise<RelayRegistration | undefined> {
-    return this.#read().registrations.find((item) => item.sessionId === sessionId && Date.parse(item.leaseExpiresAt) > now.getTime());
+    const registration = this.#read().registrationBySession.get(sessionId);
+    return registration && Date.parse(registration.leaseExpiresAt) > now.getTime() ? registration : undefined;
+  }
+
+  async registrationsForSessions(sessionIds: readonly string[], now: Date): Promise<ReadonlyMap<string, RelayRegistration>> {
+    const registrations = new Map<string, RelayRegistration>();
+    const snapshot = this.#read();
+    for (const sessionId of sessionIds) {
+      const registration = snapshot.registrationBySession.get(sessionId);
+      if (registration && Date.parse(registration.leaseExpiresAt) > now.getTime()) registrations.set(sessionId, registration);
+    }
+    return registrations;
   }
 
   async registration(endpointId: string, now: Date): Promise<RelayRegistration | undefined> {
-    return this.#read().registrations.find((item) => item.endpoint.id === endpointId && Date.parse(item.leaseExpiresAt) > now.getTime());
+    const registration = this.#read().registrationByEndpoint.get(endpointId);
+    return registration && Date.parse(registration.leaseExpiresAt) > now.getTime() ? registration : undefined;
   }
 
   async deactivateRegistration(sessionId: string, endpointId: string, leaseExpiresAt: string): Promise<boolean> {
     return this.#mutate((state) => {
       const registration = state.registrations.find((item) => item.sessionId === sessionId && item.endpoint.id === endpointId);
       return {
-        state: registration
+        state: registration && registration.leaseExpiresAt !== leaseExpiresAt
           ? { ...state, registrations: state.registrations.map((item) => item === registration ? { ...item, leaseExpiresAt } : item) }
           : state,
         value: registration !== undefined,
@@ -358,30 +446,22 @@ export class TaskRelayStore {
   }
 
   async inbox(endpointId: string, cursor: string): Promise<RelayInboxPage> {
-    const state = this.#read();
-    const selectedMailbox: StoredMailboxItem[] = [];
-    let matchingItems = 0;
-    for (const item of state.mailbox) {
-      if (item.endpointId !== endpointId || BigInt(item.cursor) <= BigInt(cursor)) continue;
-      matchingItems += 1;
-      const insertionIndex = selectedMailbox.findIndex(candidate => BigInt(item.cursor) < BigInt(candidate.cursor));
-      if (insertionIndex === -1) selectedMailbox.push(item);
-      else selectedMailbox.splice(insertionIndex, 0, item);
-      if (selectedMailbox.length > RELAY_LIMITS.INBOX_PAGE_ITEMS) selectedMailbox.pop();
+    const snapshot = this.#read();
+    const mailbox = snapshot.mailboxByEndpoint.get(endpointId) ?? [];
+    const requestedCursor = BigInt(cursor);
+    let first = 0;
+    let last = mailbox.length;
+    while (first < last) {
+      const middle = first + Math.floor((last - first) / 2);
+      if (BigInt(mailbox[middle]!.cursor) <= requestedCursor) first = middle + 1;
+      else last = middle;
     }
-
-    const selectedEnvelopeIds = new Set(selectedMailbox.map(item => item.envelopeId));
-    const envelopes = new Map<string, RelayEnvelope>();
-    for (const item of state.envelopes) {
-      if (selectedEnvelopeIds.has(item.envelope.envelopeId)) {
-        envelopes.set(item.envelope.envelopeId, item.envelope);
-      }
-    }
-
+    const matchingItems = mailbox.length - first;
+    const selectedMailbox = mailbox.slice(first, first + RELAY_LIMITS.INBOX_PAGE_ITEMS);
     const items: RelayInboxItem[] = [];
     let bytes = 0;
     for (const item of selectedMailbox) {
-      const envelope = envelopes.get(item.envelopeId);
+      const envelope = snapshot.envelopeById.get(item.envelopeId)?.envelope;
       if (envelope === undefined) continue;
       const itemBytes = encodedJsonBytes(envelope);
       if (bytes + itemBytes > RELAY_LIMITS.INBOX_PAGE_BYTES) break;
@@ -410,7 +490,7 @@ export class TaskRelayStore {
   }
 
   async peerOrigin(routeId: string): Promise<string | undefined> {
-    return this.#read().peerRoutes.find((item) => item.id === routeId)?.origin;
+    return this.#read().peerOriginByRoute.get(routeId);
   }
 
   async queuePeer(input: Omit<PeerOutboxItem, "digest" | "acceptanceId">): Promise<{ readonly kind: "accepted" | "duplicate" | "conflict"; readonly acceptanceId: string }> {
@@ -430,11 +510,28 @@ export class TaskRelayStore {
   }
 
   async outbox(): Promise<readonly PeerOutboxItem[]> {
-    return this.#read().outbox;
+    return this.#read().state.outbox;
+  }
+
+  async outboxItem(envelopeId: string): Promise<PeerOutboxItem | undefined> {
+    return this.#read().outboxByEnvelopeId.get(envelopeId);
+  }
+
+  async pendingOutboxCount(): Promise<number> {
+    return this.#read().pendingOutboxCount;
   }
 
   async updateOutbox(envelopeId: string, update: (item: PeerOutboxItem) => PeerOutboxItem): Promise<void> {
-    await this.#mutate((state) => ({ state: { ...state, outbox: state.outbox.map((item) => item.envelope.envelopeId === envelopeId ? update(item) : item) }, value: undefined }));
+    await this.#mutate((state) => {
+      const index = state.outbox.findIndex(item => item.envelope.envelopeId === envelopeId);
+      if (index === -1) return { state, value: undefined };
+      const previous = state.outbox[index]!;
+      const next = update(previous);
+      if (next === previous || canonicalJson(next) === canonicalJson(previous)) return { state, value: undefined };
+      const outbox = [...state.outbox];
+      outbox[index] = next;
+      return { state: { ...state, outbox }, value: undefined };
+    });
   }
 
   async cleanup(before: Date): Promise<number> {
@@ -469,8 +566,12 @@ export class TaskRelayStore {
         ...retainedMailbox.map(item => item.endpointId),
       ]);
       const retainedMailboxCursors = state.mailboxCursors.filter(item => retainedCursorEndpoints.has(item.endpointId));
+      const removed = state.registrations.length - retainedRegistrations.length
+        + state.mailbox.length - retainedMailbox.length
+        + state.outbox.length - retainedOutbox.length;
+      const changed = removed !== 0 || state.mailboxCursors.length !== retainedMailboxCursors.length;
       return {
-        state: {
+        state: !changed ? state : {
           ...state,
           registrations: retainedRegistrations,
           mailbox: retainedMailbox,
@@ -478,35 +579,64 @@ export class TaskRelayStore {
           envelopes: retainedEnvelopes,
           outbox: retainedOutbox,
         },
-        value: state.registrations.length - retainedRegistrations.length
-          + state.mailbox.length - retainedMailbox.length
-          + state.outbox.length - retainedOutbox.length,
+        value: removed,
       };
     });
   }
 
-  #read(): RelayState {
-    if (!existsSync(this.path)) return EMPTY;
-    const source = readFileSync(this.path, "utf8");
+  #read(): RelaySnapshot {
+    const currentVersion = fileVersion(this.path);
+    if (this.#snapshot && sameFileVersion(this.#snapshot.version, currentVersion)) return this.#snapshot;
+    if (currentVersion === undefined) return this.#snapshot = snapshot(EMPTY, undefined);
+
+    // Read a stable file identity. An external atomic replacement between stat
+    // and read is retried rather than publishing a snapshot for the old file.
+    for (let attempts = 0; attempts < 3; attempts += 1) {
+      const before = fileVersion(this.path);
+      if (before === undefined) return this.#snapshot = snapshot(EMPTY, undefined);
+      let source: string;
+      try {
+        source = readFileSync(this.path, "utf8");
+      } catch (cause: unknown) {
+        if ((cause as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw cause;
+      }
+      const after = fileVersion(this.path);
+      if (!sameFileVersion(before, after)) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(source);
+      } catch (cause) {
+        throw new MalformedRelayStoreError(cause);
+      }
+      const state = parsePersistedRelayState(parsed);
+      if (!state) throw new MalformedRelayStoreError();
+      if (state === "reset") return this.#write(EMPTY);
+      return this.#snapshot = snapshot(state, after);
+    }
+    throw new MalformedRelayStoreError(new Error("relay store changed while loading"));
+  }
+
+  #write(state: RelayState): RelaySnapshot {
+    const source = canonicalJson(state);
+    atomicWrite(this.path, source);
     let parsed: unknown;
     try {
       parsed = JSON.parse(source);
     } catch (cause) {
       throw new MalformedRelayStoreError(cause);
     }
-    const state = parsePersistedRelayState(parsed);
-    if (!state) throw new MalformedRelayStoreError();
-    if (state === "reset") {
-      atomicWrite(this.path, EMPTY);
-      return EMPTY;
-    }
-    return state;
+    const persisted = parsePersistedRelayState(parsed);
+    if (!persisted || persisted === "reset") throw new MalformedRelayStoreError();
+    const version = fileVersion(this.path);
+    return this.#snapshot = snapshot(version === undefined ? EMPTY : persisted, version);
   }
 
   async #mutate<T>(operation: (state: RelayState) => { readonly state: RelayState; readonly value: T }): Promise<T> {
     return serialized(this.path, async () => {
-      const { state, value } = operation(this.#read());
-      atomicWrite(this.path, state);
+      const previous = this.#read();
+      const { state, value } = operation(previous.state);
+      if (state !== previous.state) this.#write(state);
       return value;
     });
   }

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -92,11 +92,11 @@ const DECIMAL_CURSOR_PATTERN = /^[1-9][0-9]*$/;
  * they can defeat file identity checks and were never a safe mutation protocol.
  */
 interface FileVersion {
-  readonly dev: number;
-  readonly ino: number;
-  readonly size: number;
-  readonly mtimeMs: number;
-  readonly ctimeMs: number;
+  readonly dev: bigint;
+  readonly ino: bigint;
+  readonly size: bigint;
+  readonly mtimeNs: bigint;
+  readonly ctimeNs: bigint;
 }
 
 interface RelaySnapshot {
@@ -312,8 +312,8 @@ function atomicWrite(path: string, source: string): void {
 
 function fileVersion(path: string): FileVersion | undefined {
   try {
-    const stat = statSync(path);
-    return { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeMs: stat.mtimeMs, ctimeMs: stat.ctimeMs };
+    const stat = statSync(path, { bigint: true });
+    return { dev: stat.dev, ino: stat.ino, size: stat.size, mtimeNs: stat.mtimeNs, ctimeNs: stat.ctimeNs };
   } catch (cause: unknown) {
     if ((cause as NodeJS.ErrnoException).code === "ENOENT") return undefined;
     throw cause;
@@ -323,7 +323,7 @@ function fileVersion(path: string): FileVersion | undefined {
 function sameFileVersion(left: FileVersion | undefined, right: FileVersion | undefined): boolean {
   if (left === undefined || right === undefined) return left === right;
   return left.dev === right.dev && left.ino === right.ino && left.size === right.size
-    && left.mtimeMs === right.mtimeMs && left.ctimeMs === right.ctimeMs;
+    && left.mtimeNs === right.mtimeNs && left.ctimeNs === right.ctimeNs;
 }
 
 function freeze(value: unknown): void {
@@ -400,13 +400,16 @@ export class TaskRelayStore {
   }
 
   async register(input: Omit<RelayRegistration, "endpoint" | "leaseExpiresAt"> & { readonly endpoint: RelayEndpoint; readonly leaseExpiresAt: string }): Promise<RelayRegistration> {
+    // Copy before #mutate yields on the per-path queue: callers may mutate the
+    // object immediately after receiving this Promise.
+    const ownedInput = immutableCopy(input);
     const registered = await this.#mutate((state) => {
-      const existing = state.registrations.find((item) => item.sessionId === input.sessionId && item.generation === input.generation);
+      const existing = state.registrations.find((item) => item.sessionId === ownedInput.sessionId && item.generation === ownedInput.generation);
       const registration = existing
-        ? { ...existing, protocolVersions: input.protocolVersions, leaseExpiresAt: input.leaseExpiresAt }
-        : input;
+        ? { ...existing, protocolVersions: ownedInput.protocolVersions, leaseExpiresAt: ownedInput.leaseExpiresAt }
+        : ownedInput;
       if (existing && canonicalJson(existing) === canonicalJson(registration)) return { state, value: existing };
-      return { state: { ...state, registrations: [...state.registrations.filter((item) => item.sessionId !== input.sessionId), registration] }, value: registration };
+      return { state: { ...state, registrations: [...state.registrations.filter((item) => item.sessionId !== ownedInput.sessionId), registration] }, value: registration };
     });
     // Return the owned, persisted snapshot rather than an input alias.
     return this.#read().registrationBySession.get(registered.sessionId) ?? immutableCopy(registered);
@@ -445,21 +448,22 @@ export class TaskRelayStore {
   }
 
   async accept(envelope: RelayEnvelope, acceptedAt: string): Promise<{ readonly kind: "accepted" | "duplicate" | "conflict"; readonly acceptanceId: string }> {
+    const ownedEnvelope = immutableCopy(envelope);
     return this.#mutate<{ readonly kind: "accepted" | "duplicate" | "conflict"; readonly acceptanceId: string }>((state) => {
-      const existing = state.envelopes.find((item) => item.envelope.envelopeId === envelope.envelopeId);
-      const nextDigest = digest(envelope);
+      const existing = state.envelopes.find((item) => item.envelope.envelopeId === ownedEnvelope.envelopeId);
+      const nextDigest = digest(ownedEnvelope);
       if (existing) return { state, value: { kind: existing.digest === nextDigest ? "duplicate" as const : "conflict" as const, acceptanceId: existing.acceptanceId } };
-      const stored: StoredEnvelope = { envelope, digest: nextDigest, acceptedAt, acceptanceId: randomUUID() };
-      const previousCursor = state.mailboxCursors.find(item => item.endpointId === envelope.target.id)?.cursor ?? "0";
+      const stored: StoredEnvelope = { envelope: ownedEnvelope, digest: nextDigest, acceptedAt, acceptanceId: randomUUID() };
+      const previousCursor = state.mailboxCursors.find(item => item.endpointId === ownedEnvelope.target.id)?.cursor ?? "0";
       const cursor = (BigInt(previousCursor) + 1n).toString();
-      const mailbox: StoredMailboxItem = { endpointId: envelope.target.id, envelopeId: envelope.envelopeId, cursor, acknowledgedAt: undefined };
-      const mailboxCursor = { endpointId: envelope.target.id, cursor };
+      const mailbox: StoredMailboxItem = { endpointId: ownedEnvelope.target.id, envelopeId: ownedEnvelope.envelopeId, cursor, acknowledgedAt: undefined };
+      const mailboxCursor = { endpointId: ownedEnvelope.target.id, cursor };
       return {
         state: {
           ...state,
           envelopes: [...state.envelopes, stored],
           mailbox: [...state.mailbox, mailbox],
-          mailboxCursors: [...state.mailboxCursors.filter(item => item.endpointId !== envelope.target.id), mailboxCursor],
+          mailboxCursors: [...state.mailboxCursors.filter(item => item.endpointId !== ownedEnvelope.target.id), mailboxCursor],
         },
         value: { kind: "accepted" as const, acceptanceId: stored.acceptanceId },
       };
@@ -515,9 +519,10 @@ export class TaskRelayStore {
   }
 
   async queuePeer(input: Omit<PeerOutboxItem, "digest" | "acceptanceId">): Promise<{ readonly kind: "accepted" | "duplicate" | "conflict"; readonly acceptanceId: string }> {
+    const ownedInput = immutableCopy(input);
     return this.#mutate<{ readonly kind: "accepted" | "duplicate" | "conflict"; readonly acceptanceId: string }>((state) => {
-      const existing = state.outbox.find((item) => item.envelope.envelopeId === input.envelope.envelopeId);
-      const nextDigest = digest(input.envelope);
+      const existing = state.outbox.find((item) => item.envelope.envelopeId === ownedInput.envelope.envelopeId);
+      const nextDigest = digest(ownedInput.envelope);
       if (existing) return {
         state,
         value: {
@@ -525,7 +530,7 @@ export class TaskRelayStore {
           acceptanceId: existing.acceptanceId,
         },
       };
-      const item: PeerOutboxItem = { ...input, digest: nextDigest, acceptanceId: randomUUID() };
+      const item: PeerOutboxItem = { ...ownedInput, digest: nextDigest, acceptanceId: randomUUID() };
       return { state: { ...state, outbox: [...state.outbox, item] }, value: { kind: "accepted" as const, acceptanceId: item.acceptanceId } };
     });
   }
@@ -547,8 +552,10 @@ export class TaskRelayStore {
       let changed = false;
       const outbox = state.outbox.map((item) => {
         if (item.envelope.envelopeId !== envelopeId) return item;
-        const next = update(item);
-        if (next === item || canonicalJson(next) === canonicalJson(item)) return item;
+        // Callers receive a detached immutable item, and their result is copied
+        // before this synchronous mutation operation can yield to persistence.
+        const next = immutableCopy(update(immutableCopy(item)));
+        if (canonicalJson(next) === canonicalJson(item)) return item;
         changed = true;
         return next;
       });

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -298,6 +298,14 @@ export class MalformedRelayStoreError extends TypeError {
   }
 }
 
+/** A concurrent atomic replacement displaced the state this mutation persisted. */
+export class RelayStoreConflictError extends Error {
+  constructor() {
+    super("relay store changed after mutation persistence");
+    this.name = "RelayStoreConflictError";
+  }
+}
+
 function atomicWrite(path: string, source: string): void {
   mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
   const temporary = `${path}.${randomUUID()}.tmp`;
@@ -384,6 +392,7 @@ function snapshot(state: RelayState, version: FileVersion | undefined): RelaySna
     mailboxByEndpoint.set(item.endpointId, mailbox);
   }
   for (const mailbox of mailboxByEndpoint.values()) mailbox.sort((left, right) => BigInt(left.cursor) < BigInt(right.cursor) ? -1 : 1);
+  const pendingOutbox = Object.freeze(state.outbox.filter(item => item.forwardedAt === undefined && item.exhaustedAt === undefined));
   return {
     state,
     version,
@@ -393,8 +402,8 @@ function snapshot(state: RelayState, version: FileVersion | undefined): RelaySna
     envelopeById,
     mailboxByEndpoint,
     outboxByEnvelopeId: firstBy(state.outbox, item => item.envelope.envelopeId),
-    pendingOutbox: state.outbox.filter(item => item.forwardedAt === undefined && item.exhaustedAt === undefined),
-    pendingOutboxCount: state.outbox.filter(item => item.forwardedAt === undefined && item.exhaustedAt === undefined).length,
+    pendingOutbox,
+    pendingOutboxCount: pendingOutbox.length,
   };
 }
 
@@ -434,8 +443,10 @@ export class TaskRelayStore {
         && state.registrations.filter(item => item.sessionId === ownedInput.sessionId).length === 1) return { state, value: existing };
       return { state: { ...state, registrations: [...state.registrations.filter((item) => item.sessionId !== ownedInput.sessionId), registration] }, value: registration };
     });
-    // Return the owned, persisted snapshot rather than an input alias.
-    return this.#read().registrationsBySession.get(registered.sessionId)?.[0] ?? immutableCopy(registered);
+    // #mutate has verified this value's candidate state against the descriptor-
+    // reloaded authority. Do not reread here: a later independent mutation may
+    // legitimately supersede this completed registration.
+    return immutableCopy(registered);
   }
 
   async registrationForSession(sessionId: string, now: Date): Promise<RelayRegistration | undefined> {
@@ -711,7 +722,13 @@ export class TaskRelayStore {
     return serialized(this.path, async () => {
       const previous = this.#read();
       const { state, value } = operation(previous.state);
-      if (state !== previous.state) this.#write(state);
+      if (state !== previous.state) {
+        const authoritative = this.#write(state);
+        // The post-write descriptor reload may have observed another atomic
+        // replacement. Never report identities/results calculated from our
+        // displaced candidate as durable authority.
+        if (canonicalJson(authoritative.state) !== canonicalJson(state)) throw new RelayStoreConflictError();
+      }
       return value;
     });
   }

--- a/tests/integration/task-relay.test.ts
+++ b/tests/integration/task-relay.test.ts
@@ -126,6 +126,11 @@ describe("task relay v2 routes", () => {
 
     const sessionProjection = await fetch(`${base}/api/session-control/status?session=receiver`);
     expect(await sessionProjection.json()).toMatchObject({ taskEndpoint: receiver.endpoint });
+    const sessionList = await fetch(`${base}/api/session-control/list`);
+    expect(await sessionList.json()).toMatchObject({ sessions: [
+      expect.objectContaining({ sessionId: "receiver-id", taskEndpoint: receiver.endpoint }),
+      expect.objectContaining({ sessionId: "sender-id", taskEndpoint: sender.endpoint }),
+    ] });
     const accepted = await post("/api/task-relay/v2/send", {
       callerSession: "sender",
       envelope: {

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -1005,6 +1005,68 @@ describe("pi tasks relay v2", () => {
     }
   });
 
+  test("keeps first-match indexes and update-all semantics for accepted duplicate persisted IDs", async () => {
+    const directory = root();
+    const path = join(directory, "relay-state.json");
+    const secondOrigin = "https://other.example.ts.net";
+    try {
+      writeFileSync(path, JSON.stringify({
+        ...VALID_RELAY_STATE,
+        registrations: [
+          VALID_REGISTRATION,
+          { ...VALID_REGISTRATION, endpoint: { relay: RELAY_ID, id: RECEIVER_ID } },
+        ],
+        peerRoutes: [VALID_PEER_ROUTE, { ...VALID_PEER_ROUTE, origin: secondOrigin }],
+        outbox: [
+          { ...VALID_OUTBOX_ITEM, peerOrigin: secondOrigin },
+          { ...VALID_OUTBOX_ITEM, peerOrigin: secondOrigin, attempts: 2 },
+        ],
+      }));
+      const store = new TaskRelayStore(directory);
+      await expect(store.registrationForSession("sender", NOW)).resolves.toMatchObject({ endpoint: { id: SENDER_ID } });
+      await expect(store.peerOrigin(ROUTE_ID)).resolves.toBe(PEER_ORIGIN);
+      await expect(store.outboxItem(REMOTE_ENVELOPE.envelopeId)).resolves.toMatchObject({ attempts: 1 });
+      await store.updateOutbox(REMOTE_ENVELOPE.envelopeId, item => ({ ...item, attempts: item.attempts + 1 }));
+      await expect(store.outbox()).resolves.toEqual([
+        expect.objectContaining({ attempts: 2 }),
+        expect.objectContaining({ attempts: 3 }),
+      ]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("revalidates an external replacement that wins a v1 reset race", async () => {
+    const directory = root();
+    const path = join(directory, "relay-state.json");
+    const replacement = `${path}.replacement`;
+    try {
+      writeFileSync(path, JSON.stringify({ version: 1, discarded: true }));
+      writeFileSync(replacement, JSON.stringify({
+        version: 2,
+        registrations: [VALID_REGISTRATION],
+        envelopes: [],
+        mailbox: [],
+        mailboxCursors: [],
+        peerRoutes: [],
+        outbox: [],
+      }));
+      let fsyncCalls = 0;
+      const fsyncSpy = jest.spyOn(fs, "fsyncSync").mockImplementation((_descriptor: number) => {
+        fsyncCalls += 1;
+        if (fsyncCalls === 2) renameSync(replacement, path);
+      });
+      try {
+        await expect(new TaskRelayStore(directory).outbox()).resolves.toEqual([]);
+      } finally {
+        fsyncSpy.mockRestore();
+      }
+      await expect(new TaskRelayStore(directory).registrationForSession("sender", NOW)).resolves.toMatchObject(VALID_REGISTRATION);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("rejects representative malformed persisted relay records on reads and mutations", async () => {
     const malformedStates = [
       { label: "invalid JSON", contents: "{" },

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -856,6 +856,85 @@ describe("pi tasks relay v2", () => {
     }
   });
 
+  test("owns cached values rather than retaining caller aliases and exposes immutable read boundaries", async () => {
+    const directory = root();
+    try {
+      const store = new TaskRelayStore(directory);
+      const registrationInput = {
+        ...VALID_REGISTRATION,
+        endpoint: { ...VALID_REGISTRATION.endpoint },
+        protocolVersions: [...VALID_REGISTRATION.protocolVersions],
+      };
+      const returnedRegistration = await store.register(registrationInput);
+      registrationInput.endpoint.id = RECEIVER_ID;
+      registrationInput.protocolVersions.push(99);
+      registrationInput.leaseExpiresAt = "2026-08-09T00:02:00.000Z";
+
+      const acceptedEnvelope: RelayEnvelope = { ...LOCAL_ENVELOPE, envelopeId: "alias-local", payload: { opaque: "before" } };
+      await store.accept(acceptedEnvelope, NOW.toISOString());
+      (acceptedEnvelope.payload as { opaque: string }).opaque = "after";
+
+      const route = await store.peerRoute(PEER_ORIGIN);
+      const queuedEnvelope: RelayEnvelope = {
+        ...REMOTE_ENVELOPE,
+        envelopeId: "alias-peer",
+        target: { relay: route.id, id: RECEIVER_ID },
+        payload: { opaque: "before" },
+      };
+      await store.queuePeer({
+        envelope: queuedEnvelope,
+        peerOrigin: PEER_ORIGIN,
+        queuedAt: NOW.toISOString(),
+        attempts: 0,
+        lastAttemptAt: undefined,
+        forwardedAt: undefined,
+        exhaustedAt: undefined,
+        lastError: undefined,
+      });
+      (queuedEnvelope.payload as { opaque: string }).opaque = "after";
+
+      const registration = await store.registrationForSession("sender", NOW);
+      const inbox = await store.inbox(RECEIVER_ID, "0");
+      const outbox = await store.outbox();
+      expect(registration).toMatchObject({ endpoint: { id: SENDER_ID }, protocolVersions: [RELAY_PROTOCOL_VERSION], leaseExpiresAt: VALID_REGISTRATION.leaseExpiresAt });
+      expect(inbox.items).toEqual([expect.objectContaining({ envelope: expect.objectContaining({ payload: { opaque: "before" } }) })]);
+      expect(outbox).toEqual([expect.objectContaining({ envelope: expect.objectContaining({ payload: { opaque: "before" } }) })]);
+      expect(Object.isFrozen(returnedRegistration)).toBe(true);
+      expect(Object.isFrozen(registration)).toBe(true);
+      expect(Object.isFrozen(inbox.items[0]!.envelope)).toBe(true);
+      expect(Object.isFrozen(outbox)).toBe(true);
+      expect(() => { (returnedRegistration as unknown as { endpoint: { id: string } }).endpoint.id = RECEIVER_ID; }).toThrow();
+      expect(() => { (registration as unknown as { endpoint: { id: string } }).endpoint.id = RECEIVER_ID; }).toThrow();
+      expect(() => { (inbox.items[0]!.envelope.payload as { opaque: string }).opaque = "mutated"; }).toThrow();
+      expect(() => { (outbox[0]!.envelope.payload as { opaque: string }).opaque = "mutated"; }).toThrow();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("invalidates cached state when persistence fails after rename during directory fsync", async () => {
+    const directory = root();
+    try {
+      const store = new TaskRelayStore(directory);
+      await store.register(VALID_REGISTRATION);
+      let fsyncCalls = 0;
+      const fsyncSpy = jest.spyOn(fs, "fsyncSync").mockImplementation((_descriptor: number) => {
+        fsyncCalls += 1;
+        if (fsyncCalls === 2) throw new Error("directory fsync failed");
+      });
+      try {
+        await expect(store.register({ ...VALID_REGISTRATION, leaseExpiresAt: "2026-08-09T00:02:00.000Z" })).rejects.toThrow("directory fsync failed");
+      } finally {
+        fsyncSpy.mockRestore();
+      }
+      await expect(store.registrationForSession("sender", new Date("2026-08-09T00:01:30.000Z"))).resolves.toMatchObject({
+        leaseExpiresAt: "2026-08-09T00:02:00.000Z",
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("does not replace durable state for validated duplicate and empty-maintenance operations", async () => {
     const directory = root();
     try {

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -1017,6 +1017,25 @@ describe("pi tasks relay v2", () => {
     }
   });
 
+  test("releases pruned store graphs and reloads another instance on its next access", async () => {
+    const directory = root();
+    try {
+      const mutatingStore = new TaskRelayStore(directory);
+      const observingStore = new TaskRelayStore(directory);
+      await mutatingStore.accept({ ...LOCAL_ENVELOPE, envelopeId: "cleanup-reaccess", payload: { retained: true } }, NOW.toISOString());
+      const externallyRetained = await observingStore.inbox(RECEIVER_ID, "0");
+      expect(externallyRetained.items).toHaveLength(1);
+
+      await expect(mutatingStore.cleanup(new Date(NOW.getTime() + 1))).resolves.toBe(1);
+      await expect(mutatingStore.inbox(RECEIVER_ID, "0")).resolves.toEqual({ items: [], hasMore: false });
+      await expect(observingStore.inbox(RECEIVER_ID, "0")).resolves.toEqual({ items: [], hasMore: false });
+      // This is a caller-owned historical result, not a store-owned cache graph.
+      expect(externallyRetained.items[0]!.envelope.payload).toEqual({ retained: true });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("keeps first-match indexes and update-all semantics for accepted duplicate persisted IDs", async () => {
     const directory = root();
     const path = join(directory, "relay-state.json");

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { encodedJsonBytes, isJsonValue, RELAY_ERROR, RELAY_ID, RELAY_LIMITS, RELAY_PROTOCOL_VERSION } from "../../src/task-relay/domain.ts";
 import type { RelayEnvelope } from "../../src/task-relay/domain.ts";
 import { TaskRelayGateway } from "../../src/task-relay/gateway.ts";
-import { MalformedRelayStoreError, TaskRelayStore } from "../../src/task-relay/store.ts";
+import { MalformedRelayStoreError, RelayStoreConflictError, TaskRelayStore } from "../../src/task-relay/store.ts";
 import type { PeerOutboxItem } from "../../src/task-relay/store.ts";
 
 const NOW = new Date("2026-08-09T00:00:00.000Z");
@@ -550,24 +550,94 @@ describe("pi tasks relay v2", () => {
     }
   });
 
-  test("flushes zero pending outbox work without iterating retained terminal history", async () => {
+  test("uses real persisted pending indexes without terminal-history work after warmup", async () => {
     const directory = root();
-    let iterations = 0;
-    const terminalHistory = Array.from({ length: 1_000 }, (_, index) => ({ envelope: { envelopeId: `terminal-${index}` } }));
-    Object.defineProperty(terminalHistory, Symbol.iterator, {
-      value: function* () { for (let index = 0; index < terminalHistory.length; index += 1) { iterations += 1; yield terminalHistory[index]; } },
+    const path = join(directory, "relay-state.json");
+    let peerRequests = 0;
+    const terminals = Array.from({ length: 1_000 }, () => ({ ...VALID_OUTBOX_ITEM, forwardedAt: NOW.toISOString() }));
+    writeFileSync(path, JSON.stringify({ version: 2, registrations: [], envelopes: [], mailbox: [], mailboxCursors: [], peerRoutes: [VALID_PEER_ROUTE], outbox: terminals }));
+    const gateway = new TaskRelayGateway({
+      root: directory,
+      inspectSession: session("sender"),
+      now: () => NOW,
+      peerFetch: async () => { peerRequests += 1; return Response.json({ ok: true }); },
     });
-    const pendingSpy = jest.spyOn(TaskRelayStore.prototype, "pendingOutbox").mockResolvedValue([]);
-    const outboxSpy = jest.spyOn(TaskRelayStore.prototype, "outbox").mockResolvedValue(terminalHistory as never);
-    const gateway = new TaskRelayGateway({ root: directory, inspectSession: session("sender"), now: () => NOW });
     try {
+      // The first call validates and indexes the persisted fixture. The second
+      // warm call must only inspect metadata and its frozen empty projection.
       await expect(gateway.flushPeerOutbox()).resolves.toEqual({ forwarded: 0, pending: 0 });
-      expect(outboxSpy).not.toHaveBeenCalled();
-      expect(iterations).toBe(0);
+      const readSpy = jest.spyOn(fs, "readFileSync");
+      const writeSpy = jest.spyOn(fs, "writeFileSync");
+      try {
+        await expect(gateway.flushPeerOutbox()).resolves.toEqual({ forwarded: 0, pending: 0 });
+        expect(readSpy).not.toHaveBeenCalled();
+        expect(writeSpy).not.toHaveBeenCalled();
+      } finally {
+        readSpy.mockRestore();
+        writeSpy.mockRestore();
+      }
+      expect(peerRequests).toBe(0);
     } finally {
       gateway.close();
-      pendingSpy.mockRestore();
-      outboxSpy.mockRestore();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps the actual pending projection immutable and coherent through transitions and replacement", async () => {
+    const directory = root();
+    const path = join(directory, "relay-state.json");
+    try {
+      const store = new TaskRelayStore(directory);
+      const route = await store.peerRoute(PEER_ORIGIN);
+      const queue = async (envelopeId: string) => store.queuePeer({
+        envelope: { ...REMOTE_ENVELOPE, envelopeId, target: { relay: route.id, id: RECEIVER_ID } },
+        peerOrigin: PEER_ORIGIN, queuedAt: NOW.toISOString(), attempts: 0,
+        lastAttemptAt: undefined, forwardedAt: undefined, exhaustedAt: undefined, lastError: undefined,
+      });
+      await queue("pending-frozen");
+      const pending = await store.pendingOutbox();
+      expect(Object.isFrozen(pending)).toBe(true);
+      expect(() => { (pending as PeerOutboxItem[]).pop(); }).toThrow();
+      expect(await store.pendingOutboxCount()).toBe(1);
+      await store.updateOutbox("pending-frozen", item => ({ ...item, forwardedAt: NOW.toISOString() }));
+      await expect(store.pendingOutbox()).resolves.toEqual([]);
+      expect(await store.pendingOutboxCount()).toBe(0);
+      await queue("pending-exhausted");
+      await store.updateOutbox("pending-exhausted", item => ({ ...item, exhaustedAt: NOW.toISOString() }));
+      await expect(store.pendingOutbox()).resolves.toEqual([]);
+      expect(await store.pendingOutboxCount()).toBe(0);
+      await queue("pending-cleanup");
+      await expect(store.cleanup(new Date(NOW.getTime() + 1))).resolves.toBeGreaterThan(0);
+      expect(await store.pendingOutboxCount()).toBe(0);
+      writeFileSync(`${path}.replacement`, JSON.stringify({ version: 2, registrations: [], envelopes: [], mailbox: [], mailboxCursors: [], peerRoutes: [], outbox: [] }));
+      renameSync(`${path}.replacement`, path);
+      await expect(store.pendingOutbox()).resolves.toEqual([]);
+      expect(await store.pendingOutboxCount()).toBe(0);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("forwards only real persisted pending rows and retains coherent counts", async () => {
+    const directory = root();
+    const path = join(directory, "relay-state.json");
+    let peerRequests = 0;
+    const terminals = Array.from({ length: 1_000 }, () => ({ ...VALID_OUTBOX_ITEM, forwardedAt: NOW.toISOString() }));
+    const pending = { ...VALID_OUTBOX_ITEM };
+    writeFileSync(path, JSON.stringify({ version: 2, registrations: [], envelopes: [], mailbox: [], mailboxCursors: [], peerRoutes: [VALID_PEER_ROUTE], outbox: [pending, ...terminals] }));
+    const gateway = new TaskRelayGateway({
+      root: directory, inspectSession: session("sender"), now: () => NOW,
+      peerOrigin: "https://sender.example.ts.net",
+      peerFetch: async () => { peerRequests += 1; return Response.json({ ok: true }); },
+    });
+    try {
+      await expect(gateway.flushPeerOutbox(true)).resolves.toEqual({ forwarded: 1, pending: 0 });
+      expect(peerRequests).toBe(1);
+      const store = new TaskRelayStore(directory);
+      await expect(store.pendingOutbox()).resolves.toEqual([]);
+      expect(await store.pendingOutboxCount()).toBe(0);
+    } finally {
+      gateway.close();
       rmSync(directory, { recursive: true, force: true });
     }
   });
@@ -863,7 +933,7 @@ describe("pi tasks relay v2", () => {
     }
   });
 
-  test("does not publish own write bytes under an atomically replaced file identity", async () => {
+  test("does not report a displaced registration mutation as durable success", async () => {
     const directory = root();
     const path = join(directory, "relay-state.json");
     const replacement = `${path}.replacement`;
@@ -880,14 +950,74 @@ describe("pi tasks relay v2", () => {
         if (fsyncCalls === 2) renameSync(replacement, path);
       });
       try {
-        const registered = await store.register({ ...VALID_REGISTRATION, leaseExpiresAt: "2026-08-09T00:02:00.000Z" });
-        expect(registered.leaseExpiresAt).toBe("2026-08-09T00:03:00.000Z");
+        await expect(store.register({ ...VALID_REGISTRATION, leaseExpiresAt: "2026-08-09T00:02:00.000Z" })).rejects.toBeInstanceOf(RelayStoreConflictError);
       } finally {
         fsyncSpy.mockRestore();
       }
       await expect(store.registrationForSession("sender", new Date("2026-08-09T00:02:30.000Z"))).resolves.toMatchObject({
         leaseExpiresAt: "2026-08-09T00:03:00.000Z",
       });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed when an atomic replacement displaces a mutation candidate", async () => {
+    const directory = root();
+    const path = join(directory, "relay-state.json");
+    const empty = JSON.stringify({ version: 2, registrations: [], envelopes: [], mailbox: [], mailboxCursors: [], peerRoutes: [], outbox: [] });
+    try {
+      const store = new TaskRelayStore(directory);
+      const displace = async (operation: () => Promise<unknown>, replacementState = empty) => {
+        const replacement = `${path}.replacement`;
+        writeFileSync(replacement, replacementState);
+        let fsyncCalls = 0;
+        const fsyncSpy = jest.spyOn(fs, "fsyncSync").mockImplementation((_descriptor: number) => {
+          fsyncCalls += 1;
+          if (fsyncCalls === 2) renameSync(replacement, path);
+        });
+        try {
+          await expect(operation()).rejects.toBeInstanceOf(RelayStoreConflictError);
+        } finally {
+          fsyncSpy.mockRestore();
+        }
+        expect(JSON.parse(readFileSync(path, "utf8"))).toEqual(JSON.parse(replacementState));
+      };
+
+      await displace(() => store.accept({ ...LOCAL_ENVELOPE, envelopeId: "displaced-accept" }, NOW.toISOString()));
+      await expect(store.inbox(RECEIVER_ID, "0")).resolves.toEqual({ items: [], hasMore: false });
+      await displace(() => store.register(VALID_REGISTRATION));
+      await displace(() => store.peerRoute(PEER_ORIGIN));
+
+      const route = await store.peerRoute(PEER_ORIGIN);
+      await displace(() => store.queuePeer({
+        envelope: { ...REMOTE_ENVELOPE, target: { relay: route.id, id: RECEIVER_ID } },
+        peerOrigin: PEER_ORIGIN, queuedAt: NOW.toISOString(), attempts: 0,
+        lastAttemptAt: undefined, forwardedAt: undefined, exhaustedAt: undefined, lastError: undefined,
+      }));
+
+      await store.accept({ ...LOCAL_ENVELOPE, envelopeId: "displaced-ack" }, NOW.toISOString());
+      await displace(() => store.acknowledge(RECEIVER_ID, "displaced-ack", NOW.toISOString()));
+
+      const updateRoute = await store.peerRoute(PEER_ORIGIN);
+      await store.queuePeer({
+        envelope: { ...REMOTE_ENVELOPE, target: { relay: updateRoute.id, id: RECEIVER_ID } },
+        peerOrigin: PEER_ORIGIN, queuedAt: NOW.toISOString(), attempts: 0,
+        lastAttemptAt: undefined, forwardedAt: undefined, exhaustedAt: undefined, lastError: undefined,
+      });
+      await displace(() => store.updateOutbox(REMOTE_ENVELOPE.envelopeId, item => ({ ...item, attempts: 1, lastAttemptAt: NOW.toISOString() })));
+
+      await store.accept({ ...LOCAL_ENVELOPE, envelopeId: "displaced-cleanup" }, NOW.toISOString());
+      await displace(
+        () => store.cleanup(new Date(NOW.getTime() + 1)),
+        JSON.stringify({ version: 2, registrations: [VALID_REGISTRATION], envelopes: [], mailbox: [], mailboxCursors: [], peerRoutes: [], outbox: [] }),
+      );
+
+      // A detected displacement rejects, but a later retry against the observed
+      // authority is ordinary new work and has one durable acceptance/cursor.
+      const retried = await store.accept({ ...LOCAL_ENVELOPE, envelopeId: "displaced-retry" }, NOW.toISOString());
+      expect(retried.kind).toBe("accepted");
+      expect((await store.inbox(RECEIVER_ID, "0")).items).toHaveLength(1);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -7,6 +7,7 @@ import { encodedJsonBytes, isJsonValue, RELAY_ERROR, RELAY_ID, RELAY_LIMITS, REL
 import type { RelayEnvelope } from "../../src/task-relay/domain.ts";
 import { TaskRelayGateway } from "../../src/task-relay/gateway.ts";
 import { MalformedRelayStoreError, TaskRelayStore } from "../../src/task-relay/store.ts";
+import type { PeerOutboxItem } from "../../src/task-relay/store.ts";
 
 const NOW = new Date("2026-08-09T00:00:00.000Z");
 const session = (sessionId: string, harness = "pi", alive = true) => async (selector: string) => selector === sessionId
@@ -895,14 +896,16 @@ describe("pi tasks relay v2", () => {
         endpoint: { ...VALID_REGISTRATION.endpoint },
         protocolVersions: [...VALID_REGISTRATION.protocolVersions],
       };
-      const returnedRegistration = await store.register(registrationInput);
+      const pendingRegistration = store.register(registrationInput);
       registrationInput.endpoint.id = RECEIVER_ID;
       registrationInput.protocolVersions.push(99);
       registrationInput.leaseExpiresAt = "2026-08-09T00:02:00.000Z";
+      const returnedRegistration = await pendingRegistration;
 
       const acceptedEnvelope: RelayEnvelope = { ...LOCAL_ENVELOPE, envelopeId: "alias-local", payload: { opaque: "before" } };
-      await store.accept(acceptedEnvelope, NOW.toISOString());
+      const pendingAcceptance = store.accept(acceptedEnvelope, NOW.toISOString());
       (acceptedEnvelope.payload as { opaque: string }).opaque = "after";
+      await pendingAcceptance;
 
       const route = await store.peerRoute(PEER_ORIGIN);
       const queuedEnvelope: RelayEnvelope = {
@@ -911,7 +914,7 @@ describe("pi tasks relay v2", () => {
         target: { relay: route.id, id: RECEIVER_ID },
         payload: { opaque: "before" },
       };
-      await store.queuePeer({
+      const pendingQueue = store.queuePeer({
         envelope: queuedEnvelope,
         peerOrigin: PEER_ORIGIN,
         queuedAt: NOW.toISOString(),
@@ -922,13 +925,22 @@ describe("pi tasks relay v2", () => {
         lastError: undefined,
       });
       (queuedEnvelope.payload as { opaque: string }).opaque = "after";
+      await pendingQueue;
+      let callbackResult: PeerOutboxItem | undefined;
+      await store.updateOutbox("alias-peer", (item) => {
+        expect(Object.isFrozen(item)).toBe(true);
+        expect(() => { (item.envelope.payload as { opaque: string }).opaque = "mutated"; }).toThrow();
+        callbackResult = { ...item, lastError: "callback", envelope: { ...item.envelope, payload: { opaque: "before" } } };
+        return callbackResult;
+      });
+      (callbackResult!.envelope.payload as { opaque: string }).opaque = "after";
 
       const registration = await store.registrationForSession("sender", NOW);
       const inbox = await store.inbox(RECEIVER_ID, "0");
       const outbox = await store.outbox();
       expect(registration).toMatchObject({ endpoint: { id: SENDER_ID }, protocolVersions: [RELAY_PROTOCOL_VERSION], leaseExpiresAt: VALID_REGISTRATION.leaseExpiresAt });
       expect(inbox.items).toEqual([expect.objectContaining({ envelope: expect.objectContaining({ payload: { opaque: "before" } }) })]);
-      expect(outbox).toEqual([expect.objectContaining({ envelope: expect.objectContaining({ payload: { opaque: "before" } }) })]);
+      expect(outbox).toEqual([expect.objectContaining({ lastError: "callback", envelope: expect.objectContaining({ payload: { opaque: "before" } }) })]);
       expect(Object.isFrozen(returnedRegistration)).toBe(true);
       expect(Object.isFrozen(registration)).toBe(true);
       expect(Object.isFrozen(inbox.items[0]!.envelope)).toBe(true);

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -550,6 +550,28 @@ describe("pi tasks relay v2", () => {
     }
   });
 
+  test("flushes zero pending outbox work without iterating retained terminal history", async () => {
+    const directory = root();
+    let iterations = 0;
+    const terminalHistory = Array.from({ length: 1_000 }, (_, index) => ({ envelope: { envelopeId: `terminal-${index}` } }));
+    Object.defineProperty(terminalHistory, Symbol.iterator, {
+      value: function* () { for (let index = 0; index < terminalHistory.length; index += 1) { iterations += 1; yield terminalHistory[index]; } },
+    });
+    const pendingSpy = jest.spyOn(TaskRelayStore.prototype, "pendingOutbox").mockResolvedValue([]);
+    const outboxSpy = jest.spyOn(TaskRelayStore.prototype, "outbox").mockResolvedValue(terminalHistory as never);
+    const gateway = new TaskRelayGateway({ root: directory, inspectSession: session("sender"), now: () => NOW });
+    try {
+      await expect(gateway.flushPeerOutbox()).resolves.toEqual({ forwarded: 0, pending: 0 });
+      expect(outboxSpy).not.toHaveBeenCalled();
+      expect(iterations).toBe(0);
+    } finally {
+      gateway.close();
+      pendingSpy.mockRestore();
+      outboxSpy.mockRestore();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("retains recent forwarding diagnostics until their retention cutoff", async () => {
     const directory = root();
     try {
@@ -977,6 +999,31 @@ describe("pi tasks relay v2", () => {
     }
   });
 
+  test("retries a post-rename acceptance failure as one durable duplicate", async () => {
+    const directory = root();
+    try {
+      const store = new TaskRelayStore(directory);
+      let fsyncCalls = 0;
+      const fsyncSpy = jest.spyOn(fs, "fsyncSync").mockImplementation((_descriptor: number) => {
+        fsyncCalls += 1;
+        if (fsyncCalls === 2) throw new Error("directory fsync failed");
+      });
+      try {
+        await expect(store.accept({ ...LOCAL_ENVELOPE, envelopeId: "failed-accept" }, NOW.toISOString())).rejects.toThrow("directory fsync failed");
+      } finally {
+        fsyncSpy.mockRestore();
+      }
+      const retry = await store.accept({ ...LOCAL_ENVELOPE, envelopeId: "failed-accept" }, new Date(NOW.getTime() + 1).toISOString());
+      expect(retry.kind).toBe("duplicate");
+      const state = JSON.parse(readFileSync(join(directory, "relay-state.json"), "utf8"));
+      expect(state.envelopes).toHaveLength(1);
+      expect(state.mailbox).toEqual([expect.objectContaining({ envelopeId: "failed-accept", cursor: "1" })]);
+      expect(state.envelopes[0].acceptanceId).toBe(retry.acceptanceId);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("does not replace durable state for validated duplicate and empty-maintenance operations", async () => {
     const directory = root();
     try {
@@ -1062,6 +1109,30 @@ describe("pi tasks relay v2", () => {
         expect.objectContaining({ attempts: 2 }),
         expect.objectContaining({ attempts: 3 }),
       ]);
+      await store.register(VALID_REGISTRATION);
+      expect(JSON.parse(readFileSync(path, "utf8")).registrations).toHaveLength(1);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("selects the first active registration rather than letting an expired duplicate hide it", async () => {
+    const directory = root();
+    try {
+      writeFileSync(join(directory, "relay-state.json"), JSON.stringify({
+        version: 2,
+        registrations: [
+          { ...VALID_REGISTRATION, leaseExpiresAt: "2026-08-08T23:59:59.999Z" },
+          { ...VALID_REGISTRATION, endpoint: { relay: RELAY_ID, id: RECEIVER_ID }, generation: "active-later" },
+        ],
+        envelopes: [], mailbox: [], mailboxCursors: [], peerRoutes: [], outbox: [],
+      }));
+      const store = new TaskRelayStore(directory);
+      await expect(store.registrationForSession("sender", NOW)).resolves.toMatchObject({ endpoint: { id: RECEIVER_ID }, generation: "active-later" });
+      await expect(store.registration(RECEIVER_ID, NOW)).resolves.toMatchObject({ generation: "active-later" });
+      await expect(store.registrationsForSessions(["sender"], NOW)).resolves.toEqual(new Map([
+        ["sender", expect.objectContaining({ generation: "active-later" })],
+      ]));
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, jest, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import * as fs from "node:fs";
+import { mkdtempSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { encodedJsonBytes, isJsonValue, RELAY_ERROR, RELAY_ID, RELAY_LIMITS, RELAY_PROTOCOL_VERSION } from "../../src/task-relay/domain.ts";
@@ -788,6 +789,109 @@ describe("pi tasks relay v2", () => {
     } finally {
       gateway?.close();
       jest.useRealTimers();
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("caches validated snapshots, invalidates atomic replacements, and reparses only cold reads", async () => {
+    const directory = root();
+    const path = join(directory, "relay-state.json");
+    try {
+      const first = new TaskRelayStore(directory);
+      await first.register(VALID_REGISTRATION);
+      const cold = new TaskRelayStore(directory);
+      const readSpy = jest.spyOn(fs, "readFileSync");
+      try {
+        await cold.registrationForSession("sender", NOW);
+        await cold.registrationForSession("sender", NOW);
+        await cold.registration(SENDER_ID, NOW);
+        expect(readSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        readSpy.mockRestore();
+      }
+
+      const second = new TaskRelayStore(directory);
+      await second.register({ ...VALID_REGISTRATION, leaseExpiresAt: "2026-08-09T00:02:00.000Z" });
+      await expect(cold.registrationForSession("sender", new Date("2026-08-09T00:01:30.000Z"))).resolves.toMatchObject({
+        leaseExpiresAt: "2026-08-09T00:02:00.000Z",
+      });
+
+      const validSource = readFileSync(path, "utf8");
+      const temporary = `${path}.replacement`;
+      writeFileSync(temporary, "{");
+      renameSync(temporary, path);
+      await expectMalformedRelayStore(() => cold.outbox(), "atomically replaced malformed store");
+
+      writeFileSync(temporary, validSource);
+      renameSync(temporary, path);
+      await expect(cold.registrationForSession("sender", NOW)).resolves.toMatchObject({
+        leaseExpiresAt: "2026-08-09T00:02:00.000Z",
+      });
+
+      rmSync(path);
+      await expect(cold.registrationForSession("sender", NOW)).resolves.toBeUndefined();
+      writeFileSync(temporary, validSource);
+      renameSync(temporary, path);
+      await expect(cold.registrationForSession("sender", NOW)).resolves.toMatchObject({
+        leaseExpiresAt: "2026-08-09T00:02:00.000Z",
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("serializes same-path store mutations without stale cached registrations", async () => {
+    const directory = root();
+    try {
+      const left = new TaskRelayStore(directory);
+      const right = new TaskRelayStore(directory);
+      await Promise.all([
+        left.register(VALID_REGISTRATION),
+        right.register({ ...VALID_REGISTRATION, endpoint: { relay: RELAY_ID, id: RECEIVER_ID }, sessionId: "receiver", generation: "receiver-generation" }),
+      ]);
+      await expect(left.registrationForSession("receiver", NOW)).resolves.toMatchObject({ endpoint: { id: RECEIVER_ID } });
+      await expect(right.registrationForSession("sender", NOW)).resolves.toMatchObject({ endpoint: { id: SENDER_ID } });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("does not replace durable state for validated duplicate and empty-maintenance operations", async () => {
+    const directory = root();
+    try {
+      const store = new TaskRelayStore(directory);
+      await store.register(VALID_REGISTRATION);
+      await store.accept(LOCAL_ENVELOPE, NOW.toISOString());
+      await store.acknowledge(RECEIVER_ID, LOCAL_ENVELOPE.envelopeId, NOW.toISOString());
+      const path = join(directory, "relay-state.json");
+      const before = statSync(path);
+
+      await store.register(VALID_REGISTRATION);
+      await store.acknowledge(RECEIVER_ID, LOCAL_ENVELOPE.envelopeId, NOW.toISOString());
+      await store.updateOutbox("missing", item => item);
+      await store.cleanup(new Date(NOW.getTime() - 1));
+
+      const after = statSync(path);
+      expect({ dev: after.dev, ino: after.ino, size: after.size, mtimeMs: after.mtimeMs, ctimeMs: after.ctimeMs }).toEqual({
+        dev: before.dev, ino: before.ino, size: before.size, mtimeMs: before.mtimeMs, ctimeMs: before.ctimeMs,
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("indexes stable mailbox reads and batches active session registration lookups", async () => {
+    const directory = root();
+    try {
+      const store = new TaskRelayStore(directory);
+      await store.register(VALID_REGISTRATION);
+      await acceptInboxEnvelopes(store, RELAY_LIMITS.INBOX_PAGE_ITEMS + 10);
+      const page = await store.inbox(RECEIVER_ID, "0");
+      expect(page.items).toHaveLength(RELAY_LIMITS.INBOX_PAGE_ITEMS);
+      const registrations = await store.registrationsForSessions(["sender", "missing", "sender"], NOW);
+      expect([...registrations]).toEqual([["sender", expect.objectContaining({ endpoint: VALID_REGISTRATION.endpoint })]]);
+      expect(await store.pendingOutboxCount()).toBe(0);
+    } finally {
       rmSync(directory, { recursive: true, force: true });
     }
   });

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -840,6 +840,36 @@ describe("pi tasks relay v2", () => {
     }
   });
 
+  test("does not publish own write bytes under an atomically replaced file identity", async () => {
+    const directory = root();
+    const path = join(directory, "relay-state.json");
+    const replacement = `${path}.replacement`;
+    try {
+      const store = new TaskRelayStore(directory);
+      await store.register(VALID_REGISTRATION);
+      writeFileSync(replacement, readFileSync(path, "utf8").replace(
+        VALID_REGISTRATION.leaseExpiresAt,
+        "2026-08-09T00:03:00.000Z",
+      ));
+      let fsyncCalls = 0;
+      const fsyncSpy = jest.spyOn(fs, "fsyncSync").mockImplementation((_descriptor: number) => {
+        fsyncCalls += 1;
+        if (fsyncCalls === 2) renameSync(replacement, path);
+      });
+      try {
+        const registered = await store.register({ ...VALID_REGISTRATION, leaseExpiresAt: "2026-08-09T00:02:00.000Z" });
+        expect(registered.leaseExpiresAt).toBe("2026-08-09T00:03:00.000Z");
+      } finally {
+        fsyncSpy.mockRestore();
+      }
+      await expect(store.registrationForSession("sender", new Date("2026-08-09T00:02:30.000Z"))).resolves.toMatchObject({
+        leaseExpiresAt: "2026-08-09T00:03:00.000Z",
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   test("serializes same-path store mutations without stale cached registrations", async () => {
     const directory = root();
     try {


### PR DESCRIPTION
## Summary

First independently reviewed PR in the performance/memory series. Removes history-sized parsing/validation from stable relay reads and zero-pending retry maintenance; it is **not a general write-throughput improvement**.

- Cache an immutable, validated per-store snapshot with indexed registrations, mailbox envelopes/cursors, routes and pending outbox references.
- Bind reads to descriptor identity with nanosecond metadata and bounded pathname revalidation. Observe atomic replacement/deletion; fail closed on malformed state and detected post-write displacement.
- Batch session endpoint projection, skip validated no-op persistence, and avoid scanning retained forwarded/exhausted rows on the one-second retry tick.
- Preserve first-active registration selection, accepted persisted duplicate/update-all semantics, input/output ownership, lease/generation revocation, mailbox limits, canonical digests and fsync/rename durability.
- Add fault/alias/compatibility/maintenance regressions and a reproducible synthetic benchmark.

## Important performance tradeoff

Stable reads and no-op maintenance improve substantially, but **real mutations remain history-sized and measured approximately 2.9× slower at 5,000 messages**. Validation, reload and the final canonical authority comparison add synchronous CPU and transient strings. This tradeoff was independently reviewed and accepted for the bounded stable-read/idle-maintenance goal; do not interpret this PR as uniformly lower latency. Reusing canonical bytes/digests to reduce redundant write-path work is a follow-up opportunity, not implemented here.

Coordinator measurements, Bun 1.3.9/macOS x64, temporary files, 1 KiB envelope payloads, five-sample medians, warm filesystem, sequential baseline/candidate runs:

| Operation, 5,000 messages | Base `445e1c3` | Candidate `83a7398` |
| --- | ---: | ---: |
| Warm registration lookup | 155.658 ms | 0.008 ms |
| Two empty-outbox reads | 317.747 ms | 0.018 ms |
| Twenty warm session lookups | 3254.165 ms | 0.155 ms |
| Duplicate acknowledgement | 287.606 ms | 0.015 ms |
| Actual registration renewal write | 280.074 ms | 808.808 ms |
| Fresh envelope acceptance write | 284.091 ms | 800.477 ms |

Real gateway flush with 1,000/5,000 retained terminal outbox rows and zero pending work: candidate **0.009/0.011 ms**. No baseline terminal-flush number is claimed. Sol independently measured the same material write-cost tradeoff and flat warm terminal-maintenance behavior.

These are **synthetic local measurements**, not production latency, RSS, allocation or concurrent-load measurements. Filesystem/load variance is material. Cold validation/index construction remains history-sized; the harness's `coldLookupMs` includes fixture seeding and must not be treated as pure cold-read latency.

Committed harness:

```sh
bun scripts/task-relay-store-perf.ts src/task-relay/store.ts
```

For baseline reads, supply the base revision's store module with its relative imports resolved to unchanged dependencies. The separate real-write measurements extend the same harness's `measure` helper: on the warmed seeded store, renew the existing registration with a distinct lease timestamp every call, and accept a distinct envelope ID every call (one warm-up plus five timed samples each). They do not measure duplicate/no-op writes as real mutations.

## Verification

Exact reviewed/tested head: `83a739827fc8fb6456dae45fa1f4907c68bca068`.
Base: `445e1c3e77ecb50da689bb795fa67a24486b2066`.

- Coordinator: `bun test tests/unit tests/integration/task-relay.test.ts` — **1,623 pass, 1 skip, 0 fail; 4,857 assertions**.
- Coordinator: `bun run typecheck` — pass; `git diff --check` — pass.
- Independent Sol reviewer: **84 focused tests**, typecheck, adapted conflict/frozen-projection tests, descriptor replacement, first-active lookup and post-rename fsync recovery — pass; **APPROVE** the exact head.
- Coordinator reran six independent boundary/operation-count tests — all pass, including a real persisted 1,000-terminal-row proxy fixture showing zero terminal-row property access on a warm zero-pending flush.
- Committed regression fixtures exercise real persisted terminal/mixed outboxes, immutable pending counts, detected mutation displacement, duplicate compatibility, alias timing, cache replacement/repair, no-op writes and cleanup.

## Scope and limitations

- No database/schema migration, dependency additions, broker changes, generated assets or browser renderer changes.
- Independent processes still require a coordinated single writer. Supported external observation is atomic replace/delete-recreate, **not** in-place editing or cross-process compare-and-swap.
- Conflict detection covers a differing replacement observed during post-write validation. It cannot prevent a replacement after validation or promise linearizable cross-process read-modify-write/perpetual durability.
- Cache ownership is per store, not an unbounded global payload cache. Cleanup replaces the mutating store's graph; an idle second store may retain an old immutable snapshot until next access/collection. Caller-held old results are likewise retained by their callers.
- No live relay/session experiments, installation, service restart, deployment or automatic merge performed.
