### PR TITLE
perf: batch relay endpoint lookups when listing sessions

### DIFF
--- a/scripts/relay-session-lookup-perf.ts
+++ b/scripts/relay-session-lookup-perf.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env bun
+/** Temporary-store lookup benchmark; no live relay/session access.
+ * Optional first argument: exact-base src/task-relay/store.ts module path.
+ * Fixture seeding and correctness checks are outside measured operations.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { canonicalJson } from "../src/canonical-json.ts";
+import { RELAY_ID, RELAY_PROTOCOL_VERSION } from "../src/task-relay/domain.ts";
+
+const modulePath = process.argv[2] ? resolve(process.argv[2]) : resolve(import.meta.dir, "../src/task-relay/store.ts");
+const { TaskRelayStore } = await import(pathToFileURL(modulePath).href) as typeof import("../src/task-relay/store.ts");
+const now = new Date("2026-08-09T00:00:00.000Z");
+const registrations = Array.from({ length: 20 }, (_, i) => ({
+  sessionId: `session-${i}`, endpoint: { relay: RELAY_ID, id: randomUUID() }, generation: "generation-1",
+  protocolVersions: [RELAY_PROTOCOL_VERSION], leaseExpiresAt: new Date(now.getTime() + 60_000).toISOString(),
+}));
+const ids = registrations.map(r => r.sessionId);
+function fixture(count: number): string {
+  const envelopes = Array.from({ length: count }, (_, i) => {
+    const envelope = {
+      envelopeId: `fixture-envelope-${i}`, protocolVersion: RELAY_PROTOCOL_VERSION,
+      source: registrations[0]!.endpoint, target: registrations[1]!.endpoint,
+      payload: { index: i, content: "x".repeat(1_024) }, createdAt: now.toISOString(),
+    };
+    return { envelope, digest: createHash("sha256").update(canonicalJson(envelope)).digest("hex"), acceptedAt: now.toISOString(), acceptanceId: randomUUID() };
+  });
+  return JSON.stringify({ version: 2, registrations, envelopes,
+    mailbox: envelopes.map((item, i) => ({ endpointId: item.envelope.target.id, envelopeId: item.envelope.envelopeId, cursor: String(i + 1) })),
+    mailboxCursors: count ? [{ endpointId: registrations[1]!.endpoint.id, cursor: String(count) }] : [],
+    peerRoutes: [], outbox: [],
+  }) + "\n";
+}
+const median = (values: number[]) => Number(values.sort((a, b) => a - b)[Math.floor(values.length / 2)]!.toFixed(3));
+const root = mkdtempSync(join(tmpdir(), "relay-lookup-perf-"));
+try {
+  const store = new TaskRelayStore(root);
+  console.log(JSON.stringify({ modulePath, scope: "3-trial warm-filesystem medians in ms; store operations, not RSS/HTTP/production latency; 20 sessions, 1 KiB envelope payloads" }));
+  for (const envelopes of [0, 1_000, 5_000]) {
+    const source = fixture(envelopes);
+    const single: number[] = [];
+    const batch: number[] = [];
+    const register: number[] = [];
+    for (let trial = 0; trial < 3; trial++) {
+      writeFileSync(store.path, source, { mode: 0o600 });
+      // Exercise the same validated parser once before measurements.
+      await store.registrationForSession(ids[0]!, now);
+      let start = performance.now();
+      const repeated = await Promise.all(ids.map(id => store.registrationForSession(id, now)));
+      single.push(performance.now() - start);
+      if (repeated.some((r, i) => r?.endpoint.id !== registrations[i]!.endpoint.id)) throw new Error("scalar lookup mismatch");
+      if (typeof store.registrationsForSessions === "function") {
+        start = performance.now();
+        const selected = await store.registrationsForSessions(ids, now);
+        batch.push(performance.now() - start);
+        if (selected.size !== ids.length || ids.some((id, i) => selected.get(id)?.endpoint.id !== repeated[i]!.endpoint.id)) throw new Error("batch lookup mismatch");
+      }
+      start = performance.now();
+      await store.register({ ...registrations[0]!, leaseExpiresAt: new Date(now.getTime() + 120_000).toISOString() });
+      register.push(performance.now() - start);
+    }
+    console.log(JSON.stringify({ envelopes, bytes: Buffer.byteLength(source), scalar20Ms: median(single), ...(batch.length && { batch20Ms: median(batch) }), realRegistrationMs: median(register) }));
+  }
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}

--- a/src/server/session-control-routes.ts
+++ b/src/server/session-control-routes.ts
@@ -264,10 +264,12 @@ export const sessionControlRoutes: Record<string, RouteHandler> = {
       if (!identities || names.some(name => !identities[name])) {
         return json(res, { error: "session identity unavailable" }, 503);
       }
-      const sessions = (await Promise.all(names.map(async (name) => {
+      if (names.length === 0) return json(res, { sessions: [] });
+      const endpoints = await getTaskRelayGateway().endpointsForSessions(names.map(name => identities[name]!.wolfpackSessionId));
+      const sessions = names.map((name) => {
         const identity = identities[name]!;
-        return sessionStatusPayload(name, identity, await getTaskRelayGateway().endpointForSession(identity.wolfpackSessionId));
-      }))).sort((left, right) => left.session.localeCompare(right.session));
+        return sessionStatusPayload(name, identity, endpoints.get(identity.wolfpackSessionId));
+      }).sort((left, right) => left.session.localeCompare(right.session));
       json(res, { sessions });
     } catch (error: unknown) {
       log.warn("session-control list failed", { error: errMsg(error) });

--- a/src/task-relay/gateway.ts
+++ b/src/task-relay/gateway.ts
@@ -183,6 +183,13 @@ export class TaskRelayGateway {
     return (await this.#store.registrationForSession(sessionId, this.#now()))?.endpoint;
   }
 
+  async endpointsForSessions(sessionIds: readonly string[]): Promise<ReadonlyMap<string, RelayEndpoint>> {
+    const registrations = await this.#store.registrationsForSessions(sessionIds, this.#now());
+    const endpoints = new Map<string, RelayEndpoint>();
+    for (const [sessionId, registration] of registrations) endpoints.set(sessionId, registration.endpoint);
+    return endpoints;
+  }
+
   async disconnect(input: { readonly callerSession: string; readonly endpoint: RelayEndpoint }): Promise<RelayResult<Record<never, never>>> {
     if (!isRelayEndpoint(input.endpoint)) return relayFailure(RELAY_ERROR.INVALID_REQUEST, "invalid relay endpoint");
     const caller = await this.#caller(input.callerSession);

--- a/src/task-relay/store.ts
+++ b/src/task-relay/store.ts
@@ -319,6 +319,22 @@ export class TaskRelayStore {
     return this.#read().registrations.find((item) => item.sessionId === sessionId && Date.parse(item.leaseExpiresAt) > now.getTime());
   }
 
+  /** One fresh validated read for a batch; no cache or retained payload graph. */
+  async registrationsForSessions(sessionIds: readonly string[], now: Date): Promise<ReadonlyMap<string, RelayRegistration>> {
+    const requested = new Set(sessionIds);
+    const selected = new Map<string, RelayRegistration>();
+    if (requested.size === 0) return selected;
+    const nowMs = now.getTime();
+    for (const registration of this.#read().registrations) {
+      if (requested.has(registration.sessionId) && !selected.has(registration.sessionId)
+        && Date.parse(registration.leaseExpiresAt) > nowMs) {
+        // Preserve find() semantics: first ACTIVE match, not first/last stored.
+        selected.set(registration.sessionId, registration);
+      }
+    }
+    return selected;
+  }
+
   async registration(endpointId: string, now: Date): Promise<RelayRegistration | undefined> {
     return this.#read().registrations.find((item) => item.endpoint.id === endpointId && Date.parse(item.leaseExpiresAt) > now.getTime());
   }

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -2239,6 +2239,63 @@ describe("GET /api/sessions", () => {
   });
 });
 
+describe("session-control relay lookup batching", () => {
+  test("lists stable-ID endpoints with one fresh read, fails closed, and skips empty-list relay reads", async () => {
+    const { TaskRelayStore } = await import("../../src/task-relay/store.ts");
+    const { TaskRelayGateway, __setTaskRelayGatewayForTests } = await import("../../src/task-relay/gateway.ts");
+    const { RELAY_ID, RELAY_PROTOCOL_VERSION } = await import("../../src/task-relay/domain.ts");
+    const { randomUUID } = await import("node:crypto");
+    const relayRoot = mkdtempSync(join(TEST_DEV_DIR, "relay-list-batch-"));
+    const store = new TaskRelayStore(relayRoot);
+    const now = new Date("2026-08-09T00:00:00.000Z");
+    const names = Array.from({ length: 20 }, (_, i) => `relay-list-${19 - i}`);
+    const backend = new MockBackend({ sessions: names });
+    const identities = await backend.listIdentities();
+    const registrations = names.map(name => ({
+      sessionId: identities[name]!.wolfpackSessionId,
+      endpoint: { relay: RELAY_ID, id: randomUUID() }, generation: "process-1",
+      protocolVersions: [RELAY_PROTOCOL_VERSION], leaseExpiresAt: new Date(now.getTime() + 60_000).toISOString(),
+    }));
+    for (const registration of registrations) await store.register(registration);
+    const previousGateway = getTaskRelayGateway();
+    const gateway = new TaskRelayGateway({ root: relayRoot, now: () => now });
+    __setTaskRelayGatewayForTests(gateway);
+    __setTestBackend(backend);
+    const read = spyOn(fs, "readFileSync");
+    const relayReads = () => read.mock.calls.filter(([path]) => path === store.path).length;
+    try {
+      const response = await get("/api/session-control/list");
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.sessions.map((s: any) => s.session)).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+      for (const registration of registrations) {
+        expect(body.sessions.find((s: any) => s.sessionId === registration.sessionId)?.taskEndpoint).toEqual(registration.endpoint);
+      }
+      expect(relayReads()).toBe(1);
+      await store.deactivateRegistration(registrations[0]!.sessionId, registrations[0]!.endpoint.id, now.toISOString());
+      read.mockClear();
+      const updated = await (await get("/api/session-control/list")).json();
+      expect(updated.sessions.find((s: any) => s.sessionId === registrations[0]!.sessionId)).not.toHaveProperty("taskEndpoint");
+      expect(relayReads()).toBe(1);
+      writeFileSync(store.path, "{malformed");
+      read.mockClear();
+      expect((await get("/api/session-control/list")).status).toBe(503);
+      expect(relayReads()).toBe(1);
+      backend.setSessions([]);
+      read.mockClear();
+      const empty = await get("/api/session-control/list");
+      expect(empty.status).toBe(200);
+      expect(await empty.json()).toEqual({ sessions: [] });
+      expect(relayReads()).toBe(0);
+    } finally {
+      read.mockRestore();
+      __setTaskRelayGatewayForTests(previousGateway);
+      __setTestBackend(mockBackend);
+      rmSync(relayRoot, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("agent-native top-level session control", () => {
   beforeEach(() => {
     mockBackend.setSessions(["wolf-1", "wolf-2"]);

--- a/tests/unit/task-relay-session-batch.test.ts
+++ b/tests/unit/task-relay-session-batch.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import * as fs from "node:fs";
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { RELAY_ID, RELAY_PROTOCOL_VERSION } from "../../src/task-relay/domain.ts";
+import type { RelayRegistration } from "../../src/task-relay/domain.ts";
+import { TaskRelayStore } from "../../src/task-relay/store.ts";
+import { TaskRelayGateway } from "../../src/task-relay/gateway.ts";
+
+const NOW = new Date("2026-08-09T00:00:00.000Z");
+function registration(sessionId: string, leaseExpiresAt = new Date(NOW.getTime() + 60_000).toISOString()): RelayRegistration {
+  return { sessionId, endpoint: { relay: RELAY_ID, id: randomUUID() }, generation: randomUUID(), protocolVersions: [RELAY_PROTOCOL_VERSION], leaseExpiresAt };
+}
+function state(registrations: readonly RelayRegistration[]) {
+  return { version: 2, registrations, envelopes: [], mailbox: [], mailboxCursors: [], peerRoutes: [], outbox: [] };
+}
+let root: string;
+let store: TaskRelayStore;
+beforeEach(() => {
+  root = fs.mkdtempSync(join(tmpdir(), "relay-session-batch-"));
+  store = new TaskRelayStore(root);
+});
+afterEach(() => { fs.rmSync(root, { recursive: true, force: true }); });
+function seed(registrations: readonly RelayRegistration[]) {
+  fs.writeFileSync(store.path, JSON.stringify(state(registrations)));
+}
+
+describe("fresh batched relay registration lookup", () => {
+  for (const count of [1, 20, 100]) {
+    test(`${count} lookups read/validate once and traverse registration timestamps linearly`, async () => {
+      const registrations = Array.from({ length: 1_000 }, (_, i) => registration(`session-${i}`));
+      seed(registrations);
+      const ids = registrations.slice(0, count).map(r => r.sessionId);
+      const read = spyOn(fs, "readFileSync");
+      const parse = spyOn(Date, "parse");
+      const write = spyOn(fs, "writeFileSync");
+      try {
+        const selected = await store.registrationsForSessions(ids, NOW);
+        expect(selected.size).toBe(count);
+        expect(read).toHaveBeenCalledTimes(1);
+        expect(parse).toHaveBeenCalledTimes(1_000 + count); // Validation + requested lease checks.
+        expect(write).toHaveBeenCalledTimes(0);
+        for (const r of registrations.slice(0, count)) expect(selected.get(r.sessionId)).toEqual(r);
+      } finally {
+        read.mockRestore(); parse.mockRestore(); write.mockRestore();
+      }
+    });
+  }
+
+  test("matches scalar first-active selection for duplicates, expiry, missing and opaque keys", async () => {
+    const expired = registration("duplicate", NOW.toISOString());
+    const active = registration("duplicate");
+    const later = registration("duplicate");
+    seed([expired, active, later, registration("__proto__"), registration("constructor"), registration("expired", NOW.toISOString())]);
+    const ids = ["constructor", "duplicate", "missing", "expired", "__proto__", "duplicate"];
+    const selected = await store.registrationsForSessions(ids, NOW);
+    expect(selected.get("duplicate")).toEqual(active);
+    expect(selected.size).toBe(3);
+    for (const id of ids) expect(selected.get(id)).toEqual(await store.registrationForSession(id, NOW));
+    expect((await store.registrationsForSessions(ids, new Date(NOW.getTime() + 60_000))).size).toBe(0);
+  });
+
+  test("each call sees replacement/deletion and one store instance sees another's writes", async () => {
+    const first = registration("s1");
+    seed([first]);
+    expect((await store.registrationsForSessions(["s1"], NOW)).get("s1")).toEqual(first);
+    const replacement = registration("s1");
+    fs.writeFileSync(join(root, "replacement"), JSON.stringify(state([replacement])));
+    fs.renameSync(join(root, "replacement"), store.path);
+    expect((await store.registrationsForSessions(["s1"], NOW)).get("s1")).toEqual(replacement);
+    const secondStore = new TaskRelayStore(root);
+    const next = registration("s1");
+    await secondStore.register(next);
+    expect((await store.registrationsForSessions(["s1"], NOW)).get("s1")).toEqual(next);
+    fs.unlinkSync(store.path);
+    expect((await store.registrationsForSessions(["s1"], NOW)).size).toBe(0);
+    seed([first]);
+    expect((await store.registrationsForSessions(["s1"], NOW)).get("s1")).toEqual(first);
+  });
+
+  test("result and input mutations cannot alter disk or subsequent batches", async () => {
+    const original = registration("s1");
+    seed([original]);
+    const ids = ["s1"];
+    const pending = store.registrationsForSessions(ids, NOW);
+    ids[0] = "other";
+    const selected = await pending;
+    Reflect.set(selected.get("s1")!.endpoint, "id", randomUUID());
+    (selected as Map<string, RelayRegistration>).clear();
+    expect((await store.registrationsForSessions(["s1"], NOW)).get("s1")).toEqual(original);
+    expect(JSON.parse(fs.readFileSync(store.path, "utf8"))).toEqual(state([original]));
+  });
+
+  test("empty selection does not read/reset even a malformed or legacy store", async () => {
+    for (const source of ["{invalid", '{"version":1}']) {
+      fs.writeFileSync(store.path, source);
+      const read = spyOn(fs, "readFileSync");
+      try {
+        expect((await store.registrationsForSessions([], NOW)).size).toBe(0);
+        expect(read).toHaveBeenCalledTimes(0);
+      } finally { read.mockRestore(); }
+      expect(fs.readFileSync(store.path, "utf8")).toBe(source);
+    }
+  });
+
+  test("nonempty legacy lookup preserves durable v1 reset", async () => {
+    fs.writeFileSync(store.path, '{"version":1}');
+    expect((await store.registrationsForSessions(["s1"], NOW)).size).toBe(0);
+    expect(JSON.parse(fs.readFileSync(store.path, "utf8"))).toEqual(state([]));
+  });
+
+  test("gateway projects endpoints with one clock sample and no cross-call lease cache", async () => {
+    const a = registration("a");
+    const b = registration("b");
+    seed([a, b]);
+    let clockCalls = 0;
+    const gateway = new TaskRelayGateway({ root, now: () => new Date(NOW.getTime() + clockCalls++ * 60_000) });
+    try {
+      const endpoints = await gateway.endpointsForSessions(["b", "a", "missing"]);
+      expect(clockCalls).toBe(1);
+      expect(endpoints.get("a")).toEqual(a.endpoint);
+      expect(endpoints.get("b")).toEqual(b.endpoint);
+      expect(endpoints.has("missing")).toBe(false);
+      expect((await gateway.endpointsForSessions(["a", "b"])).size).toBe(0);
+      expect(clockCalls).toBe(2);
+    } finally { gateway.close(); }
+  });
+});

--- a/tests/unit/task-relay.test.ts
+++ b/tests/unit/task-relay.test.ts
@@ -86,6 +86,7 @@ function storeOperations(store: TaskRelayStore): readonly (() => Promise<unknown
   return [
     () => store.register(VALID_REGISTRATION),
     () => store.registrationForSession("sender", NOW),
+    () => store.registrationsForSessions(["sender", "receiver"], NOW),
     () => store.registration(SENDER_ID, NOW),
     () => store.deactivateRegistration("sender", SENDER_ID, NOW.toISOString()),
     () => store.accept(LOCAL_ENVELOPE, NOW.toISOString()),


### PR DESCRIPTION
## Summary

A narrow relay read-batching improvement for `GET /api/session-control/list` / `wolfpack list`.

Previously, each session endpoint lookup reread, parsed and validated the entire relay file. Listing 20 sessions meant 20 full reads/validations—even though all lookups belonged to one request.

- Add one request-scoped `registrationsForSessions` lookup and gateway endpoint projection.
- Read/validate the file once, scan registrations once, and key results by stable session ID.
- Preserve first **active** duplicate matching, exact lease expiry, sorted response shape, omitted unavailable endpoints, malformed-store rejection and existing v1 reset behavior.
- Empty lists still avoid relay access; incomplete backend identity information still fails closed.
- Returned data is detached from disk and future calls. No process-global or persistent payload cache, no cross-call index, no schema change, and **no changes to any existing mutation/write function**.

This does **not** reopen/include the cached relay rewrite from closed PR #347. It is a fresh, small implementation on current main, which now includes #353. Single-endpoint reads, envelope writes, inbox/outbox maintenance and dashboard `/api/sessions` polling are not optimized here.

## Measurements

Three-trial synthetic warm-filesystem medians, 20 sessions and 1 KiB payloads. Fixture seeding and correctness checks excluded. Same committed harness; baseline module and all its local imports are byte-identical to base `0a021af` (also present in retained `b67372f` export).

| Retained envelopes | File bytes | Base: 20 scalar lookups | Candidate: one batch |
| ---: | ---: | ---: | ---: |
| 0 | 4,298 | 1.868 ms | 0.109 ms |
| 1,000 | 1,621,928 | 355.822 ms | 19.047 ms |
| 5,000 | 8,109,928 | 1,827.593 ms | 90.303 ms |

At 5,000 envelopes, real registration writes measured **166.648 ms baseline / 162.864 ms candidate**; no material write regression observed in this run, and the mutation implementation is unchanged. This is not a guarantee about production latency or every workload.

Independent Sol runs against a private exact-base archive reproduced **19.7–23.4×** batching gains at 5,000 envelopes. Absolute timings were slower than the parent's run, and write measurements varied with run order (candidate −14.9% to +2.4% at 5,000 envelopes); no stable material write regression was found.

The batch still incurs one history-sized read/parse/digest validation (about 90 ms for the synthetic 8 MB fixture), plus request-sized metadata projection. These are store timings, **not full HTTP latency, measured RSS or requested heap bytes**. There is no persistent cache to retain parsed message history between requests.

```sh
bun scripts/relay-session-lookup-perf.ts
bun scripts/relay-session-lookup-perf.ts /absolute/path/to/exact-base/src/task-relay/store.ts
```

## Verification

Exact head: `06055465bd0fc6eaf01b2fbfda19ad6514886586`.
Base: `0a021afc950f9c4d326662709974d490de286418`.

- **1,641 unit pass / 1 pre-existing skip**, zero failures.
- **205 API + relay + control-schema integration pass**, zero failures.
- Typecheck and diff check pass; tracked implementation tree clean.
- 1/20/100 requested-session tests assert one real file read/validation and bounded timestamp work across 1,000 registrations; no v2 lookup writes.
- Existing malformed/corrupt fixture table exercises the new nonempty batch method too.
- Tests cover expiry, first-active duplicates, opaque keys, replacement/deletion/recreation, another store instance's writes, detached results/input capture, empty selection and legacy v1 reset.
- Actual session-list API test asserts one read for 20 sessions, stable-ID endpoint matching/sorting, fresh revocation, malformed-store 503, and zero relay reads for an empty list.
- A private process-only mutant kept the batch API but restored scalar lookup loops. The new API budget test failed as intended: **20 reads received / 1 expected**.

## Scope / review status

Each batch uses one file observation and one request-time lease cutoff. Endpoint discovery is not a permanent authorization grant; existing send/ownership/lease checks remain separate. This does not add stronger cross-process replacement/linearizability guarantees to the existing loader. Existing legacy-v1 reads can still perform the deliberate durable reset.

Cross-machine communication remains routed through each machine's own relay and its opaque peer-route mapping; this batch is scoped to one server's session-list request. Sol independently exercised two isolated relay roots with overlapping session names: remote CLI selection of B, B's batched endpoint discovery (one B read / zero A reads), A-owned opaque peer resolution, A→B delivery, B→A reply, and both acknowledgements. The private scenario passed, as did all four remote CLI routing tests. **Transport was simulated/local; this revision has not been tested live across two Tailnet machines.**

**Independent Sol verdict: APPROVE exact `06055465bd0fc6eaf01b2fbfda19ad6514886586`, no blocking findings.** Independently reproduced 1,641 unit pass / 1 skip, 205 integration pass, 36 focused pass, typecheck/diff check, and the scalar-loop mutant's expected 20-vs-1 read failure. Both GitHub test and ghostty-vt-behavior checks passed. Review task `332b4807-f23f-40f8-a40f-5cf3d045073b` acknowledged; draft gate cleared.

No merge or deployment performed. Main checkout and unrelated docs preserved; no live services restarted for this change.
