### PR TITLE
perf: batch dashboard runtime-state updates

### DIFF
--- a/scripts/agent-runtime-state-perf.ts
+++ b/scripts/agent-runtime-state-perf.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env bun
+/**
+ * Synthetic temporary-store benchmark; never opens the live runtime-state file.
+ * Run the SAME script against candidate and an exact-base module export:
+ *   bun scripts/agent-runtime-state-perf.ts [absolute/path/to/base/src/server/agent-status.ts]
+ * Setup/input allocation is outside measured operations. Times include real
+ * serialization/fsync for changed writes, not production latency or RSS.
+ */
+import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { AgentRuntimeStateInput } from "../src/server/agent-status.ts";
+
+const modulePath = process.argv[2] ? resolve(process.argv[2]) : resolve(import.meta.dir, "../src/server/agent-status.ts");
+const { AgentRuntimeStateStore } = await import(pathToFileURL(modulePath).href) as typeof import("../src/server/agent-status.ts");
+const times = ["2026-07-25T00:00:00.000Z", "2026-07-25T00:01:00.000Z", "2026-07-25T00:02:00.000Z"] as const;
+function inputs(count: number, observedAt: string): AgentRuntimeStateInput[] {
+  return Array.from({ length: count }, (_, i) => ({
+    sessionKey: `session-${i}`,
+    broker: { state: "alive", observedAt },
+    sources: [],
+    fallback: { rawOutputChanged: false, observedAt },
+    currentRun: { runId: `session-${i}`, runOrder: 1 },
+  }));
+}
+function elapsed(run: () => void): number {
+  const start = performance.now();
+  run();
+  return performance.now() - start;
+}
+function median(values: number[]): number {
+  return Number(values.sort((a, b) => a - b)[Math.floor(values.length / 2)]!.toFixed(3));
+}
+
+console.log(JSON.stringify({ modulePath, scope: "5-trial local medians in ms; requested operation work, not RSS or production latency; current timestamps remain persisted" }));
+const root = mkdtempSync(join(tmpdir(), "runtime-state-perf-"));
+try {
+  for (const count of [10, 100, 1_000]) {
+    const initial = inputs(count, times[0]);
+    const changed = inputs(count, times[1]);
+    const keys = new Set(initial.map((input) => input.sessionKey));
+    const results: Record<string, number[]> = {};
+    let bytes = 0;
+    for (let trial = 0; trial < 5; trial++) {
+      const path = join(root, `state-${count}-${trial}.json`);
+      const store = new AgentRuntimeStateStore(path);
+      for (const input of initial) store.reduce(input, { persist: false });
+      store.flush();
+      const measure = (name: string, run: () => void) => (results[name] ??= []).push(elapsed(run));
+      measure("changedReductionsMs", () => {
+        for (const input of changed) store.reduce(input, { persist: false });
+      });
+      measure("pruneAndRealFlushMs", () => { store.prune(keys, { persist: false }); store.flush(); });
+      measure("cleanFlushMs", () => store.flush());
+      measure("equivalentBatchIncludingFlushMs", () => {
+        for (const input of changed) store.reduce(input, { persist: false });
+        store.prune(keys, { persist: false });
+        store.flush();
+      });
+      measure("realAcknowledgementMs", () => {
+        if (!store.acknowledge("session-0", store.get("session-0")!.transitionSequence, times[2])) {
+          throw new Error("benchmark acknowledgement unexpectedly rejected");
+        }
+      });
+      measure("restartLoadMs", () => {
+        const restarted = new AgentRuntimeStateStore(path);
+        if (restarted.get("session-0")?.acknowledgedAt !== times[2]) throw new Error("persistence mismatch");
+      });
+      bytes = statSync(path).size;
+    }
+    console.log(JSON.stringify({ count, bytes, ...Object.fromEntries(Object.entries(results).map(([name, values]) => [name, median(values)])) }));
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/src/server/agent-status.ts
+++ b/src/server/agent-status.ts
@@ -531,8 +531,29 @@ export function agentRuntimeStatePath(): string {
   return process.env.WOLFPACK_AGENT_RUNTIME_STATE_PATH || resolve(homedir(), ".wolfpack", "agent-runtime-state.json");
 }
 
+function sameRuntimeState(previous: AgentRuntimeState | undefined, next: AgentRuntimeState): boolean {
+  if (!previous || previous.observedAt !== next.observedAt) return false;
+  const keys = Object.keys(next) as (keyof AgentRuntimeState)[];
+  return keys.length === Object.keys(previous).length
+    && keys.every((key) => Object.hasOwn(previous, key) && Object.is(previous[key], next[key]));
+}
+
+/** Freeze constructor-owned JSON, including any extension fields accepted on disk. */
+function freezePersistedState(state: AgentRuntimeState): void {
+  const pending: object[] = [state];
+  while (pending.length > 0) {
+    const value = pending.pop()!;
+    for (const child of Object.values(value)) {
+      if (child !== null && typeof child === "object") pending.push(child);
+    }
+    Object.freeze(value);
+  }
+}
+
+/** Single-owner projection: load once, update entries, then persist a batch. */
 export class AgentRuntimeStateStore {
-  private file: AgentRuntimeStateFile;
+  private readonly file: AgentRuntimeStateFile;
+  private dirty = true;
 
   constructor(readonly path = agentRuntimeStatePath()) {
     this.file = this.read();
@@ -557,15 +578,9 @@ export class AgentRuntimeStateStore {
       ...input,
       previous: this.file.sessions[input.sessionKey],
     });
-    this.file = {
-      schemaVersion: AGENT_RUNTIME_STATE_SCHEMA_VERSION,
-      sessions: {
-        ...this.file.sessions,
-        [input.sessionKey]: next,
-      },
-    };
+    const stored = this.set(input.sessionKey, next);
     if (options.persist !== false) this.write();
-    return next;
+    return stored;
   }
 
   acknowledge(sessionKey: string, transitionSequence: number, acknowledgedAt = new Date().toISOString()): AgentRuntimeState | null {
@@ -578,41 +593,60 @@ export class AgentRuntimeStateStore {
       acknowledgedSequence,
       unseen: current.transitionSequence > acknowledgedSequence,
     };
-    this.file = {
-      schemaVersion: AGENT_RUNTIME_STATE_SCHEMA_VERSION,
-      sessions: {
-        ...this.file.sessions,
-        [sessionKey]: next,
-      },
-    };
+    const stored = this.set(sessionKey, next);
     this.write();
-    return next;
+    return stored;
   }
 
   prune(
     activeSessionKeys: ReadonlySet<string>,
     options: { readonly persist?: boolean } = {},
   ): void {
-    const sessions = Object.fromEntries(
-      Object.entries(this.file.sessions).filter(([key]) => activeSessionKeys.has(key)),
-    );
-    this.file = { schemaVersion: AGENT_RUNTIME_STATE_SCHEMA_VERSION, sessions };
+    for (const key of Object.keys(this.file.sessions)) {
+      if (!activeSessionKeys.has(key)) {
+        delete this.file.sessions[key];
+        this.dirty = true;
+      }
+    }
     if (options.persist !== false) this.write();
   }
 
-  /** Persist a group of in-memory reductions with one full-file write. */
+  private set(sessionKey: string, next: AgentRuntimeState): AgentRuntimeState {
+    const previous = this.file.sessions[sessionKey];
+    if (sameRuntimeState(previous, next)) return previous!;
+    // Reducer values are flat; acknowledgement only shares already-frozen disk
+    // extensions. Never mutate old results or freeze caller-owned input graphs.
+    this.file.sessions[sessionKey] = Object.freeze(next);
+    this.dirty = true;
+    return next;
+  }
+
+  /** Persist pending reductions once; unchanged flushes do no serialization/write. */
   flush(): void {
     this.write();
   }
 
   private read(): AgentRuntimeStateFile {
-    if (!existsSync(this.path)) return { schemaVersion: AGENT_RUNTIME_STATE_SCHEMA_VERSION, sessions: {} };
+    // Null-prototype storage keeps opaque names such as __proto__ safe even
+    // though per-entry updates no longer use computed-property object spreads.
+    const sessions: Record<string, AgentRuntimeState> = Object.create(null);
+    const file: AgentRuntimeStateFile = { schemaVersion: AGENT_RUNTIME_STATE_SCHEMA_VERSION, sessions };
+    if (!existsSync(this.path)) return file;
     const parsed = JSON.parse(readFileSync(this.path, "utf-8")) as unknown;
-    if (!isAgentRuntimeStateFile(parsed)) return { schemaVersion: AGENT_RUNTIME_STATE_SCHEMA_VERSION, sessions: {} };
-    return parsed;
+    if (!isAgentRuntimeStateFile(parsed)) return file;
+    for (const [key, state] of Object.entries(parsed.sessions)) {
+      freezePersistedState(state);
+      sessions[key] = state;
+    }
+    this.dirty = false;
+    return file;
   }
 
   private write(): void {
+    // Preserve explicit flush/recreation after removal. This is not external
+    // writer/replacement detection: the existing load-once ownership model stays.
+    if (!this.dirty && existsSync(this.path)) return;
+    this.dirty = true; // Recreation attempts must also remain retryable on failure.
     const directory = dirname(this.path);
     mkdirSync(directory, { recursive: true, mode: 0o700 });
     const tmp = `${this.path}.tmp-${process.pid}-${randomBytes(6).toString("hex")}`;
@@ -634,6 +668,9 @@ export class AgentRuntimeStateStore {
       if (fd !== undefined) closeSync(fd);
       rmSync(tmp, { force: true });
     }
+    // Only a fully successful write/cleanup clears pending changes. An error
+    // retains the existing in-memory update and the next flush retries it.
+    this.dirty = false;
   }
 }
 

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll, beforeEach, afterEach, spyOn } from "bun:test";
+import * as fs from "node:fs";
 import type { Server } from "node:http";
 import { connect } from "node:net";
 import type { AddressInfo } from "node:net";
@@ -103,7 +104,7 @@ const {
   _testing: pushTesting,
 } = await import("../../src/server/push.ts");
 const { activePtySessions } = await import("../../src/server/websocket.ts");
-const { AgentRuntimeStateStore, __resetAgentRuntimeStateStoreForTests } = await import("../../src/server/agent-status.ts");
+const { AgentRuntimeStateStore, getAgentRuntimeStateStore, __resetAgentRuntimeStateStoreForTests } = await import("../../src/server/agent-status.ts");
 const { forgetSessionObservation } = await import("../../src/server/session-observation.ts");
 
 const {
@@ -315,6 +316,61 @@ describe("GET /api/sessions", () => {
     // Reset backend to known state
     mockBackend.setSessions(["wolf-1", "wolf-2"]);
     mockBackend.setCapturePane(async (s: string) => `captured output for ${s}\n`);
+  });
+
+  test("persists one real runtime-state write per changed dashboard batch, none for an identical batch", async () => {
+    mockBackend.setSessions(Array.from({ length: 100 }, (_, i) => `batch-${i}`));
+    const clock = spyOn(Date, "now").mockReturnValue(Date.parse("2026-07-25T00:00:00.000Z"));
+    const rename = spyOn(fs, "renameSync");
+    const runtimePath = process.env.WOLFPACK_AGENT_RUNTIME_STATE_PATH!;
+    const writes = () => rename.mock.calls.filter(([, destination]) => destination === runtimePath).length;
+    try {
+      const first = await (await get("/api/sessions")).json();
+      expect(first.sessions).toHaveLength(100);
+      expect(writes()).toBe(1);
+      expect(Object.keys(new AgentRuntimeStateStore(runtimePath).snapshot().sessions)).toHaveLength(100);
+      const same = await (await get("/api/sessions")).json();
+      expect(same.sessions.map((s: any) => s.runtimeState)).toEqual(first.sessions.map((s: any) => s.runtimeState));
+      expect(writes()).toBe(1);
+      clock.mockReturnValue(Date.parse("2026-07-25T00:01:00.000Z"));
+      await get("/api/sessions");
+      expect(writes()).toBe(2); // New observation timestamps must still persist.
+      mockBackend.setSessions([]);
+      await get("/api/sessions");
+      expect(writes()).toBe(3); // Real removals persist.
+      await get("/api/sessions");
+      expect(writes()).toBe(3); // Repeated empty observation does not rewrite.
+    } finally {
+      rename.mockRestore();
+      clock.mockRestore();
+    }
+  });
+
+  test("a capture-pending observation preserves an acknowledgement made while it awaited", async () => {
+    mockBackend.setSessions(["ack-flight"]);
+    mockBackend.setCapturePane(async () => "same screen\n");
+    const first = await (await get("/api/sessions")).json();
+    const sessionId = first.sessions[0].identity.wolfpackSessionId;
+    const transitionSequence = first.sessions[0].runtimeState.transitionSequence;
+    let started!: () => void;
+    let release!: () => void;
+    const capturing = new Promise<void>((resolve) => { started = resolve; });
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    mockBackend.setCapturePane(async () => { started(); await gate; return "same screen\n"; });
+    mockBackend.setOutputSequence("ack-flight", "1");
+    const pending = get("/api/sessions");
+    try {
+      await capturing;
+      // Apply the ack route's real store operation while capture is held.
+      expect(getAgentRuntimeStateStore().acknowledge(sessionId, transitionSequence)?.unseen).toBe(false);
+      release();
+      const observed = await (await pending).json();
+      expect(observed.sessions[0].runtimeState).toMatchObject({ transitionSequence, acknowledgedSequence: transitionSequence, unseen: false });
+      expect(new AgentRuntimeStateStore(process.env.WOLFPACK_AGENT_RUNTIME_STATE_PATH!).get(sessionId)).toMatchObject({ acknowledgedSequence: transitionSequence, unseen: false });
+    } finally {
+      release();
+      await pending;
+    }
   });
 
   test("returns session list with lastLine and triage", async () => {

--- a/tests/unit/agent-runtime-state-batching.test.ts
+++ b/tests/unit/agent-runtime-state-batching.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AgentRuntimeStateStore } from "../../src/server/agent-status.ts";
+import type { AgentRuntimeState, AgentRuntimeStateInput } from "../../src/server/agent-status.ts";
+
+const FIRST = "2026-07-25T00:00:00.000Z";
+const LATER = "2026-07-25T00:01:00.000Z";
+function input(sessionKey = "s1", observedAt = FIRST): AgentRuntimeStateInput {
+  return {
+    sessionKey,
+    broker: { state: "alive", observedAt },
+    sources: [],
+    fallback: { rawOutputChanged: false, observedAt },
+    currentRun: { runId: sessionKey, runOrder: 1 },
+  };
+}
+
+let dir: string;
+let path: string;
+let restores: (() => void)[];
+function track<T extends { mockRestore(): void }>(spy: T): T {
+  restores.push(() => spy.mockRestore());
+  return spy;
+}
+beforeEach(() => {
+  dir = fs.mkdtempSync(join(tmpdir(), "runtime-batching-"));
+  path = join(dir, "state.json");
+  restores = [];
+});
+afterEach(() => {
+  for (const restore of restores.reverse()) restore();
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("runtime-state batching ownership and work budgets", () => {
+  for (const size of [10, 100, 1_000]) {
+    test(`${size} per-entry updates never enumerate/copy the session map`, () => {
+      const store = new AgentRuntimeStateStore(path);
+      const keys = new Set(Array.from({ length: size }, (_, i) => `s${i}`));
+      for (const key of keys) store.reduce(input(key), { persist: false });
+      store.flush();
+      // Observe the real backing dictionary: do not mock away the production
+      // store/reducer. A spread, stringify or map replacement must fail here.
+      const file = Reflect.get(store, "file") as { sessions: Record<string, AgentRuntimeState> };
+      let enumerations = 0;
+      let reads = 0;
+      const backing = new Proxy(file.sessions, {
+        ownKeys(target) { enumerations++; return Reflect.ownKeys(target); },
+        get(target, key, receiver) { reads++; return Reflect.get(target, key, receiver); },
+      });
+      file.sessions = backing;
+      const rename = track(spyOn(fs, "renameSync"));
+      for (const key of keys) store.reduce(input(key, LATER), { persist: false });
+      expect(enumerations).toBe(0);
+      expect((Reflect.get(store, "file") as typeof file).sessions).toBe(backing);
+      expect(rename).toHaveBeenCalledTimes(0);
+      store.prune(keys, { persist: false });
+      store.flush();
+      expect(rename).toHaveBeenCalledTimes(1);
+      expect(enumerations).toBe(2); // One prune traversal, one serialization.
+      expect(reads).toBeLessThanOrEqual(4 * size + 5);
+      store.flush();
+      expect(enumerations).toBe(2); // A clean flush does not even serialize.
+      expect(rename).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  test("equivalent reductions, unchanged prune and clean/restarted flush do no writes", () => {
+    const store = new AgentRuntimeStateStore(path);
+    const first = store.reduce(input());
+    const bytes = fs.readFileSync(path, "utf8");
+    const inode = fs.statSync(path).ino;
+    const rename = track(spyOn(fs, "renameSync"));
+    const write = track(spyOn(fs, "writeFileSync"));
+    expect(store.reduce(input())).toBe(first);
+    store.prune(new Set(["s1"]));
+    store.flush();
+    new AgentRuntimeStateStore(path).flush();
+    expect(rename).toHaveBeenCalledTimes(0);
+    expect(write).toHaveBeenCalledTimes(0);
+    expect(fs.readFileSync(path, "utf8")).toBe(bytes);
+    expect(fs.statSync(path).ino).toBe(inode);
+  });
+
+  test("observation and acknowledgement timestamps remain meaningful changes", () => {
+    const store = new AgentRuntimeStateStore(path);
+    const first = store.reduce(input());
+    const rename = track(spyOn(fs, "renameSync"));
+    const observed = store.reduce(input("s1", LATER));
+    expect(observed.observedAt).toBe(LATER);
+    expect(observed.changedAt).toBe(first.changedAt);
+    expect(observed.transitionSequence).toBe(first.transitionSequence);
+    expect(rename).toHaveBeenCalledTimes(1);
+    const ack = store.acknowledge("s1", first.transitionSequence, FIRST);
+    expect(rename).toHaveBeenCalledTimes(2);
+    expect(store.acknowledge("s1", first.transitionSequence, FIRST)).toBe(ack);
+    expect(rename).toHaveBeenCalledTimes(2);
+    store.acknowledge("s1", first.transitionSequence, LATER);
+    expect(rename).toHaveBeenCalledTimes(3);
+    expect(new AgentRuntimeStateStore(path).get("s1")?.acknowledgedAt).toBe(LATER);
+    for (const sequence of [NaN, -1, 0.5, first.transitionSequence + 1]) {
+      expect(store.acknowledge("s1", sequence)).toBeNull();
+    }
+    expect(store.acknowledge("missing", first.transitionSequence)).toBeNull();
+    expect(rename).toHaveBeenCalledTimes(3);
+  });
+
+  test("old snapshots/results remain stable and public aliases cannot evade dirty tracking", () => {
+    const store = new AgentRuntimeStateStore(path);
+    const caller = input();
+    const first = store.reduce(caller);
+    const snapshot = store.snapshot();
+    expect(Object.isFrozen(caller)).toBe(false);
+    expect(Object.isFrozen(caller.broker)).toBe(false);
+    expect(Object.isFrozen(caller.currentRun)).toBe(false);
+    expect(Object.isFrozen(caller.sources)).toBe(false);
+    for (const value of [first, store.get("s1")!, snapshot.sessions.s1!]) {
+      expect(Object.isFrozen(value)).toBe(true);
+      expect(Reflect.set(value, "unseen", false)).toBe(false);
+    }
+    delete snapshot.sessions.s1;
+    expect(store.get("s1")).toBe(first);
+    const held = store.snapshot();
+    const ack = store.acknowledge("s1", first.transitionSequence, LATER)!;
+    expect(Object.isFrozen(ack)).toBe(true);
+    expect(first.unseen).toBe(true);
+    expect(held.sessions.s1).toBe(first);
+    store.reduce(input("s2"));
+    store.prune(new Set(["s2"]));
+    expect(Object.keys(held.sessions)).toEqual(["s1"]);
+    expect(store.get("s1")).toBeUndefined();
+    expect(new AgentRuntimeStateStore(path).get("s1")).toBeUndefined();
+  });
+
+  test("loaded extension graphs are owned/frozen and acknowledgement preserves them", () => {
+    const seed = new AgentRuntimeStateStore(path).reduce(input());
+    fs.writeFileSync(path, JSON.stringify({ schemaVersion: 1, sessions: {
+      s1: { ...seed, extension: { labels: ["original"] } },
+    } }));
+    const store = new AgentRuntimeStateStore(path);
+    const state = store.get("s1") as AgentRuntimeState & { extension: { labels: string[] } };
+    expect(Object.isFrozen(state.extension)).toBe(true);
+    expect(Reflect.set(state.extension.labels, "0", "mutated")).toBe(false);
+    store.acknowledge("s1", state.transitionSequence, LATER);
+    expect(JSON.parse(fs.readFileSync(path, "utf8")).sessions.s1.extension.labels).toEqual(["original"]);
+  });
+
+  test("opaque prototype-like session keys survive updates, snapshot, restart and pruning", () => {
+    const store = new AgentRuntimeStateStore(path);
+    const keys = ["__proto__", "constructor", "toString"];
+    for (const key of keys) {
+      expect(store.get(key)).toBeUndefined();
+      store.reduce(input(key), { persist: false });
+    }
+    store.flush();
+    expect(Object.keys(store.snapshot().sessions)).toEqual(keys);
+    const restarted = new AgentRuntimeStateStore(path);
+    for (const key of keys) expect(restarted.get(key)?.runId).toBe(key);
+    restarted.prune(new Set(["__proto__"]));
+    expect(restarted.get("constructor")).toBeUndefined();
+    expect(Object.keys(new AgentRuntimeStateStore(path).snapshot().sessions)).toEqual(["__proto__"]);
+  });
+
+  test("missing/invalid files are initialized, and deleting a clean file permits recreation", () => {
+    const store = new AgentRuntimeStateStore(path);
+    expect(fs.existsSync(path)).toBe(false);
+    store.flush();
+    expect(JSON.parse(fs.readFileSync(path, "utf8"))).toEqual({ schemaVersion: 1, sessions: {} });
+    expect(fs.statSync(path).mode & 0o777).toBe(0o600);
+    store.reduce(input());
+    fs.unlinkSync(path);
+    store.flush();
+    expect(new AgentRuntimeStateStore(path).get("s1")).toEqual(store.get("s1"));
+    fs.writeFileSync(path, '{"schemaVersion":0,"sessions":{}}');
+    const invalid = new AgentRuntimeStateStore(path);
+    invalid.flush();
+    expect(JSON.parse(fs.readFileSync(path, "utf8"))).toEqual({ schemaVersion: 1, sessions: {} });
+    fs.writeFileSync(path, "{invalid-json");
+    expect(() => new AgentRuntimeStateStore(path)).toThrow();
+  });
+
+  test("post-rename cleanup failure does not falsely mark the store clean", () => {
+    const store = new AgentRuntimeStateStore(path);
+    const first = store.reduce(input());
+    const cleanup = track(spyOn(fs, "rmSync").mockImplementationOnce(() => { throw new Error("cleanup failure"); }));
+    expect(() => store.acknowledge("s1", first.transitionSequence, LATER)).toThrow("cleanup failure");
+    cleanup.mockRestore();
+    // Rename already succeeded, but the public write operation failed.
+    expect(new AgentRuntimeStateStore(path).get("s1")?.acknowledgedAt).toBe(LATER);
+    const rename = track(spyOn(fs, "renameSync"));
+    store.flush();
+    expect(rename).toHaveBeenCalledTimes(1);
+    store.flush();
+    expect(rename).toHaveBeenCalledTimes(1);
+  });
+
+  test("failed recreation of a previously clean file remains retryable after rename", () => {
+    const store = new AgentRuntimeStateStore(path);
+    store.reduce(input());
+    fs.unlinkSync(path);
+    const cleanup = track(spyOn(fs, "rmSync").mockImplementationOnce(() => { throw new Error("cleanup failure"); }));
+    expect(() => store.flush()).toThrow("cleanup failure");
+    cleanup.mockRestore();
+    expect(fs.existsSync(path)).toBe(true);
+    const rename = track(spyOn(fs, "renameSync"));
+    store.flush();
+    expect(rename).toHaveBeenCalledTimes(1);
+  });
+
+  for (const operation of ["writeFileSync", "fsyncSync", "renameSync"] as const) {
+    test(`${operation} failure retains pending acknowledgement for retry`, () => {
+      const store = new AgentRuntimeStateStore(path);
+      const first = store.reduce(input());
+      const diskBefore = fs.readFileSync(path, "utf8");
+      const failure = track(spyOn(fs, operation).mockImplementationOnce(() => { throw new Error("injected persistence failure"); }));
+      expect(() => store.acknowledge("s1", first.transitionSequence, LATER)).toThrow("injected persistence failure");
+      expect(fs.readFileSync(path, "utf8")).toBe(diskBefore);
+      expect(store.get("s1")?.unseen).toBe(false); // Existing in-memory-on-error semantics.
+      expect(fs.readdirSync(dir)).toEqual(["state.json"]);
+      failure.mockRestore();
+      store.flush();
+      expect(new AgentRuntimeStateStore(path).get("s1")?.acknowledgedAt).toBe(LATER);
+      const rename = track(spyOn(fs, "renameSync"));
+      store.flush();
+      expect(rename).toHaveBeenCalledTimes(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Replace per-reduction whole-session-map spreads in `AgentRuntimeStateStore` with owned per-key updates. Existing dashboard/notification `persist:false` + `flush()` boundaries remain unchanged.

- A changed N-session observation no longer copies N whole maps. One prune traversal and one full-file serialization remain when the batch actually changes state.
- Equivalent reductions, unchanged pruning, and clean flushes avoid serialization/fsync/rename.
- **Normal observations with advancing `observedAt` still persist**, even when visible status is unchanged. This is not timestamp suppression or zero-I/O polling for nonempty dashboards.
- Old state values remain stable and are now runtime-frozen, matching their readonly TypeScript contract. Snapshot membership is a detached, caller-mutable copy. Persisted extension graphs are frozen without freezing caller-owned inputs.
- Null-prototype internal keys avoid introducing `__proto__`/`constructor` setter or inherited-property behavior.
- File format, real acknowledgement durability, temp-file permissions, fsync/rename and best-effort directory fsync are preserved. Failed writes—including post-rename cleanup and clean-file recreation failures—retain retry intent.
- Initial empty/invalid-schema files can be materialized; deleting a clean file permits recreation. Existing load-once/single-owner semantics remain: no external replacement detection, cross-process CAS, schema migration, notification policy change or extra global payload cache.

## Evidence / tradeoffs

Five-trial same-host local medians; fixture construction/input allocation excluded. Actual temporary stores and disk writes. Baseline source module and its imported contract are identical to base `72b1d71`; baseline agent-status blob `fdb056fe5868aec2df7cd0fe61d8a255440550d0` verified against the retained `b67372f` export used by the harness.

1,000-session fixture, persisted size **475,911 bytes**:

| Operation | Base ms | Candidate ms |
| --- | ---: | ---: |
| Changed in-memory reductions | 75.567 | 2.031 |
| Prune + real flush | 3.639 | 3.917 |
| Clean flush | 2.936 | 0.015 |
| Equivalent full batch + flush | 77.738 | 2.823 |
| Real acknowledgement | 2.653 | 3.841 |
| Restart/load | 1.730 | 3.078 |

**Tradeoff to review:** large batches improve greatly, but standalone acknowledgement and constructor/load are slower in this synthetic fixture (~45% and ~1.8x respectively); full-file persistence remains history-sized. Runtime immutability has a cost. At 10 sessions, real flushes were approximately unchanged (0.700→0.692 ms). Do not interpret these timings as production latency, requested heap bytes or RSS. Deterministic traversal/write budgets, not timing thresholds, are the CI gates.

Independent Sol measurements reproduced the gains and found somewhat larger 1,000-entry regressions across two runs: real prune/flush **+15–21%**, acknowledgement **+52–65%**, and restart/load **+68–92%**. Sol judged the tradeoff acceptable given the eliminated quadratic batch work and small absolute costs at 10 sessions, not as a universal latency improvement.

```sh
bun scripts/agent-runtime-state-perf.ts
bun scripts/agent-runtime-state-perf.ts /absolute/path/to/exact-base/src/server/agent-status.ts
```

Dirty tracking records changes since successful persistence, not a retained second durable snapshot. A change then reversal within a batch can still trigger a write. Entry derivation, explicit membership snapshots, pruning, persistence and serialization are not allocation-free.

## Verification

Exact head `23fdf7a00c7a4d45e35a6abe49a2e3fbd921cdf3`, base `72b1d71`.

- Full unit suite: **1,632 pass, 1 skip, zero failures**.
- API and control-schema integration: **201 pass, zero failures**.
- Typecheck and diff check pass; tracked implementation tree clean.
- 10/100/1,000-entry real-store budgets assert no session-map enumeration/replacement during reductions; only two traversals for changed prune+flush and one rename.
- Real `/api/sessions` batches establish one write for 100 changed sessions, none for equivalent repeats, and persistence for timestamps/removals.
- A capture-pending real observation retains an acknowledgement applied through the route's store operation while awaiting capture.
- Existing quiet-alert/shared-flight/epoch/retirement/unavailable/acknowledgement integration cases pass unchanged.
- Ownership, snapshots, opaque keys, malformed/missing/restarted stores, failure cleanup and retry coverage included.

## Review / rollout status

Implemented directly by the parent and subsequently independently reviewed by Sol at exact head `23fdf7a00c7a4d45e35a6abe49a2e3fbd921cdf3`. **Sol: APPROVE, no blocking findings.** Independent verification: 1,632 unit pass / 1 skip, 201 API+schema integration pass, 83 focused pass, typecheck/diff check pass. An exact-base private probe confirms the work-budget regression is non-vacuous. Both GitHub test and ghostty-vt-behavior checks passed. Review task `8119b04b-b063-4235-b10f-64b28aa5264f` acknowledged; draft gate cleared.

No merge or deployment performed for this change. Main user checkout and unrelated untracked docs preserved. PR #347 was closed unmerged and is not included.
