### PR TITLE
perf: share broker snapshots and order subscription output

### DIFF
--- a/broker/Cargo.toml
+++ b/broker/Cargo.toml
@@ -8,7 +8,8 @@ license = "MIT"
 build = "build.rs"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+# `rc` serializes `Arc<Snapshot>` as the unchanged Snapshot wire shape.
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 thiserror = "1"
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/broker/examples/snapshot_cache_measure.rs
+++ b/broker/examples/snapshot_cache_measure.rs
@@ -1,0 +1,194 @@
+//! Bounded snapshot-cache allocation/scaling harness.
+//!
+//! This exercises `Session::snapshot_terminal` rather than measuring an
+//! isolated `Arc::clone`: each sample feeds real 120-column terminal history,
+//! measures fixture construction, cold terminal materialization plus cache
+//! insertion, a production cache hit, and serialization of the returned
+//! snapshot. Requested allocator bytes and calls are process-heap requests
+//! only; they are neither RSS nor RPC latency measurements.
+//!
+//! Run against this checkout (with a verified native bundle):
+//!
+//! ```text
+//! CARGO_TARGET_DIR=/private/target cargo run --locked --manifest-path broker/Cargo.toml \
+//!   --example snapshot_cache_measure
+//! ```
+//!
+//! For a base comparison, export the desired base commit to a separate plain
+//! directory, copy this harness and the same verified bundle into that export,
+//! and run the identical command with a separate target. This keeps the
+//! measured cache/materialization path and native inputs identical while the
+//! prior implementation's deep cache clones remain in effect.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tokio::sync::broadcast;
+use wolfpack_broker::protocol::Event;
+use wolfpack_broker::session::{Session, SpawnOptions};
+
+struct CountingAllocator;
+
+static TRACK_ALLOCATIONS: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_CALLS: AtomicU64 = AtomicU64::new(0);
+static ALLOCATION_BYTES: AtomicU64 = AtomicU64::new(0);
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwards the exact layout supplied by the allocator caller.
+        let allocation = unsafe { System.alloc(layout) };
+        if TRACK_ALLOCATIONS.load(Ordering::Relaxed) && !allocation.is_null() {
+            ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATION_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        allocation
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: forwards the exact layout supplied by the allocator caller.
+        let allocation = unsafe { System.alloc_zeroed(layout) };
+        if TRACK_ALLOCATIONS.load(Ordering::Relaxed) && !allocation.is_null() {
+            ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATION_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        allocation
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: forwards the exact pointer/layout/new size supplied by the
+        // allocator caller.
+        let allocation = unsafe { System.realloc(ptr, layout, new_size) };
+        if TRACK_ALLOCATIONS.load(Ordering::Relaxed) && !allocation.is_null() {
+            ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+            ALLOCATION_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        allocation
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: forwards the exact pointer/layout supplied by the allocator caller.
+        unsafe { System.dealloc(ptr, layout) };
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AllocationSample {
+    calls: u64,
+    requested_bytes: u64,
+}
+
+fn measure<T>(operation: impl FnOnce() -> T) -> (T, AllocationSample) {
+    ALLOCATION_CALLS.store(0, Ordering::Relaxed);
+    ALLOCATION_BYTES.store(0, Ordering::Relaxed);
+    TRACK_ALLOCATIONS.store(true, Ordering::SeqCst);
+    let result = operation();
+    TRACK_ALLOCATIONS.store(false, Ordering::SeqCst);
+    (
+        result,
+        AllocationSample {
+            calls: ALLOCATION_CALLS.load(Ordering::Relaxed),
+            requested_bytes: ALLOCATION_BYTES.load(Ordering::Relaxed),
+        },
+    )
+}
+
+fn print_sample(rows: usize, phase: &str, sample: AllocationSample) {
+    println!(
+        "rows={rows:>4} phase={phase:<38} allocation_calls={} requested_bytes={}",
+        sample.calls, sample.requested_bytes
+    );
+}
+
+fn fixture_bytes(rows: usize) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(rows * 120);
+    for _ in 0..rows {
+        bytes.extend_from_slice(&[b'x'; 119]);
+        bytes.push(b'\n');
+    }
+    bytes
+}
+
+fn wait_for_bus_quiet(session: &Session) -> Result<(), Box<dyn std::error::Error>> {
+    let bus = session.output_bus();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut last_seq = bus.current_seq();
+    let mut last_change = Instant::now();
+    loop {
+        if Instant::now() >= deadline {
+            return Err(format!("output bus did not settle (last seq {last_seq})").into());
+        }
+        thread::sleep(Duration::from_millis(5));
+        let current_seq = bus.current_seq();
+        if current_seq != last_seq {
+            last_seq = current_seq;
+            last_change = Instant::now();
+        } else if current_seq > 0 && last_change.elapsed() >= Duration::from_millis(100) {
+            return Ok(());
+        }
+    }
+}
+
+fn run_sample(rows: usize) -> Result<(), Box<dyn std::error::Error>> {
+    let (fixture, fixture_sample) = measure(|| fixture_bytes(rows));
+    print_sample(rows, "fixture_construction", fixture_sample);
+
+    let (events, _) = broadcast::channel::<Event>(1);
+    let session = Session::spawn(
+        SpawnOptions {
+            name: format!("snapshot-cache-measure-{rows}"),
+            cwd: "/tmp".into(),
+            // Keep the child alive while feeding in bounded batches. This
+            // avoids the exit reaper's drain barrier becoming part of the
+            // materialization/cache measurement.
+            command: vec!["sh".into(), "-c".into(), "stty -echo; cat".into()],
+            env: vec![],
+            cols: 120,
+            rows: 24,
+        },
+        events,
+    )?;
+    thread::sleep(Duration::from_millis(50));
+    for batch in fixture.chunks(120 * 250) {
+        session.write_stdin(batch)?;
+        wait_for_bus_quiet(&session)?;
+    }
+
+    let (cold, cold_sample) = measure(|| session.snapshot_terminal(None, None));
+    let cold = cold?;
+    let actual_rows = cold.visible_screen.len() + cold.scrollback.len();
+    print_sample(rows, "cold_materialize_plus_cache_insert", cold_sample);
+
+    let (cached, hit_sample) = measure(|| session.snapshot_terminal(None, None));
+    let cached = cached?;
+    print_sample(rows, "production_cache_hit", hit_sample);
+
+    let ((serialized_len, same_snapshot), serialization_sample) = measure(|| {
+        let encoded = serde_json::to_vec(&cached).expect("snapshot serialization");
+        (encoded.len(), cold == cached)
+    });
+    print_sample(
+        rows,
+        "snapshot_response_serialization",
+        serialization_sample,
+    );
+    println!(
+        "rows={rows:>4} snapshot_rows={actual_rows} serialized_bytes={serialized_len} cache_value_equal={same_snapshot}"
+    );
+
+    let _ = session.kill(libc::SIGKILL);
+    let _ = session.wait_for_exit(Duration::from_secs(5));
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("snapshot_cache_measure: requested allocation counts/bytes, not RSS or latency");
+    for rows in [500, 1_000, 5_000] {
+        run_sample(rows)?;
+    }
+    Ok(())
+}

--- a/broker/src/protocol.rs
+++ b/broker/src/protocol.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;
@@ -218,8 +220,11 @@ pub enum ResponsePayload {
     CreateSession { session: SessionInfo },
     KillSession { killed: bool },
     SessionInfo { session: SessionInfo },
-    Snapshot { snapshot: Snapshot },
-    SnapshotSubscribe { snapshot: Snapshot, current_seq: u64, replay_truncated: bool },
+    /// Snapshots are immutable and potentially history-sized. `Arc` avoids
+    /// copying the cell graph from the per-session cache into a response;
+    /// serde's `rc` support retains the exact Snapshot JSON shape.
+    Snapshot { snapshot: Arc<Snapshot> },
+    SnapshotSubscribe { snapshot: Arc<Snapshot>, current_seq: u64, replay_truncated: bool },
     Resize { ok: bool },
     Subscribe { ok: bool, current_seq: u64, replay_truncated: bool },
     Unsubscribe { ok: bool },
@@ -558,13 +563,20 @@ mod tests {
 
     #[test]
     fn snapshot_payload_envelope() {
+        let snapshot = Arc::new(sample_snapshot());
         let resp = ControlResponse::ok(
             3,
-            ResponsePayload::Snapshot { snapshot: sample_snapshot() },
+            ResponsePayload::Snapshot { snapshot: Arc::clone(&snapshot) },
         );
+        let payload_snapshot = match resp.payload.as_ref().expect("snapshot payload") {
+            ResponsePayload::Snapshot { snapshot } => snapshot,
+            other => panic!("unexpected payload: {other:?}"),
+        };
+        assert!(Arc::ptr_eq(&snapshot, payload_snapshot), "response must retain shared snapshot ownership");
         let s = serde_json::to_string(&resp).unwrap();
         let back: ControlResponse = serde_json::from_str(&s).unwrap();
         assert_eq!(resp, back);
+        assert_eq!(serde_json::to_value(&snapshot).unwrap(), serde_json::to_value(sample_snapshot()).unwrap());
     }
 
     #[test]

--- a/broker/src/server.rs
+++ b/broker/src/server.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use tokio::net::{UnixListener, UnixStream};
-use tokio::sync::{broadcast, mpsc, watch, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{broadcast, mpsc, oneshot, watch, OwnedSemaphorePermit, Semaphore};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -49,6 +49,31 @@ const OUTPUT_FORWARD_BUFFER_MAX_BYTES: usize = 8 * 1024 * 1024;
 /// frame and this depth caps queued data before socket backpressure applies.
 const INPUT_QUEUE_MAX_BYTES: usize = 4 * 1024 * 1024;
 const INPUT_QUEUE_CAPACITY: usize = INPUT_QUEUE_MAX_BYTES / MAX_INPUT_BINARY_PAYLOAD as usize;
+
+/// Private successful-write acknowledgement for a control boundary. A
+/// subscription forwarder waits on this instead of treating queue insertion as
+/// a socket-ordering barrier.
+struct QueuedControl {
+    frame: Frame,
+    written: Option<oneshot::Sender<()>>,
+}
+
+impl QueuedControl {
+    fn plain(frame: Frame) -> Self {
+        Self { frame, written: None }
+    }
+
+    fn response_with_barrier(response: ControlResponse) -> (Self, oneshot::Receiver<()>) {
+        let (written, barrier) = oneshot::channel();
+        (
+            Self {
+                frame: Frame::ControlResponse(response),
+                written: Some(written),
+            },
+            barrier,
+        )
+    }
+}
 
 struct SocketBindUmaskGuard {
     previous_umask: libc::mode_t,
@@ -294,7 +319,7 @@ async fn handle_connection(
     // redraw burst. The socket writer prioritises this queue over output.
     let control_queue_cap = writer_queue_cap.unwrap_or(CONTROL_QUEUE_CAPACITY);
     let output_queue_cap = writer_queue_cap.unwrap_or(WRITER_QUEUE_CAPACITY);
-    let (writer_tx, writer_rx) = mpsc::channel::<Frame>(control_queue_cap);
+    let (writer_tx, writer_rx) = mpsc::channel::<QueuedControl>(control_queue_cap);
     let (output_tx, output_rx) = mpsc::channel::<Frame>(output_queue_cap);
     let writer_task = tokio::spawn(connection_writer(
         write_half,
@@ -400,11 +425,11 @@ async fn handle_connection(
 /// Drain the per-connection event receiver into the writer queue. Logs
 /// and continues on lag (events are best-effort by protocol contract);
 /// returns when the broadcast channel closes or the writer queue dies.
-async fn forward_events(mut rx: broadcast::Receiver<Event>, writer_tx: mpsc::Sender<Frame>) {
+async fn forward_events(mut rx: broadcast::Receiver<Event>, writer_tx: mpsc::Sender<QueuedControl>) {
     loop {
         match rx.recv().await {
             Ok(ev) => {
-                if writer_tx.send(Frame::Event(ev)).await.is_err() {
+                if writer_tx.send(QueuedControl::plain(Frame::Event(ev))).await.is_err() {
                     return;
                 }
             }
@@ -442,7 +467,7 @@ fn record_queue_high_water(queue: &'static str, depth: usize) {
 
 async fn connection_writer(
     mut w: tokio::net::unix::OwnedWriteHalf,
-    mut control_rx: mpsc::Receiver<Frame>,
+    mut control_rx: mpsc::Receiver<QueuedControl>,
     mut output_rx: mpsc::Receiver<Frame>,
     control_queue_cap: usize,
     output_queue_cap: usize,
@@ -463,10 +488,10 @@ async fn connection_writer(
                 continue;
             }
         }
-        let (is_control, frame) = tokio::select! {
+        let (is_control, frame, written) = tokio::select! {
             biased;
-            Some(frame) = control_rx.recv() => (true, frame),
-            Some(frame) = output_rx.recv() => (false, frame),
+            Some(control) = control_rx.recv() => (true, control.frame, control.written),
+            Some(frame) = output_rx.recv() => (false, frame, None),
             else => return,
         };
         record_queue_high_water(
@@ -478,8 +503,13 @@ async fn connection_writer(
             },
         );
         if let Err(error) = write_frame_async(&mut w, &frame).await {
+            // Dropping `written` makes boundary forwarders stop without
+            // emitting output after a failed response write.
             warn!(%error, "broker writer failed; closing connection");
             return;
+        }
+        if let Some(written) = written {
+            let _ = written.send(());
         }
         control_streak = if is_control { control_streak + 1 } else { 0 };
     }
@@ -491,7 +521,7 @@ async fn dispatch_frame(
     frame: Frame,
     router: &SessionRouter,
     registry: &Arc<Registry>,
-    writer_tx: &mpsc::Sender<Frame>,
+    writer_tx: &mpsc::Sender<QueuedControl>,
     output_tx: &mpsc::Sender<Frame>,
     input_tx: &mpsc::Sender<InputFrame>,
     subs: &mut HashMap<Uuid, JoinHandle<()>>,
@@ -505,7 +535,7 @@ async fn dispatch_frame(
             methods::UNSUBSCRIBE => handle_unsubscribe(req, writer_tx, subs).await,
             _ => {
                 let resp = router.handle(req);
-                writer_tx.send(Frame::ControlResponse(resp)).await.is_ok()
+                send_response(writer_tx, resp).await
             }
         },
         Frame::InputBinary(inp) => input_tx.send(inp).await.is_ok(),
@@ -525,7 +555,7 @@ async fn dispatch_frame(
 async fn handle_snapshot_subscribe(
     req: ControlRequest,
     registry: &Arc<Registry>,
-    writer_tx: &mpsc::Sender<Frame>,
+    writer_tx: &mpsc::Sender<QueuedControl>,
     output_tx: &mpsc::Sender<Frame>,
     subs: &mut HashMap<Uuid, JoinHandle<()>>,
 ) -> bool {
@@ -615,7 +645,7 @@ async fn handle_snapshot_subscribe(
     if let Some(previous) = subs.remove(&params.session_id) {
         previous.abort();
     }
-    if !send_response(
+    let Some(response_written) = send_response_with_barrier(
         writer_tx,
         ControlResponse::ok(
             id,
@@ -627,11 +657,15 @@ async fn handle_snapshot_subscribe(
         ),
     )
     .await
-    {
+    else {
         return false;
-    }
+    };
     let session_id = params.session_id;
-    let handle = tokio::spawn(forward_output(
+    // Do not await the socket write in this dispatcher: unsubscribe,
+    // replacement, shutdown and input must remain responsive while a slow peer
+    // is blocked. The subscription map owns this waiting task for cancellation.
+    let handle = tokio::spawn(forward_after_response_written(
+        response_written,
         session_id,
         sub.replay,
         sub.receiver,
@@ -654,7 +688,7 @@ async fn handle_snapshot_subscribe(
 async fn handle_subscribe(
     req: ControlRequest,
     registry: &Arc<Registry>,
-    writer_tx: &mpsc::Sender<Frame>,
+    writer_tx: &mpsc::Sender<QueuedControl>,
     output_tx: &mpsc::Sender<Frame>,
     subs: &mut HashMap<Uuid, JoinHandle<()>>,
 ) -> bool {
@@ -706,7 +740,7 @@ async fn handle_subscribe(
         prev.abort();
     }
 
-    if !send_response(
+    let Some(response_written) = send_response_with_barrier(
         writer_tx,
         ControlResponse::ok(
             id,
@@ -718,12 +752,13 @@ async fn handle_subscribe(
         ),
     )
     .await
-    {
+    else {
         return false;
-    }
+    };
 
     let session_id = params.session_id;
-    let handle = tokio::spawn(forward_output(
+    let handle = tokio::spawn(forward_after_response_written(
+        response_written,
         session_id,
         sub.replay,
         sub.receiver,
@@ -735,7 +770,7 @@ async fn handle_subscribe(
 
 async fn handle_unsubscribe(
     req: ControlRequest,
-    writer_tx: &mpsc::Sender<Frame>,
+    writer_tx: &mpsc::Sender<QueuedControl>,
     subs: &mut HashMap<Uuid, JoinHandle<()>>,
 ) -> bool {
     let id = req.id;
@@ -895,8 +930,29 @@ fn chunk_to_frame(session_id: Uuid, chunk: OutputChunk) -> OutputFrame {
     }
 }
 
-async fn send_response(writer_tx: &mpsc::Sender<Frame>, resp: ControlResponse) -> bool {
-    writer_tx.send(Frame::ControlResponse(resp)).await.is_ok()
+async fn send_response(writer_tx: &mpsc::Sender<QueuedControl>, resp: ControlResponse) -> bool {
+    writer_tx.send(QueuedControl::plain(Frame::ControlResponse(resp))).await.is_ok()
+}
+
+async fn send_response_with_barrier(
+    writer_tx: &mpsc::Sender<QueuedControl>,
+    response: ControlResponse,
+) -> Option<oneshot::Receiver<()>> {
+    let (queued, barrier) = QueuedControl::response_with_barrier(response);
+    writer_tx.send(queued).await.ok()?;
+    Some(barrier)
+}
+
+async fn forward_after_response_written(
+    barrier: oneshot::Receiver<()>,
+    session_id: Uuid,
+    replay: Vec<OutputChunk>,
+    receiver: tokio::sync::broadcast::Receiver<OutputChunk>,
+    output_tx: mpsc::Sender<Frame>,
+) {
+    if barrier.await.is_ok() {
+        forward_output(session_id, replay, receiver, output_tx).await;
+    }
 }
 
 fn unknown_session(id: u64, session_id: Uuid) -> ControlResponse {
@@ -997,7 +1053,7 @@ mod tests {
             .await
         );
 
-        let response = match writer_rx.recv().await.expect("snapshot response") {
+        let response = match writer_rx.recv().await.expect("snapshot response").frame {
             Frame::ControlResponse(response) => response,
             frame => panic!("unexpected frame: {frame:?}"),
         };
@@ -1226,7 +1282,7 @@ mod tests {
             .await
             .expect("queue output");
         control_tx
-            .send(Frame::ControlResponse(unknown_session(7, Uuid::nil())))
+            .send(QueuedControl::plain(Frame::ControlResponse(unknown_session(7, Uuid::nil()))))
             .await
             .expect("queue control response");
         drop(control_tx);
@@ -1259,7 +1315,7 @@ mod tests {
         let (output_tx, output_rx) = mpsc::channel(16);
         for id in 0..12 {
             control_tx
-                .send(Frame::ControlResponse(unknown_session(id, Uuid::nil())))
+                .send(QueuedControl::plain(Frame::ControlResponse(unknown_session(id, Uuid::nil()))))
                 .await
                 .unwrap();
         }
@@ -1290,6 +1346,126 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn snapshot_subscribe_response_write_precedes_associated_output_after_control_burst() {
+        let (events, _) = broadcast::channel::<Event>(16);
+        let registry = Arc::new(Registry::new(events));
+        let session = registry
+            .create(CreateOptions {
+                name: Some("writer-boundary".into()),
+                cwd: "/tmp".into(),
+                command: vec!["sleep".into(), "30".into()],
+                env: vec![],
+                cols: 80,
+                rows: 24,
+            })
+            .expect("create session");
+        // This is replay at the snapshot cut. A second chunk is live after
+        // the handler has installed its receiver; both must wait for the
+        // successful socket write of response id 99.
+        session.output_bus().publish(OutputChunk {
+            seq: 1,
+            data: Arc::new(b"replay".to_vec()),
+        });
+
+        let (broker_stream, mut client_stream) = UnixStream::pair().expect("socket pair");
+        let (_read_half, write_half) = broker_stream.into_split();
+        let (control_tx, control_rx) = mpsc::channel(16);
+        let (output_tx, output_rx) = mpsc::channel(16);
+        for id in 0..8 {
+            control_tx
+                .send(QueuedControl::plain(Frame::ControlResponse(unknown_session(id, Uuid::nil()))))
+                .await
+                .expect("queue prior control");
+        }
+        let writer = tokio::spawn(connection_writer(write_half, control_rx, output_rx, 16, 16));
+        let mut subscriptions = HashMap::new();
+        assert!(handle_snapshot_subscribe(
+            ControlRequest {
+                id: 99,
+                method: methods::SNAPSHOT_SUBSCRIBE.into(),
+                params: json!({ "session_id": session.id() }),
+            },
+            &registry,
+            &control_tx,
+            &output_tx,
+            &mut subscriptions,
+        )
+        .await);
+        session.output_bus().publish(OutputChunk {
+            seq: 2,
+            data: Arc::new(b"live".to_vec()),
+        });
+
+        for id in 0..8 {
+            assert!(matches!(
+                read_frame_async(&mut client_stream).await.expect("read prior control"),
+                Frame::ControlResponse(ControlResponse { id: received, .. }) if received == id
+            ));
+        }
+        assert!(matches!(
+            read_frame_async(&mut client_stream).await.expect("read snapshot boundary"),
+            Frame::ControlResponse(ControlResponse { id: 99, payload: Some(ResponsePayload::SnapshotSubscribe { .. }), .. })
+        ));
+        let mut associated = Vec::new();
+        while associated.len() < b"replaylive".len() {
+            match read_frame_async(&mut client_stream).await.expect("read associated output") {
+                Frame::OutputBinary(OutputFrame { session_id, data, .. }) if session_id == session.id() => {
+                    associated.extend_from_slice(&data);
+                }
+                frame => panic!("unexpected frame after snapshot boundary: {frame:?}"),
+            }
+        }
+        assert_eq!(associated, b"replaylive");
+
+        for (_, handle) in subscriptions.drain() {
+            handle.abort();
+        }
+        drop(control_tx);
+        drop(output_tx);
+        writer.await.expect("writer task failed");
+        let _ = session.kill(libc::SIGKILL);
+        let _ = session.wait_for_exit(std::time::Duration::from_secs(5));
+    }
+
+    #[tokio::test]
+    async fn dropped_boundary_ack_cancels_waiting_forwarder_without_output() {
+        let session_id = Uuid::new_v4();
+        let bus = crate::output_bus::OutputBus::new(8, 8);
+        bus.publish(OutputChunk { seq: 1, data: Arc::new(b"replay".to_vec()) });
+        let sub = bus.subscribe(Some(0));
+        let (output_tx, mut output_rx) = mpsc::channel(1);
+        let (written, barrier) = oneshot::channel();
+        drop(written);
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            forward_after_response_written(barrier, session_id, sub.replay, sub.receiver, output_tx),
+        )
+        .await
+        .expect("forwarder should stop when writer drops ack");
+        assert!(output_rx.try_recv().is_err(), "failed response must not release associated output");
+    }
+
+    #[tokio::test]
+    async fn pending_boundary_forwarder_is_abortable_for_replacement_or_shutdown() {
+        let session_id = Uuid::new_v4();
+        let bus = crate::output_bus::OutputBus::new(8, 8);
+        bus.publish(OutputChunk { seq: 1, data: Arc::new(b"replay".to_vec()) });
+        let sub = bus.subscribe(Some(0));
+        let (output_tx, mut output_rx) = mpsc::channel(1);
+        let (_written, barrier) = oneshot::channel();
+        let forwarder = tokio::spawn(forward_after_response_written(
+            barrier,
+            session_id,
+            sub.replay,
+            sub.receiver,
+            output_tx,
+        ));
+        forwarder.abort();
+        assert!(forwarder.await.expect_err("aborted forwarder").is_cancelled());
+        assert!(output_rx.try_recv().is_err(), "aborted boundary must not emit replay");
+    }
+
+    #[tokio::test]
     async fn output_burst_leaves_writer_capacity_for_control_response() {
         const OUTPUT_CHUNKS: u64 = 400;
         let session_id = Uuid::new_v4();
@@ -1316,14 +1492,14 @@ mod tests {
 
         tokio::time::timeout(
             std::time::Duration::from_millis(100),
-            control_tx.send(Frame::ControlResponse(unknown_session(7, Uuid::nil()))),
+            control_tx.send(QueuedControl::plain(Frame::ControlResponse(unknown_session(7, Uuid::nil())))),
         )
         .await
         .expect("output saturated the writer queue and starved a control response")
         .expect("control queue closed");
         assert!(matches!(
             control_rx.recv().await,
-            Some(Frame::ControlResponse(ControlResponse { id: 7, .. }))
+            Some(QueuedControl { frame: Frame::ControlResponse(ControlResponse { id: 7, .. }), .. })
         ));
 
         forwarder.abort();

--- a/broker/src/session.rs
+++ b/broker/src/session.rs
@@ -194,7 +194,7 @@ struct CachedSnapshot {
     seq: u64,
     scrollback_lines: Option<u32>,
     target_cols: Option<u16>,
-    snapshot: Snapshot,
+    snapshot: Arc<Snapshot>,
 }
 
 pub struct Session {
@@ -218,7 +218,7 @@ pub struct Session {
     bus: Arc<OutputBus>,
     /// Most recent materialized snapshot. JSON encoding happens later on the
     /// connection writer, outside the terminal lock; identical sequence/key
-    /// requests reuse this immutable protocol value.
+    /// requests reuse this immutable `Arc` without cloning its cell graph.
     snapshot_cache: Mutex<Option<CachedSnapshot>>,
 }
 
@@ -477,7 +477,7 @@ impl Session {
         &self,
         scrollback_lines: Option<u32>,
         target_cols: Option<u16>,
-    ) -> Result<Snapshot, TerminalStateError> {
+    ) -> Result<Arc<Snapshot>, TerminalStateError> {
         let id = self.id();
         let term = self.terminal.lock().expect("terminal poisoned");
         // Read seq under the same lock the drainer holds while bumping it,
@@ -486,14 +486,14 @@ impl Session {
         if let Some(cached) = self.cached_snapshot(seq, scrollback_lines, target_cols) {
             return Ok(cached);
         }
-        let snapshot = term.try_snapshot_with_reflow(
+        let snapshot = Arc::new(term.try_snapshot_with_reflow(
             id,
             seq,
             now_ms(),
             scrollback_lines.map(|n| n as usize),
             target_cols.map(|c| c as usize),
-        )?;
-        self.cache_snapshot(seq, scrollback_lines, target_cols, &snapshot);
+        )?);
+        self.cache_snapshot(seq, scrollback_lines, target_cols, Arc::clone(&snapshot));
         Ok(snapshot)
     }
 
@@ -502,21 +502,21 @@ impl Session {
         &self,
         scrollback_lines: Option<u32>,
         target_cols: Option<u16>,
-    ) -> Result<(Snapshot, Subscription), TerminalStateError> {
+    ) -> Result<(Arc<Snapshot>, Subscription), TerminalStateError> {
         let id = self.id();
         let term = self.terminal.lock().expect("terminal poisoned");
         let seq = self.seq.load(Ordering::SeqCst);
         let snapshot = if let Some(cached) = self.cached_snapshot(seq, scrollback_lines, target_cols) {
             cached
         } else {
-            let snapshot = term.try_snapshot_with_reflow(
+            let snapshot = Arc::new(term.try_snapshot_with_reflow(
                 id,
                 seq,
                 now_ms(),
                 scrollback_lines.map(|n| n as usize),
                 target_cols.map(|c| c as usize),
-            )?;
-            self.cache_snapshot(seq, scrollback_lines, target_cols, &snapshot);
+            )?);
+            self.cache_snapshot(seq, scrollback_lines, target_cols, Arc::clone(&snapshot));
             snapshot
         };
         let subscription = self.bus.subscribe(Some(seq));
@@ -528,7 +528,7 @@ impl Session {
         seq: u64,
         scrollback_lines: Option<u32>,
         target_cols: Option<u16>,
-    ) -> Option<Snapshot> {
+    ) -> Option<Arc<Snapshot>> {
         self.snapshot_cache
             .lock()
             .expect("snapshot cache poisoned")
@@ -536,7 +536,7 @@ impl Session {
             .filter(|cached| cached.seq == seq
                 && cached.scrollback_lines == scrollback_lines
                 && cached.target_cols == target_cols)
-            .map(|cached| cached.snapshot.clone())
+            .map(|cached| Arc::clone(&cached.snapshot))
     }
 
     fn cache_snapshot(
@@ -544,13 +544,13 @@ impl Session {
         seq: u64,
         scrollback_lines: Option<u32>,
         target_cols: Option<u16>,
-        snapshot: &Snapshot,
+        snapshot: Arc<Snapshot>,
     ) {
         *self.snapshot_cache.lock().expect("snapshot cache poisoned") = Some(CachedSnapshot {
             seq,
             scrollback_lines,
             target_cols,
-            snapshot: snapshot.clone(),
+            snapshot,
         });
     }
 
@@ -1182,17 +1182,57 @@ mod tests {
     }
 
     #[test]
-    fn repeated_snapshot_key_reuses_sequence_cache() {
+    fn repeated_snapshot_key_reuses_immutable_cache_without_deep_copying() {
         let sess = spawn_session(opts(vec!["printf", "cached"])).expect("spawn");
         assert!(sess.output_bus().wait_closed(Duration::from_secs(5)));
         let first = sess.snapshot_terminal(Some(10), Some(80)).expect("snapshot");
         let second = sess.snapshot_terminal(Some(10), Some(80)).expect("cached snapshot");
-        assert_eq!(first, second);
+        assert!(Arc::ptr_eq(&first, &second), "cache hit must share the snapshot graph");
         let cache = sess.snapshot_cache.lock().expect("snapshot cache poisoned");
         let cached = cache.as_ref().expect("snapshot should be cached");
+        assert!(Arc::ptr_eq(&first, &cached.snapshot));
         assert_eq!(cached.seq, first.seq);
         assert_eq!(cached.scrollback_lines, Some(10));
         assert_eq!(cached.target_cols, Some(80));
+        drop(cache);
+
+        // A caller can opt into copy-on-write without mutating the cache or a
+        // future response. The ordinary cache-hit path above remains shared.
+        let mut caller_copy = Arc::clone(&second);
+        Arc::make_mut(&mut caller_copy).title = Some("caller-local".into());
+        assert!(!Arc::ptr_eq(&second, &caller_copy));
+        assert_ne!(second.title.as_deref(), Some("caller-local"));
+        assert_eq!(caller_copy.title.as_deref(), Some("caller-local"));
+
+        // One-entry replacement releases the old graph as soon as no caller
+        // retains it; callers that still hold an Arc remain valid by design.
+        let old = Arc::downgrade(&second);
+        drop(first);
+        drop(second);
+        drop(caller_copy);
+        let replacement = sess.snapshot_terminal(Some(9), Some(80)).expect("different key materializes replacement");
+        assert!(old.upgrade().is_none(), "replaced cache must not retain old graph");
+        assert_eq!(sess.snapshot_cache.lock().expect("snapshot cache poisoned").as_ref().unwrap().seq, replacement.seq);
+    }
+
+    #[test]
+    fn new_output_replaces_cache_and_releases_unheld_old_snapshot() {
+        let sess = spawn_session(opts(vec!["cat"])).expect("spawn");
+        sess.write_stdin(b"FIRST\\n").expect("write first marker");
+        wait_for_bus_quiet(&sess, Duration::from_millis(100), Duration::from_secs(5));
+        let first = sess.snapshot_terminal(None, None).expect("first snapshot");
+        let first_seq = first.seq;
+        let old = Arc::downgrade(&first);
+        drop(first);
+
+        sess.write_stdin(b"SECOND\\n").expect("write second marker");
+        wait_for_bus_quiet(&sess, Duration::from_millis(100), Duration::from_secs(5));
+        let second = sess.snapshot_terminal(None, None).expect("second snapshot");
+        assert!(second.seq > first_seq, "new terminal output must advance the cache key");
+        assert!(old.upgrade().is_none(), "new cache entry must release unheld prior graph");
+
+        let _ = sess.kill(libc::SIGKILL);
+        let _ = sess.wait_for_exit(Duration::from_secs(5));
     }
 
     #[test]
@@ -1355,7 +1395,7 @@ mod tests {
     }
 
     #[test]
-    fn resize_pty_failure_rolls_terminal_back_without_committing_state_or_events() {
+    fn resize_pty_failure_rolls_terminal_back_without_invalidating_cached_snapshot() {
         let id = Uuid::new_v4();
         let inner = resize_test_state(id);
         let (events, mut receiver) = broadcast::channel(4);
@@ -1364,12 +1404,38 @@ mod tests {
             ..RecordingPtyResize::default()
         };
         let terminal = Mutex::new(RecordingTerminalResize::new(80, 24));
+        let cached = Arc::new(Snapshot {
+            session_id: id,
+            seq: 0,
+            cols: 80,
+            rows: 24,
+            visible_screen: vec![],
+            scrollback: vec![],
+            cursor: Default::default(),
+            modes: Default::default(),
+            scroll_region: Default::default(),
+            title: None,
+            captured_at_ms: 0,
+        });
+        let cache = Mutex::new(Some(Arc::clone(&cached)));
+        let cached_weak = Arc::downgrade(&cached);
+        drop(cached);
 
-        let error =
-            resize_terminal_pty_and_state(&inner, id, &mut pty, &terminal, 132, 50, &events, || {})
-                .expect_err("PTY resize failure must abort transaction");
+        let error = resize_terminal_pty_and_state(
+            &inner,
+            id,
+            &mut pty,
+            &terminal,
+            132,
+            50,
+            &events,
+            || *cache.lock().expect("snapshot cache poisoned") = None,
+        )
+        .expect_err("PTY resize failure must abort transaction");
 
         assert!(matches!(error, ResizeError::Pty(_)));
+        assert!(cached_weak.upgrade().is_some(), "failed resize must retain valid cache");
+        assert!(cache.lock().expect("snapshot cache poisoned").is_some());
         assert_eq!(pty.calls, vec![(132, 50)]);
         let terminal = terminal.lock().expect("terminal poisoned");
         assert_eq!(terminal.calls, vec![(132, 50), (80, 24)]);
@@ -1413,8 +1479,12 @@ mod tests {
         let sess = spawn_session(opts(vec!["sleep", "30"])).expect("spawn");
         let before = sess.snapshot();
         assert_eq!((before.cols, before.rows), (80, 24));
+        let stale = sess.snapshot_terminal(None, None).expect("snapshot before resize");
+        let stale_weak = Arc::downgrade(&stale);
+        drop(stale);
 
         sess.resize(132, 50, &test_events()).expect("resize ok");
+        assert!(stale_weak.upgrade().is_none(), "successful resize must release cache ownership");
 
         let after = sess.snapshot();
         assert_eq!((after.cols, after.rows), (132, 50));


### PR DESCRIPTION
## Summary

Third PR in the performance/memory series: share immutable broker snapshots instead of deep-copying their cell/string graphs into the cache, on cache hits, and into responses.

- `CachedSnapshot`, `Session::snapshot_terminal`, `snapshot_and_subscribe` and the two snapshot response variants share `Arc<Snapshot>`.
- Serde `rc` keeps the JSON wire representation unchanged. This is an intentional Rust ownership/API type change, not a wire-schema change.
- Preserve one-entry cache keying, output/resize invalidation, captured sequence/timestamp semantics, and the terminal→sequence→subscription atomic cut.
- Pointer/COW/Weak-reference tests establish reuse, caller mutation isolation and release of cache ownership on replacement/invalidation.

### Snapshot/subscription ordering fix found during review

Independent review also reproduced an **inherited base bug**, not caused by Arc sharing: after eight prior controls, writer fairness could send newly associated output before a queued `snapshot_subscribe` response.

The narrow correction adds a private successful-write acknowledgement. Snapshot and ordinary subscription forwarders await their own response write before emitting replay/live output. Dispatch does not await that socket write; pending forwarders remain in the subscription map for unsubscribe/replacement/shutdown cancellation. Bounded queues and unrelated-output fairness remain unchanged. No new wire fields or unlimited replay guarantee are introduced.

## Allocation evidence

Real `Session::snapshot_terminal` measurements with the same verified Ghostty bundle and equivalent base/candidate snapshots. These are **requested allocation calls/bytes**, not RSS, latency or full-RPC costs.

| Actual materialized rows | Base cache-hit allocations | Candidate cache-hit allocations | Base requested bytes avoided per hit |
| ---: | ---: | ---: | ---: |
| 501 | 60,623 | 0 | 2,961,912 |
| 614 | 74,296 | 0 | 3,629,968 |
| 744 | 90,026 | 0 | 4,398,528 |

Cold materialization plus insertion also avoids the deep cached copy (approximately 2.96–4.40 MB of requested allocations in these fixtures). JSON serialization allocations were unchanged: 14 requests / 2,097,024 requested bytes per measured fixture. Materialization and serialization remain history-sized; the complete snapshot RPC is **not O(1)**.

The input requested 500/1,000/5,000 lines, but terminal retention produced only **501/614/744 actual rows**. These are not 1,000- or 5,000-materialized-row measurements. The reviewer independently reproduced the allocation results, verified complete fixture input with private marker probes, and compared normalized base/candidate snapshot contents and exact wire payloads.

The committed harness uses a bus-idle heuristic and process-wide allocation counters; neither provides per-thread attribution or a general completion guarantee. The reported runs were reproducible, but do not generalize them into production memory/latency claims.

```sh
cargo run --manifest-path broker/Cargo.toml --locked --offline --example snapshot_cache_measure
```

For base comparison, copy the same example into a separate exact-base export and use the same verified native inputs with a private target.

## Verification

Exact reviewed head: `f0b8e849c22f92b986e4cd57f3965c569d19077d`.
Reviewed/tested original base: `445e1c3e77ecb50da689bb795fa67a24486b2066`.

- Independent fresh-target Linux compilation: **167 broker tests passed**, zero failures; includes native/FFI, static linking, socket integration, terminal fixtures, stress and scroll-region tests.
- Focused server: **13 passed**; focused snapshot: **27 passed**.
- Committed ordering regression: **50/50 corrected runs passed**. In a private copy with its gate bypassed, **100/100 runs failed**, establishing that the regression detects the original race.
- Ordinary-subscribe probe passed corrected and failed **30/30** with its gate bypassed.
- Real socket-write failure, closed enqueue, pending unsubscribe and replacement probes passed; map-owned shutdown abort behavior verified; writer fairness regression passed.
- Both snapshot wire variants were independently byte-identical to base under Serde `rc`.
- Default Clippy exits successfully with **11 inherited diagnostics**; strict `-D warnings` still fails with the same seven unique inherited errors. No new diagnostic found. Repository-wide formatting is not clean; inherited and touched formatting differences remain, with no configured global fmt gate.
- Exact source-archive SHA256 independently matched: `baae48adf473d01fc59d0198c59bb0f5fde26f9ddfd47d5748e44da278865d7b`.
- Sol final verdict: **APPROVE** exact head.

Main advanced to `9cf141c` (#350 tombstone expiry) after this head's independent verification. Local three-way merge inspection found no conflicts; CI will validate integration with current main. The reviewed branch has not been silently rebased or amended.

## Scope / limits

Rust/Cargo 1.92.0, Bun 1.3.9, pinned verified Ghostty/Zig inputs, disposable Linux x86_64 containers with private targets. Native bundle archive SHA256 `e81fde6d11420e8306abf746fdf238c812f6c3f78879d9d4d54f670429f7ce6d`.

**macOS native execution remains unverified** because the installed SDK 11.3 is incompatible with the pinned Ghostty build dependency. No SDK/source/provenance bypass was used.

Caller-held snapshots may legitimately retain old graphs after cache eviction. Normal bounded broadcast/replay lag and recovery semantics remain authoritative. No live Wolfpack session or host service was tested/restarted, no global tools changed, and no deployment or automatic merge was performed.
