### PR TITLE
feat: add bounded relay engine and investigation logging primitives

### DIFF
--- a/docs/memory-owned-relay-design.md
+++ b/docs/memory-owned-relay-design.md
@@ -211,3 +211,18 @@ broker, installed-package modification or service restart is involved.
 
 The audit exits nonzero when it reproduces compatibility defects. This is a
 pre-change diagnostic, not a passing regression proving the redesign works.
+
+Recorded on audit revision `43dc7af3ca74c1ad452eb6cd155d609a0d07f475`, using
+installed `@sgtbeatdown/pi-tasks` 0.1.7 (adapter source SHA-256
+`42380e582702b59071f26323c6fd1fec41b198954f289379317f8e5dd0b2605d`):
+
+- Injected lost response produced `RELAY_UNAVAILABLE`; retrying the same logical
+  envelope produced **`ENVELOPE_CONFLICT`** because wire `createdAt` changed.
+- The real gateway accepted the original only once; exact-wire retry returned
+  `duplicate`, and genuinely changed payload still returned `ENVELOPE_CONFLICT`.
+- Simulated removal of cursor 1 exposed a real second-page envelope at cursor 2;
+  the installed adapter assigned it **cursor 1**, confirming incompatibility with
+  pending-only pages, not demonstrating a current retained-row paging failure.
+- Audit exit **1** (defects reproduced). Typecheck and diff checks passed on that
+  revision. No production behavior was changed; neither bug is fixed by this
+  design/audit commit. This is not an end-to-end task-core or live-network test.

--- a/docs/memory-owned-relay-design.md
+++ b/docs/memory-owned-relay-design.md
@@ -266,6 +266,18 @@ was removed after preserving evidence. This is **not** an all-green integration
 or native validation result. Subsequent hardlink rejection in the investigation
 writer is additional source hardening, not a fix for that baseline failure.
 
+The cleanup regression is now isolated from the operator's login-shell startup
+and installed provider CLIs: its child has private shell/executable-probe/Pi
+fixtures, while still executing the real schema HTTP suite and provider version
+probe. The original 3-second child and 4.5-second outer deadlines are unchanged.
+Instrumentation established that the stdin gate completed; server login-shell
+initialization followed by real `/api/providers` probes consumed the deadline.
+Merely setting the inherited PATH was insufficient because server import restores
+the login-shell PATH. The fixed test additionally checks unchanged sentinel
+contents and that the owned provider was actually probed. A private unsafe-cleanup
+mutant completed the eight schema tests but failed on the deleted sentinel,
+confirming this is not a weakened or vacuous cleanup regression.
+
 ### Compatibility reproduction
 
 `scripts/relay-memory-compat-audit.ts` accepts an explicit absolute adapter source

--- a/docs/memory-owned-relay-design.md
+++ b/docs/memory-owned-relay-design.md
@@ -249,6 +249,23 @@ live-process reset handling and upstream immutable timestamp/terminal-error
 handling must land together before changing production behavior. No benchmark or
 release-readiness claim follows from this isolated engine slice.
 
+### Initial engine validation and remaining failures
+
+At `4d5b3f971f60953902f33372fe647fa1f3022ec6`, typecheck passed and the
+full unit suite reported **1,698 pass, 1 skip, 0 fail**. Three private mutants
+were rejected by their focused regressions: retained ACKed payload/mailbox rows,
+exhaustion disguised as pending, and a stranded logger completion wake.
+
+The full integration suite reported **427 pass, 22 broker-dependent skips,
+1 fail**. The unchanged `control-api-schema-temp-cleanup.test.ts` child hit its
+3-second timeout (exit 137). The same failure reproduced in a clean worktree at
+merged base `175861b49045e5c5e7859261f081aa8d912d0a4c`; that isolated probe was
+also marked incomplete because the executor terminated lingering descendants.
+No timing bound or unrelated test was weakened. The temporary baseline worktree
+was removed after preserving evidence. This is **not** an all-green integration
+or native validation result. Subsequent hardlink rejection in the investigation
+writer is additional source hardening, not a fix for that baseline failure.
+
 ### Compatibility reproduction
 
 `scripts/relay-memory-compat-audit.ts` accepts an explicit absolute adapter source

--- a/docs/memory-owned-relay-design.md
+++ b/docs/memory-owned-relay-design.md
@@ -1,9 +1,10 @@
 # Memory-owned relay: proposed contract (#351)
 
-Status: **design/compatibility gate, not implemented or approved for cutover**.
+Status: **defaults approved; implementation in progress, no production cutover**.
 Based on merged #359 (`175861b49045e5c5e7859261f081aa8d912d0a4c`).
-This document proposes the decisions needed before replacing the operational
-store. Neither existing installations nor historical files are changed.
+The user approved destination-mailbox-confirmed acceptance, bounded retries/hard
+pre-admission limits, and best-effort private investigation logging on 2026-09-08.
+Neither existing installations nor historical files are changed.
 
 ## Scope and ownership
 
@@ -174,8 +175,9 @@ authorized coordination.
 
 ## 5. Verification and implementation sequence
 
-1. Resolve the acceptance/no-rearm, logging-loss and compatibility-cutover choices
-   above. Record final field/error/expiry contracts in Wolfpack and adapter docs.
+1. Acceptance/no-rearm, hard bounds and logging-loss defaults are approved.
+   Finish the coordinated wire field/error/expiry and compatibility-cutover
+   contracts in Wolfpack and adapter docs; do not silently cut over old clients.
 2. Add behavior tests for a bounded, instance-owned engine: atomic multi-budget
    admission, credit recovery, ownership, opaque keys, genuine content conflicts,
    strict leases, cursor gaps, duplicate ACKs, expired receipts and bounded expiry
@@ -198,6 +200,54 @@ authorized coordination.
    process RSS including workers and accounting high-water marks. Publish commands,
    input hashes, hardware, latency budgets, failures and regressions. Archive size
    must not change operational parse/scan/write work; this is not live-fleet proof.
+
+### First implementation slice (not connected to production)
+
+- `src/task-relay/memory-store.ts`: instance-owned epoch, registration/generation
+  and route indexes, owned encoded active envelopes, per-mailbox monotonic decimal
+  cursors, atomic multi-budget admission, ACK release, compact receipts, and
+  token-owned forwarding attempts. No root/path, filesystem, network or timers.
+- `src/task-relay/expiry-index.ts`: indexed min-heap with exactly one node per
+  expiring owner. Renewals replace nodes; maintenance processes a bounded batch.
+- `src/task-relay/investigation.ts`: data-only capture into an independently
+  bounded async queue. Queue accounting includes the in-flight write. A fixed-slot
+  private writer rotates before overflow; partial historical records are never
+  appended into on restart. A coalesced cleanup request uses the same writer queue
+  to avoid races and permit idle retention cleanup. Gateway timer wiring remains.
+- `tests/unit/task-relay-memory.test.ts` and
+  `tests/unit/task-relay-investigation.test.ts`: budget/ownership/expiry/cursor,
+  retry and log-failure tests, including two independent engine instances with
+  a lost peer response and 5,000 completed payloads. These are **not** real HTTP,
+  worker packaging, actual adapter, two-host, or performance measurements.
+
+The engine keeps routes stable for its lifetime rather than silently evicting
+aliases. Expired registrations remain pinned by obligations/receipts. Its current
+retry policy uses the immutable wire creation timestamp with 30 seconds of clock
+skew allowance, a two-minute admission/attempt-start horizon, and the agreed
+15-minute terminal receipt window. No new network attempt starts after deadline;
+a still-owned bounded in-flight call may subsequently confirm acceptance.
+The gateway must enforce network deadlines; worker loss instead loses its epoch.
+
+Receipt byte reservations are conservative upper bounds for retained metadata,
+not native allocation measurements. Registration and receipt counts also bound
+secondary indexes. The byte ceiling can bind before the count ceiling; the
+receipt window limits sustained admission rate and must be benchmarked/tuned
+rather than advertised as unlimited throughput.
+
+The writer retains at most 16 × 16 MiB fixed segments. Age is measured from
+segment creation, never refreshed by appends. Unknown filesystem creation times
+expire conservatively. Cleanup requires the gateway timer while running and
+rechecks old slots on next startup; no cleanup service runs while Wolfpack is
+stopped. Investigation health exposes dropped/invalid records, dropped bytes,
+write/maintenance failures and bounded error categories, without raw exception
+messages. Exporting health and rate-limited warnings at the gateway remains.
+
+`TaskRelayGateway`, its worker entry, HTTP routes and the installed adapter still
+use the existing contract. The new engine is deliberately not a drop-in store
+facade: negotiation, broker-authorized gateway integration, explicit cursors,
+live-process reset handling and upstream immutable timestamp/terminal-error
+handling must land together before changing production behavior. No benchmark or
+release-readiness claim follows from this isolated engine slice.
 
 ### Compatibility reproduction
 

--- a/docs/memory-owned-relay-design.md
+++ b/docs/memory-owned-relay-design.md
@@ -1,0 +1,213 @@
+# Memory-owned relay: proposed contract (#351)
+
+Status: **design/compatibility gate, not implemented or approved for cutover**.
+Based on merged #359 (`175861b49045e5c5e7859261f081aa8d912d0a4c`).
+This document proposes the decisions needed before replacing the operational
+store. Neither existing installations nor historical files are changed.
+
+## Scope and ownership
+
+Each relay worker owns its registrations, opaque peer routes, pending mailboxes,
+forwarding attempts and compact receipts in memory. No SQL, shared filesystem,
+spool, crash journal, startup replay or full-state snapshot rewrite is involved.
+Investigation output is separate and never read to authorize normal delivery.
+
+The existing worker admission/transfer limits, caller/session/generation/lease
+validation, peer trust boundary, content-blind payload validation, canonical
+content conflicts and forwarding single-flight remain. This is not a new
+inter-session security boundary. `tasks/v1` and endpoint-owned `pi-tasks/v2`
+task records, events and task authority are not redesigned.
+
+Restart durability was already ruled out by #351. Loss of a relay process can
+lose even accepted messages. Endpoint task storage surviving that loss does not
+mean transport replay or successful delivery is guaranteed.
+
+## 1. Recommended acceptance and retry contract
+
+**Transfer ownership only after the destination mailbox accepts**, not when the
+source merely queues an outbound attempt. This works with the endpoint core's
+existing distinction between pending and relay-accepted outbox entries:
+
+- Local success: this process owns the destination mailbox entry.
+- Remote success: the destination relay confirmed its mailbox acceptance. The
+  source may release its forwarding payload and retain a compact receipt.
+- Remote unresolved: return a retryable transport error, **not successful
+  acceptance with `forwarding: pending`**. The endpoint keeps its pending outbox.
+- Response loss is an unknown outcome, not proof of rejection. Retry identical
+  content/identity; a destination that already accepted returns the same receipt.
+- Retry calls coalesce on one in-flight attempt per identity. Capacity and
+  cooldown rejections do not consume a network attempt. Propose four actual
+  attempts, at least one second apart, within two minutes of first admission;
+  retries do not refresh that deadline.
+- Exhaustion returns a stable terminal `DELIVERY_UNCONFIRMED` outcome, including
+  that delivery may have occurred. It must never return misleading `pending`.
+- Initially, **no same-ID rearm after exhaustion**. Keep that result throughout
+  the receipt window. A genuinely new logical operation is an explicit endpoint
+  decision, with duplicate-effect risk disclosed; never invent one automatically.
+
+Source-side background attempts, if retained, obey those same limits and cannot
+cause the endpoint outbox to become accepted before the client sees confirmation.
+A simpler first implementation can let endpoint retries drive forwarding and
+retain only bounded in-flight/attempt metadata between calls.
+
+Destination mailbox acceptance is not endpoint persistence, Pi insertion, model
+execution or task completion. Accepted, unacknowledged mailbox payloads are **not
+silently age-evicted** to make room. Hold them until transport acknowledgment or
+process loss; full mailboxes backpressure new admissions. Expired leases prohibit
+delivery but do not themselves discard accepted payloads. Endpoint generations
+with outstanding obligations remain separately indexed; a new generation cannot
+consume the old generation's mailbox. Explicit abandonment/retirement, if added,
+needs an observable terminal transport result rather than silent reclamation.
+This conservative policy can leave capacity occupied by an abandoned endpoint;
+that is a deliberate tradeoff, not unlimited memory or a recovery guarantee.
+
+## 2. Proposed bounds and receipts
+
+Initial values for review, not measured memory/SLO claims:
+
+| Resource, per worker | Count ceiling | Encoded-data ceiling |
+| --- | ---: | ---: |
+| All active envelope payloads, including forwarding | 4,096 | 64 MiB |
+| One destination mailbox (subset of global) | 256 | 8 MiB |
+| One peer's pending forwarding (subset of global) | 128 | 8 MiB |
+| Compact receipts/attempt outcomes | 50,000 | 8 MiB |
+| Registrations and retained generations | 2,048 | Shared metadata pool |
+| Peer routes | 2,048 | Shared metadata pool |
+| Other operational metadata/index keys | Bounded by owner counts | 16 MiB |
+| Investigation queue, independent of active payload pool | 1,024 | 4 MiB |
+
+Existing HTTP/payload/page and worker transfer limits remain independent caps.
+Retain each active envelope in an owned encoded representation, not a retained
+parsed object graph plus a historical full-state array. Budget headers and
+payload, not just payload. Validate scalar/key lengths, use exact counters and
+bounded expiry indexes; repeated renewal must not accumulate stale heap entries.
+Encoded bytes and object counts are not native heap or total-RSS guarantees.
+
+Reserve message, metadata and eventual receipt credits atomically **before**
+acceptance. Reject with retryable `RELAY_CAPACITY` and a retry hint when full;
+never evict an accepted entry or an unexpired receipt to admit another. Repeated
+duplicates must not consume additional credits. Acknowledgment releases the
+active payload charge; separate logging references remain charged to logging.
+
+Propose a **15-minute compact receipt window after terminal disposition**, pinned
+longer while the associated payload is active. Retain identity, canonical digest,
+acceptance/result, scope and expiry, but no completed payload. Duplicate retries
+do not extend expiry. Terminal outcomes also reserve bounded receipt capacity.
+Deduplication is not forever and not across process lifetimes. A retry outside
+the agreed horizon is not promised duplicate acceptance. The coordinated protocol
+needs immutable, owner-persisted creation/deadline metadata so a conforming late
+retry is rejected even after its receipt expires. A forgotten ID alone cannot
+prove that a request is old. Define clock-skew tolerance, check existing receipts
+before treating an identity as new, and test expired-retry rejection. Deliberate
+ID/content reuse after the window is not covered by a forever-deduplication claim.
+
+## 3. Investigation policy — requires explicit agreement
+
+Recommendation: bounded, private, **best-effort** append-only investigation logs,
+not a second delivery authority. Capture validated payload once for an admitted
+message and metadata for acceptance, forwarding attempts/outcomes, ACK, rejection
+and process epoch. Do not log arbitrary malformed/unauthorized request bodies.
+
+- Local-user-only directory/files (0700/0600). Payloads may contain sensitive task
+  content; neither automatic upload nor a public log-reading endpoint is added.
+- Propose 24-hour retention and 256 MiB total rotated output, whichever binds
+  first; rotation must bound temporary overshoot. Existing historical relay files
+  are outside this new writer's rotation/deletion scope.
+- Bounded asynchronous queue; ordinary delivery does not await log writes/fsync.
+- Queue overflow/disk failure drops investigation records, **not accepted work**.
+  Expose degraded health, dropped-record/byte counts and bounded error metadata;
+  warnings are rate-limited. No silent assertion of complete audit coverage.
+- Abrupt exit can lose queued records. Even a successful relay acceptance is not
+  proof its investigation record reached disk. No crash-recovery replay.
+
+If complete investigation coverage is required instead, choose fail-closed
+pre-admission logging backpressure explicitly. That is a different availability
+contract and should be resolved before implementing the writer.
+
+## 4. Cursor, epoch and adapter contract
+
+Use a negotiated new transport profile (working name **`volatile-v1`**) rather
+than silently replacing v2 guarantees underneath old clients/peers. Old clients
+must fail explicitly before registration/acceptance; do not fall back to a
+file-backed or silently compatible-looking mode. Final wire/schema naming and
+adapter release coordination are implementation gates.
+
+- Each worker lifetime has a fresh epoch. Registration/receive/ACK/send scope is
+  checked against it; opaque endpoint/routing identities cannot silently alias
+  old lifetimes. Startup does not inspect legacy relay-state contents.
+- Epoch mismatch is an explicit reset error, not an empty inbox or acceptance of
+  a stale endpoint. Re-registration does not authorize rewriting old task source
+  or target identities. The owning adapter must stop/surface stale bindings and
+  perform its explicit rebind flow; no transparent task recovery is promised.
+- Cursor counters are monotonic per mailbox. Return each delivery's **actual
+  decimal cursor**; deleting completed rows creates gaps, not renumbering.
+  Keep decimal strings end-to-end, with no safe-integer conversion or synthesized
+  `requestCursor + arrayIndex`. Reject out-of-scope/future cursors explicitly.
+- `nextCursor` reflects the last returned delivery, not a discarded/truncated
+  suffix; empty pages do not fabricate advancement. Respect requested page limits
+  on the server and existing item/byte caps. ACKs remain identity- and owner-bound.
+- Restart/reset negotiation must be handled while an existing Pi process is
+  still running, not only when `createWolfpackTaskCore` first initializes it.
+
+The installed pi-tasks 0.1.7 adapter currently regenerates wire `createdAt` in
+`toWolfpackEnvelope`, synthesizes numeric delivery cursors and ignores forwarding
+status when an acceptance ID is present. Its core marks successful sends accepted
+and subsequently flushes pending rows only. It currently quarantines terminal
+`TARGET_NOT_REGISTERED` specifically, not every new terminal transport code.
+Adding a new error name alone will therefore not stop its repeated flushes.
+
+Recommended timestamp contract: persist immutable transport creation/deadline
+metadata with the originating endpoint's outbox envelope, and derive the wire
+`createdAt` from that value on every send. Receipt/admission time remains separate.
+The existing envelope serialization can own this transport metadata without a
+second database or redesigning canonical task events. Its exact upstream schema
+and treatment of preexisting outbox entries need coordinated source review.
+**Do not exclude `createdAt` from conflict hashing**, invent a new timestamp on
+retry, or rely on an adapter in-memory cache that disappears on restart. Every
+admitted immutable header and opaque payload remains part of content identity.
+
+Required upstream changes are narrow transport encoding/cursor/reset/error
+handling, reusing existing endpoint task authority and quarantine mechanisms.
+Do not edit the installed package as the implementation or introduce a second
+endpoint task database. Release and installed-package parity need separate,
+authorized coordination.
+
+## 5. Verification and implementation sequence
+
+1. Resolve the acceptance/no-rearm, logging-loss and compatibility-cutover choices
+   above. Record final field/error/expiry contracts in Wolfpack and adapter docs.
+2. Add behavior tests for a bounded, instance-owned engine: atomic multi-budget
+   admission, credit recovery, ownership, opaque keys, genuine content conflicts,
+   strict leases, cursor gaps, duplicate ACKs, expired receipts and bounded expiry
+   indexes. No filesystem reads or full-state reconstruction in hot paths.
+3. Integrate the engine behind #359's worker boundary and the negotiated profile.
+   Implement bounded investigation output independently. Preserve old files in
+   place; do not import them as live state or delete them during startup.
+4. Coordinate the adapter source change. Test actual adapter → actual relay
+   acceptance followed by lost response, identical retry, changed-content
+   conflict, sparse/truncated pages, live-process epoch reset and terminal retry
+   handling. Check adapter restarts, not merely an in-process timestamp cache.
+5. Verify local and isolated two-process/two-relay delivery → receive → ACK;
+   concurrent retries, outage/recovery/exhaustion, renewal, capacity and logging
+   failure. Replace obsolete persistence expectations without dropping live
+   routing/authority coverage. Run broad integrations including task-gateway and
+   real compiled-worker packaging, not just the earlier selected #359 suites.
+6. Benchmark exact revisions with fixed active work and varying archived history,
+   including empty/1k/5k × 1 KiB and 1k × 16 KiB histories, local and simulated
+   peer traffic. Measure complete delivery/ACK, renewal, event-loop latency, CPU,
+   process RSS including workers and accounting high-water marks. Publish commands,
+   input hashes, hardware, latency budgets, failures and regressions. Archive size
+   must not change operational parse/scan/write work; this is not live-fleet proof.
+
+### Compatibility reproduction
+
+`scripts/relay-memory-compat-audit.ts` accepts an explicit absolute adapter source
+path. It creates a private real gateway/store, injects response loss *after*
+acceptance, retries the same logical envelope and checks exact-wire deduplication
+and genuine changed-content rejection. It separately simulates the proposed
+post-ACK cursor gap using a real second-page response; that gap is not a claim
+about current v2's retained-row behavior. No task core/store, live HTTP/Tailnet,
+broker, installed-package modification or service restart is involved.
+
+The audit exits nonzero when it reproduces compatibility defects. This is a
+pre-change diagnostic, not a passing regression proving the redesign works.

--- a/scripts/relay-memory-compat-audit.ts
+++ b/scripts/relay-memory-compat-audit.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+/** Read-only adapter audit against a real, privately rooted relay gateway.
+ * Usage: bun scripts/relay-memory-compat-audit.ts /absolute/path/to/wolfpack-task-relay.ts
+ * The explicitly selected adapter module executes locally. No default broker,
+ * real HTTP/Tailnet, endpoint task store, installed package or service is used/modified.
+ * Exit 1 means a compatibility defect was reproduced, not a harness success claim.
+ */
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join } from "node:path";
+import { AGENT_KIND } from "../src/agent-kind.ts";
+import { TaskRelayGateway } from "../src/task-relay/gateway.ts";
+import { RELAY_PROTOCOL_VERSION, type RelayEnvelope as WireEnvelope } from "../src/task-relay/domain.ts";
+
+const selected = process.argv[2];
+assert(selected && isAbsolute(selected), "explicit absolute adapter source path required");
+const adapterPath = realpathSync(selected);
+const sha = () => createHash("sha256").update(readFileSync(adapterPath)).digest("hex");
+const adapterSha256 = sha();
+const revision = execFileSync("git", ["rev-parse", "HEAD"], { cwd: join(import.meta.dir, ".."), encoding: "utf8" }).trim();
+const { createWolfpackTaskRelay } = await import(adapterPath);
+const { TASK_PROTOCOL_VERSION } = await import(join(dirname(adapterPath), "task-protocol.ts"));
+const root = mkdtempSync(join(tmpdir(), "wolfpack-relay-compat-audit-"));
+const gateway = new TaskRelayGateway({ root, inspectSession: async selector => ({
+  ok: true, session: selector, sessionId: selector, projectPath: root, harness: AGENT_KIND.PI.id, alive: true,
+}) });
+let dropFirstAcceptedResponse = true, simulateRemovedCursorOne = false;
+const sent: { envelope: WireEnvelope; result: unknown }[] = [];
+const transport = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  const url = new URL(String(input));
+  assert.equal(url.origin, "https://compat-audit.invalid");
+  const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+  let result: unknown;
+  switch (url.pathname) {
+    case "/api/task-relay/v2/connect": result = await gateway.connect(body); break;
+    case "/api/task-relay/v2/send": {
+      const reply = await gateway.send(body);
+      sent.push({ envelope: structuredClone(body.envelope), result: reply });
+      if (reply.ok && dropFirstAcceptedResponse) {
+        dropFirstAcceptedResponse = false;
+        throw new Error("injected response loss AFTER actual relay acceptance");
+      }
+      result = reply; break;
+    }
+    case "/api/task-relay/v2/receive":
+      // This explicitly simulates the proposed post-ack gap, not current v2 behavior.
+      result = await gateway.receive({ callerSession: url.searchParams.get("callerSession")!,
+        cursor: simulateRemovedCursorOne ? "1" : url.searchParams.get("cursor")! }); break;
+    case "/api/task-relay/v2/delivery-ack": result = await gateway.acknowledgeDelivery(body); break;
+    default: throw new Error(`unexpected audit route: ${url.pathname}`);
+  }
+  return Response.json(result);
+}) as typeof fetch;
+const adapter = (sessionName: string) => createWolfpackTaskRelay({ sessionName, generation: "compat-audit",
+  baseUrl: "https://compat-audit.invalid", fetch: transport });
+try {
+  const sender = adapter("sender"), receiver = adapter("receiver");
+  const source = await sender.endpoint(), target = await receiver.endpoint();
+  const logical = { envelopeId: "lost-response", protocolVersion: TASK_PROTOCOL_VERSION, source, target,
+    taskId: "compat-audit-task", kind: "assignment", payload: JSON.stringify({ audit: true }) };
+  let firstError: string | undefined, retryError: string | undefined;
+  try { await sender.send(logical); } catch (error) { firstError = (error as { code?: string }).code ?? String(error); }
+  assert(firstError, "response-loss injection must be observed by the adapter");
+  await Bun.sleep(20); // ensure the second serialization happens at a distinct wall-clock time
+  try { await sender.send(logical); } catch (error) { retryError = (error as { code?: string }).code ?? String(error); }
+  assert.equal(sent.length, 2);
+  const original = sent[0]!.envelope;
+  const exactRetry = await gateway.send({ callerSession: "sender", envelope: original });
+  assert(exactRetry.ok && exactRetry.kind === "duplicate", "actual relay must deduplicate exact retry bytes");
+  const changed = await gateway.send({ callerSession: "sender", envelope: { ...original, payload: { changed: true } } });
+  assert(!changed.ok && changed.error.code === "ENVELOPE_CONFLICT", "genuine changed content must still conflict");
+  const before = await gateway.receive({ callerSession: "receiver", cursor: "0" });
+  assert(before.ok && before.envelopes.length === 1, "response loss must not produce multiple relay deliveries");
+  await sender.send({ ...logical, envelopeId: "after-gap" });
+  const ack = await gateway.acknowledgeDelivery({ callerSession: "receiver", envelopeId: original.envelopeId });
+  assert(ack.ok);
+  const realSecondPage = await gateway.receive({ callerSession: "receiver", cursor: "1" });
+  assert(realSecondPage.ok && realSecondPage.envelopes.length === 1 && realSecondPage.nextCursor === "2");
+  simulateRemovedCursorOne = true;
+  const page = await receiver.receive({ endpoint: target, cursor: "0", limit: 50 });
+  assert.equal(page.deliveries.length, 1);
+  const changedRetryContent = JSON.stringify(sent[0]!.envelope) !== JSON.stringify(sent[1]!.envelope);
+  const wrongGapCursor = page.deliveries[0].cursor !== realSecondPage.nextCursor;
+  assert.equal(sha(), adapterSha256, "selected adapter source changed during audit");
+  console.log(JSON.stringify({ revision, adapterPath, adapterSha256, wireProtocolVersion: RELAY_PROTOCOL_VERSION,
+    firstError, retryError, changedRetryContent,
+    firstCreatedAt: sent[0]!.envelope.createdAt, retryCreatedAt: sent[1]!.envelope.createdAt,
+    exactRetryKind: exactRetry.kind, genuineConflict: changed.error.code,
+    cursorGap: { simulatedRemoval: true, actualCursor: realSecondPage.nextCursor, assignedCursor: page.deliveries[0].cursor, wrongGapCursor },
+    scope: "real installed adapter + real private gateway/store; injected HTTP transport and response loss; proposed cursor gap simulated; no task core/store or live services" }));
+  if (changedRetryContent || retryError || wrongGapCursor) process.exitCode = 1;
+} finally {
+  gateway.close();
+  rmSync(root, { recursive: true, force: true });
+}

--- a/src/task-relay/expiry-index.ts
+++ b/src/task-relay/expiry-index.ts
@@ -1,0 +1,69 @@
+/** Indexed min-heap: one node per owner, including after arbitrarily many renewals. */
+export class RelayExpiryIndex {
+  readonly #heap: { key: string; at: number }[] = [];
+  readonly #positions = new Map<string, number>();
+
+  get size(): number { return this.#heap.length; }
+
+  set(key: string, at: number): void {
+    if (!Number.isFinite(at)) throw new TypeError("invalid expiry");
+    const existing = this.#positions.get(key);
+    if (existing !== undefined) {
+      this.#heap[existing]!.at = at;
+      this.#down(this.#up(existing));
+      return;
+    }
+    const index = this.#heap.length;
+    this.#heap.push({ key, at });
+    this.#positions.set(key, index);
+    this.#up(index);
+  }
+
+  delete(key: string): boolean {
+    const index = this.#positions.get(key);
+    if (index === undefined) return false;
+    this.#positions.delete(key);
+    const last = this.#heap.pop()!;
+    if (index < this.#heap.length) {
+      this.#heap[index] = last;
+      this.#positions.set(last.key, index);
+      this.#down(this.#up(index));
+    }
+    return true;
+  }
+
+  takeDue(now: number): string | undefined {
+    const first = this.#heap[0];
+    if (!first || first.at > now) return undefined;
+    this.delete(first.key);
+    return first.key;
+  }
+
+  #swap(a: number, b: number): void {
+    [this.#heap[a], this.#heap[b]] = [this.#heap[b]!, this.#heap[a]!];
+    this.#positions.set(this.#heap[a]!.key, a);
+    this.#positions.set(this.#heap[b]!.key, b);
+  }
+
+  #up(index: number): number {
+    while (index > 0) {
+      const parent = (index - 1) >> 1;
+      if (this.#heap[parent]!.at <= this.#heap[index]!.at) break;
+      this.#swap(index, parent);
+      index = parent;
+    }
+    return index;
+  }
+
+  #down(index: number): void {
+    for (;;) {
+      const left = index * 2 + 1, right = left + 1;
+      let smallest = index;
+      if (left < this.#heap.length && this.#heap[left]!.at < this.#heap[smallest]!.at) smallest = left;
+      if (right < this.#heap.length && this.#heap[right]!.at < this.#heap[smallest]!.at) smallest = right;
+      if (smallest === index) return;
+      this.#swap(index, smallest);
+      index = smallest;
+    }
+  }
+}

--- a/src/task-relay/investigation.ts
+++ b/src/task-relay/investigation.ts
@@ -1,0 +1,246 @@
+import { constants } from "node:fs";
+import { lstat, mkdir, open, unlink } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { canonicalJson } from "../canonical-json.ts";
+import type { RelayEnvelope } from "./domain.ts";
+import { RELAY_LIMITS, isOpaqueRelayId } from "./domain.ts";
+import { captureRelayWire } from "./worker-protocol.ts";
+
+const KINDS = ["registered", "disconnected", "accepted", "acknowledged", "forward_queued", "forward_attempt", "forward_confirmed", "forward_retry", "forward_unconfirmed", "rejected"] as const;
+export interface RelayInvestigationEvent {
+  readonly epoch: string;
+  readonly at: number;
+  readonly kind: typeof KINDS[number];
+  readonly envelopeId?: string;
+  readonly envelope?: RelayEnvelope;
+  readonly reason?: "capacity" | "conflict" | "expired";
+}
+export interface RelayInvestigationSink { offer(event: RelayInvestigationEvent): boolean }
+export interface RelayInvestigationWriter { append(line: string): Promise<void>; cleanup?(): Promise<void> }
+export const INVESTIGATION_LIMITS = Object.freeze({
+  queueItems: 1024, queueBytes: 4 * 1024 * 1024, recordBytes: RELAY_LIMITS.HTTP_BODY_BYTES + 2048,
+  segments: 16, segmentBytes: 16 * 1024 * 1024, retentionMs: 24 * 60 * 60 * 1000,
+});
+const increment = (value: number, by = 1): number => Math.min(Number.MAX_SAFE_INTEGER, value + by);
+
+/** Best effort only. Counts include the in-flight write, not just waiting rows. */
+export class BoundedRelayInvestigation implements RelayInvestigationSink {
+  readonly #queue: { line: string | undefined; bytes: number }[] = [];
+  readonly #writer: RelayInvestigationWriter;
+  readonly #maxItems: number;
+  readonly #maxBytes: number;
+  #queuedBytes = 0;
+  #running: Promise<void> | undefined;
+  #closed = false;
+  #written = 0;
+  #dropped = 0;
+  #droppedBytes = 0;
+  #invalid = 0;
+  #writeFailures = 0;
+  #maintenanceFailures = 0;
+  #maintenanceQueued = false;
+  #lastFailure: "invalid_event" | "capacity" | "write_failed" | "maintenance_failed" | "closed" | undefined;
+
+  constructor(writer: RelayInvestigationWriter, limits: { readonly items?: number; readonly bytes?: number } = {}) {
+    this.#writer = writer;
+    this.#maxItems = limits.items ?? INVESTIGATION_LIMITS.queueItems;
+    this.#maxBytes = limits.bytes ?? INVESTIGATION_LIMITS.queueBytes;
+    if (!Number.isSafeInteger(this.#maxItems) || this.#maxItems < 1 || this.#maxItems > INVESTIGATION_LIMITS.queueItems
+      || !Number.isSafeInteger(this.#maxBytes) || this.#maxBytes < 1 || this.#maxBytes > INVESTIGATION_LIMITS.queueBytes) throw new TypeError("invalid investigation queue limits");
+  }
+
+  offer(input: RelayInvestigationEvent): boolean {
+    let line: string;
+    try {
+      const event = captureRelayWire(input, INVESTIGATION_LIMITS.recordBytes - 1).value;
+      if (!event || !isOpaqueRelayId(event.epoch) || !Number.isSafeInteger(event.at) || event.at < 0 || !KINDS.includes(event.kind)
+        || (event.reason !== undefined && !["capacity", "conflict", "expired"].includes(event.reason))
+        || Object.keys(event).some(key => !["epoch", "at", "kind", "envelopeId", "envelope", "reason"].includes(key))) throw new TypeError("invalid event");
+      line = canonicalJson(event) + "\n";
+    } catch {
+      this.#invalid = increment(this.#invalid); this.#dropped = increment(this.#dropped);
+      this.#lastFailure = "invalid_event";
+      return false;
+    }
+    const size = Buffer.byteLength(line);
+    if (this.#closed || this.#queue.length >= this.#maxItems || size > this.#maxBytes - this.#queuedBytes) {
+      this.#drop(size, this.#closed ? "closed" : "capacity");
+      return false;
+    }
+    this.#queue.push({ line, bytes: size }); this.#queuedBytes += size;
+    this.#start();
+    return true;
+  }
+
+  /** Gateway timer requests an idle retention sweep through the SAME bounded
+   * writer queue; concurrent sweeps coalesce and never race an append. */
+  requestCleanup(): boolean {
+    if (!this.#writer.cleanup || this.#closed || this.#maintenanceQueued || this.#queue.length >= this.#maxItems) return false;
+    this.#maintenanceQueued = true;
+    this.#queue.push({ line: undefined, bytes: 0 });
+    this.#start();
+    return true;
+  }
+
+  health() {
+    return { queuedItems: this.#queue.length, queuedBytes: this.#queuedBytes, written: this.#written,
+      droppedRecords: this.#dropped, droppedBytes: this.#droppedBytes, invalidRecords: this.#invalid,
+      writeFailures: this.#writeFailures, maintenanceFailures: this.#maintenanceFailures,
+      degraded: this.#dropped > 0 || this.#maintenanceFailures > 0, lastFailure: this.#lastFailure, closed: this.#closed };
+  }
+
+  /** Explicit graceful/test drain only; ordinary acceptance never awaits this. */
+  async drain(): Promise<void> { while (this.#running) await this.#running; }
+  async close(): Promise<void> { this.#closed = true; await this.drain(); }
+
+  #start(): void {
+    // Install the owner before writer code runs; also cover offers between the
+    // pump's final check and its completion microtask (otherwise they strand).
+    this.#running ??= Promise.resolve().then(() => this.#pump()).finally(() => {
+      this.#running = undefined;
+      if (this.#queue.length) this.#start();
+    });
+  }
+
+  async #pump(): Promise<void> {
+    while (this.#queue.length) {
+      const item = this.#queue[0]!;
+      try {
+        if (item.line === undefined) await this.#writer.cleanup!();
+        else { await this.#writer.append(item.line); this.#written = increment(this.#written); }
+      } catch {
+        if (item.line === undefined) { this.#maintenanceFailures = increment(this.#maintenanceFailures); this.#lastFailure = "maintenance_failed"; }
+        else { this.#writeFailures = increment(this.#writeFailures); this.#drop(item.bytes, "write_failed"); }
+      } finally {
+        this.#queue.shift(); this.#queuedBytes -= item.bytes;
+        if (item.line === undefined) this.#maintenanceQueued = false;
+      }
+    }
+  }
+
+  #drop(size: number, reason: "capacity" | "write_failed" | "closed"): void {
+    this.#dropped = increment(this.#dropped); this.#droppedBytes = increment(this.#droppedBytes, size); this.#lastFailure = reason;
+  }
+}
+
+interface Segment { readonly slot: number; size: number; at: number }
+/**
+ * Fixed private slots, no directory-wide history read or unbounded file listing.
+ * Total disk bound = slots * segmentBytes, with no rotation overshoot. Only this
+ * dedicated directory's named slots are managed; legacy relay-state is untouched.
+ * Not a local-user security sandbox, durable audit, or recovery authority.
+ */
+export class RotatingRelayInvestigationWriter implements RelayInvestigationWriter {
+  readonly #directory: string;
+  readonly #slots: number;
+  readonly #segmentBytes: number;
+  readonly #retentionMs: number;
+  readonly #clock: () => number;
+  readonly #segments = new Map<number, Segment>();
+  #initialized = false;
+  #active: number | undefined;
+  #busy = false;
+
+  constructor(directory: string, options: { readonly slots?: number; readonly segmentBytes?: number; readonly retentionMs?: number; readonly clock?: () => number } = {}) {
+    this.#directory = resolve(directory);
+    this.#slots = options.slots ?? INVESTIGATION_LIMITS.segments;
+    this.#segmentBytes = options.segmentBytes ?? INVESTIGATION_LIMITS.segmentBytes;
+    this.#retentionMs = options.retentionMs ?? INVESTIGATION_LIMITS.retentionMs;
+    this.#clock = options.clock ?? Date.now;
+    if (!Number.isInteger(this.#slots) || this.#slots < 1 || this.#slots > INVESTIGATION_LIMITS.segments
+      || !Number.isSafeInteger(this.#segmentBytes) || this.#segmentBytes < 1 || this.#segmentBytes > INVESTIGATION_LIMITS.segmentBytes
+      || !Number.isSafeInteger(this.#retentionMs) || this.#retentionMs < 1 || this.#retentionMs > INVESTIGATION_LIMITS.retentionMs) throw new TypeError("invalid investigation rotation limits");
+  }
+
+  async append(line: string): Promise<void> {
+    if (this.#busy) throw new Error("investigation writer requires serialized admission");
+    if (typeof line !== "string" || line.length > this.#segmentBytes || Buffer.byteLength(line) > this.#segmentBytes) throw new Error("investigation record exceeds segment");
+    this.#busy = true;
+    try {
+      const now = this.#clock();
+      if (!Number.isSafeInteger(now) || now < 0) throw new Error("invalid investigation clock");
+      await this.#initialize();
+      await this.#prune(now);
+      const size = Buffer.byteLength(line);
+      let segment = this.#active === undefined ? undefined : this.#segments.get(this.#active);
+      if (segment && segment.size + size > this.#segmentBytes) { this.#active = undefined; segment = undefined; }
+      if (!segment) {
+        let slot = 0;
+        while (slot < this.#slots && this.#segments.has(slot)) slot++;
+        if (slot === this.#slots) {
+          const oldest = [...this.#segments.values()].reduce((a, b) => a.at <= b.at ? a : b);
+          slot = oldest.slot;
+          await this.#remove(slot); // Before creating/writing, never a temporary extra segment.
+        }
+        const file = await open(this.#path(slot), constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600);
+        await file.close();
+        segment = { slot, size: 0, at: now }; this.#segments.set(slot, segment); this.#active = slot;
+      }
+      const file = await open(this.#path(segment.slot), constants.O_WRONLY | constants.O_APPEND | constants.O_NOFOLLOW);
+      try {
+        const stat = await file.stat();
+        this.#privateRegular(stat);
+        if (stat.size !== segment.size || stat.size + size > this.#segmentBytes) throw new Error("investigation segment changed externally");
+        await file.writeFile(line, "utf8");
+        segment.size += size; // Retention is from segment creation, never refreshed by writes.
+      } finally { await file.close(); }
+    } catch (error) {
+      // A partial write may exist. Re-stat only fixed slots and start a NEW
+      // segment next time; never concatenate new JSON onto a partial old record.
+      this.#initialized = false; this.#active = undefined;
+      throw error;
+    } finally { this.#busy = false; }
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.#busy) throw new Error("investigation writer requires serialized admission");
+    this.#busy = true;
+    try {
+      const now = this.#clock();
+      if (!Number.isSafeInteger(now) || now < 0) throw new Error("invalid investigation clock");
+      await this.#initialize();
+      await this.#prune(now);
+    } catch (error) {
+      this.#initialized = false; this.#active = undefined;
+      throw error;
+    } finally { this.#busy = false; }
+  }
+
+  async #prune(now: number): Promise<void> {
+    for (const segment of this.#segments.values()) {
+      if (now - segment.at >= this.#retentionMs) await this.#remove(segment.slot);
+    }
+  }
+
+  async #initialize(): Promise<void> {
+    await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+    const directory = await lstat(this.#directory);
+    if (!directory.isDirectory() || directory.isSymbolicLink() || (directory.mode & 0o077) !== 0
+      || (process.getuid && directory.uid !== process.getuid())) throw new Error("investigation directory must be private and owned");
+    if (this.#initialized) return;
+    this.#segments.clear();
+    for (let slot = 0; slot < this.#slots; slot++) {
+      try {
+        const stat = await lstat(this.#path(slot));
+        this.#privateRegular(stat);
+        if (stat.size > this.#segmentBytes) throw new Error("existing investigation segment exceeds budget");
+        // Unknown creation time expires conservatively instead of extending
+        // retention on every append/restart. File contents are not replayed.
+        this.#segments.set(slot, { slot, size: stat.size, at: stat.birthtimeMs > 0 ? Math.min(stat.birthtimeMs, stat.mtimeMs) : 0 });
+      } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+    }
+    this.#initialized = true;
+  }
+
+  async #remove(slot: number): Promise<void> {
+    this.#privateRegular(await lstat(this.#path(slot)));
+    await unlink(this.#path(slot));
+    this.#segments.delete(slot);
+    if (this.#active === slot) this.#active = undefined;
+  }
+
+  #path(slot: number): string { return join(this.#directory, `relay-investigation-${String(slot).padStart(2, "0")}.jsonl`); }
+  #privateRegular(stat: { isFile(): boolean; mode: number; uid: number }): void {
+    if (!stat.isFile() || (stat.mode & 0o077) !== 0 || (process.getuid && stat.uid !== process.getuid())) throw new Error("investigation segment must be a private owned regular file");
+  }
+}

--- a/src/task-relay/investigation.ts
+++ b/src/task-relay/investigation.ts
@@ -240,7 +240,7 @@ export class RotatingRelayInvestigationWriter implements RelayInvestigationWrite
   }
 
   #path(slot: number): string { return join(this.#directory, `relay-investigation-${String(slot).padStart(2, "0")}.jsonl`); }
-  #privateRegular(stat: { isFile(): boolean; mode: number; uid: number }): void {
-    if (!stat.isFile() || (stat.mode & 0o077) !== 0 || (process.getuid && stat.uid !== process.getuid())) throw new Error("investigation segment must be a private owned regular file");
+  #privateRegular(stat: { isFile(): boolean; mode: number; uid: number; nlink: number }): void {
+    if (!stat.isFile() || stat.nlink !== 1 || (stat.mode & 0o077) !== 0 || (process.getuid && stat.uid !== process.getuid())) throw new Error("investigation segment must be a private unshared owned regular file");
   }
 }

--- a/src/task-relay/memory-store.ts
+++ b/src/task-relay/memory-store.ts
@@ -1,0 +1,427 @@
+import { createHash, randomUUID } from "node:crypto";
+import { canonicalJson } from "../canonical-json.ts";
+import { canonicalTailnetOrigin } from "../tailnet-machine-contract.ts";
+import { RELAY_ID, RELAY_LIMITS, RELAY_PROTOCOL_VERSION, isOpaqueRelayId, isPeerRelayId, isRelayEnvelope, isRelayTimestamp } from "./domain.ts";
+import type { RelayEndpoint, RelayEnvelope, RelayRegistration } from "./domain.ts";
+import { captureRelayWire } from "./worker-protocol.ts";
+import { RelayExpiryIndex } from "./expiry-index.ts";
+import type { RelayInvestigationEvent, RelayInvestigationSink } from "./investigation.ts";
+
+export const MEMORY_RELAY_PROFILE = "volatile-v1";
+export const MEMORY_RELAY_LIMITS = Object.freeze({
+  activeItems: 4096, activeBytes: 64 * 1024 * 1024,
+  mailboxItems: 256, mailboxBytes: 8 * 1024 * 1024,
+  peerItems: 128, peerBytes: 8 * 1024 * 1024,
+  receipts: 50_000, receiptBytes: 8 * 1024 * 1024,
+  registrations: 2048, routes: 2048, metadataBytes: 16 * 1024 * 1024,
+});
+export const MEMORY_RELAY_TIMING = Object.freeze({ retryMs: 1000, deadlineMs: 120_000, receiptMs: 900_000, clockSkewMs: 30_000 });
+type Limits = { readonly [K in keyof typeof MEMORY_RELAY_LIMITS]: number };
+export type MemoryRelayCode = "RELAY_CAPACITY" | "RELAY_RESET" | "INVALID_REQUEST" | "INVALID_CURSOR"
+  | "REGISTRATION_EXPIRED" | "TARGET_NOT_REGISTERED" | "CROSS_RELAY_ENDPOINT" | "ENVELOPE_CONFLICT" | "ENVELOPE_EXPIRED";
+export class MemoryRelayError extends Error {
+  constructor(readonly code: MemoryRelayCode) { super(code); }
+  get retryable(): boolean { return this.code === "RELAY_CAPACITY"; }
+}
+function fail(code: MemoryRelayCode): never { throw new MemoryRelayError(code); }
+const bytes = (value: unknown): number => Buffer.byteLength(canonicalJson(value));
+const decimal = (value: unknown): value is string => typeof value === "string" && /^(0|[1-9][0-9]{0,31})$/.test(value);
+const text = (value: unknown): value is string => typeof value === "string" && value.length > 0 && value.length <= 512;
+const keys = (value: object, expected: readonly string[]): boolean => Object.keys(value).every(key => expected.includes(key));
+function time(now: number): void {
+  if (!Number.isSafeInteger(now) || now < 0 || now > 8_640_000_000_000_000 - MEMORY_RELAY_TIMING.receiptMs) fail("INVALID_REQUEST");
+}
+function captured<T>(input: T, limit: number): T {
+  try { return captureRelayWire(input, limit).value; } catch { return fail("INVALID_REQUEST"); }
+}
+
+interface RegistrationEntry {
+  value: RelayRegistration;
+  readonly mailbox: Map<string, bigint>;
+  cursor: bigint;
+  mailboxBytes: number;
+  references: number;
+  bytes: number;
+}
+interface Route { readonly id: string; readonly origin: string; readonly bytes: number; items: number; payloadBytes: number }
+type State = "mailbox" | "acknowledged" | "forwarding" | "forwarded" | "unconfirmed";
+/** No payload/parsed envelope is allowed in a receipt or secondary index. */
+interface Receipt {
+  readonly id: string;
+  readonly digest: string;
+  readonly source: RelayEndpoint;
+  readonly target: RelayEndpoint;
+  readonly bytes: number;
+  readonly payloadBytes: number;
+  readonly cursor: string | undefined;
+  readonly deadline: number;
+  acceptanceId: string | undefined;
+  state: State;
+  attempts: number;
+  nextAttemptAt: number;
+  token: string | undefined;
+  expiresAt: number | undefined;
+}
+export type ForwardAttempt = { readonly kind: "attempt"; readonly token: string; readonly envelope: RelayEnvelope; readonly origin: string }
+  | { readonly kind: "pending"; readonly retryAt: number }
+  | { readonly kind: "forwarded"; readonly acceptanceId: string }
+  | { readonly kind: "unconfirmed"; readonly mayHaveBeenDelivered: true };
+
+/**
+ * Worker-owned engine for the negotiated volatile profile. No filesystem/root,
+ * timers, network calls, full-state snapshots or process-global store registry.
+ * Methods linearize synchronously; the gateway still owns broker inspection and
+ * trusted peer admission. NOT wired into the legacy v2 gateway until cutover.
+ */
+export class MemoryRelayStore {
+  readonly #epoch = randomUUID();
+  readonly #limits: Limits;
+  readonly #sink: RelayInvestigationSink | undefined;
+  readonly #registrations = new Map<string, RegistrationEntry>();
+  readonly #sessions = new Map<string, string>();
+  readonly #routes = new Map<string, Route>();
+  readonly #origins = new Map<string, string>();
+  readonly #receipts = new Map<string, Receipt>();
+  readonly #payloads = new Map<string, string>();
+  readonly #expiry = new RelayExpiryIndex();
+  #activeBytes = 0;
+  #receiptBytes = 0;
+  #metadataBytes = 0;
+  #logDrops = 0;
+
+  constructor(options: { readonly limits?: Partial<Limits>; readonly investigation?: RelayInvestigationSink } = {}) {
+    const overrides = captured(options.limits ?? {}, 4096);
+    if (!overrides || typeof overrides !== "object" || Array.isArray(overrides) || !keys(overrides, Object.keys(MEMORY_RELAY_LIMITS))) fail("INVALID_REQUEST");
+    const limits = { ...MEMORY_RELAY_LIMITS, ...overrides };
+    for (const key of Object.keys(limits) as (keyof Limits)[]) {
+      if (!Number.isSafeInteger(limits[key]) || limits[key] < 1 || limits[key] > MEMORY_RELAY_LIMITS[key]) fail("INVALID_REQUEST");
+    }
+    this.#limits = Object.freeze(limits);
+    this.#sink = options.investigation;
+  }
+
+  get epoch(): string { return this.#epoch; }
+  checkEpoch(epoch: string): void { if (epoch !== this.#epoch) fail("RELAY_RESET"); }
+
+  stats() {
+    return { activeItems: this.#payloads.size, activeBytes: this.#activeBytes, receipts: this.#receipts.size,
+      receiptBytes: this.#receiptBytes, registrations: this.#registrations.size, sessions: this.#sessions.size,
+      routes: this.#routes.size, metadataBytes: this.#metadataBytes, expiryEntries: this.#expiry.size,
+      investigationEnabled: this.#sink !== undefined, logDrops: this.#logDrops };
+  }
+
+  /** sessionId must come from the gateway's fresh authoritative broker inspection. */
+  register(input: { readonly sessionId: string; readonly generation: string; readonly leaseMs: number; readonly protocolVersions: readonly number[] }, now: number): RelayRegistration {
+    time(now);
+    const value = captured(input, 4096);
+    if (!value || !keys(value, ["sessionId", "generation", "leaseMs", "protocolVersions"]) || !text(value.sessionId) || !text(value.generation)
+      || !Number.isInteger(value.leaseMs) || value.leaseMs < 1 || value.leaseMs > RELAY_LIMITS.MAX_LEASE_MS
+      || !Array.isArray(value.protocolVersions) || value.protocolVersions.length > 16 || !value.protocolVersions.every(Number.isInteger)
+      || !value.protocolVersions.includes(RELAY_PROTOCOL_VERSION)) fail("INVALID_REQUEST");
+    // Renew the current generation even at lease expiry if it still owns state.
+    const priorId = this.#sessions.get(value.sessionId);
+    const prior = priorId === undefined ? undefined : this.#registrations.get(priorId);
+    const existing = prior?.value.generation === value.generation ? prior : undefined;
+    const registration: RelayRegistration = {
+      endpoint: existing?.value.endpoint ?? { relay: RELAY_ID, id: randomUUID() },
+      sessionId: value.sessionId, generation: value.generation,
+      protocolVersions: [...new Set(value.protocolVersions)].sort((a, b) => a - b),
+      leaseExpiresAt: new Date(now + value.leaseMs).toISOString(),
+    };
+    // Include space for the fixed-size cursor, references, and index ownership.
+    const size = bytes(registration) + 128;
+    if ((!existing && this.#registrations.size >= this.#limits.registrations)
+      || this.#metadataBytes + size - (existing?.bytes ?? 0) > this.#limits.metadataBytes) fail("RELAY_CAPACITY");
+    const entry = existing ?? { value: registration, mailbox: new Map(), cursor: 0n, mailboxBytes: 0, references: 0, bytes: 0 };
+    this.#metadataBytes += size - entry.bytes;
+    entry.value = registration; entry.bytes = size;
+    this.#registrations.set(registration.endpoint.id, entry);
+    this.#sessions.set(value.sessionId, registration.endpoint.id);
+    if (!entry.references) this.#expiry.set(`g:${registration.endpoint.id}`, Date.parse(registration.leaseExpiresAt));
+    this.#emit("registered", now);
+    return structuredClone(registration);
+  }
+
+  registration(epoch: string, id: string, now: number): RelayRegistration | undefined {
+    this.checkEpoch(epoch); time(now);
+    const entry = this.#activeRegistration(id, now);
+    return entry && structuredClone(entry.value);
+  }
+
+  registrationForSession(epoch: string, sessionId: string, now: number): RelayRegistration | undefined {
+    this.checkEpoch(epoch); time(now);
+    const id = this.#sessions.get(sessionId);
+    return id === undefined ? undefined : this.registration(epoch, id, now);
+  }
+
+  disconnect(epoch: string, sessionId: string, endpointId: string, now: number): boolean {
+    this.checkEpoch(epoch); time(now);
+    const entry = this.#activeRegistration(endpointId, now);
+    if (!entry || entry.value.sessionId !== sessionId) return false;
+    entry.value = { ...entry.value, leaseExpiresAt: new Date(now).toISOString() };
+    if (!entry.references) this.#expiry.set(`g:${endpointId}`, now);
+    this.#emit("disconnected", now);
+    return true;
+  }
+
+  peerRoute(epoch: string, origin: string): { readonly id: string; readonly origin: string } {
+    this.checkEpoch(epoch);
+    if (!text(origin)) fail("INVALID_REQUEST");
+    let url: URL;
+    try { url = new URL(origin); } catch { return fail("INVALID_REQUEST"); }
+    if (url.protocol !== "https:" || url.origin !== origin || url.pathname !== "/" || url.search || url.hash || canonicalTailnetOrigin(url.hostname) !== origin) fail("INVALID_REQUEST");
+    const existing = this.#origins.get(origin);
+    if (existing) return { id: existing, origin };
+    const id = `${RELAY_ID}:peer:${randomUUID()}`;
+    const size = bytes({ id, origin }) + 64;
+    if (this.#routes.size >= this.#limits.routes || this.#metadataBytes + size > this.#limits.metadataBytes) fail("RELAY_CAPACITY");
+    this.#routes.set(id, { id, origin, bytes: size, items: 0, payloadBytes: 0 });
+    this.#origins.set(origin, id); this.#metadataBytes += size;
+    return { id, origin }; // Routes remain stable for the epoch; never silently evict aliases.
+  }
+
+  peerOrigin(epoch: string, id: string): string | undefined { this.checkEpoch(epoch); return this.#routes.get(id)?.origin; }
+
+  accept(epoch: string, input: RelayEnvelope, now: number): { readonly kind: "accepted" | "duplicate"; readonly acceptanceId: string } {
+    this.checkEpoch(epoch); time(now);
+    const envelope = this.#envelope(input);
+    if (envelope.target.relay !== RELAY_ID) fail("CROSS_RELAY_ENDPOINT");
+    const target = this.#activeRegistration(envelope.target.id, now);
+    if (!target) fail("TARGET_NOT_REGISTERED");
+    this.#source(envelope, now);
+    const found = this.#existing(envelope, now);
+    if (found) {
+      if (found.state !== "mailbox" && found.state !== "acknowledged") fail("ENVELOPE_CONFLICT");
+      return { kind: "duplicate", acceptanceId: found.acceptanceId! };
+    }
+    const cursor = (target.cursor + 1n).toString();
+    if (!decimal(cursor)) fail("RELAY_CAPACITY");
+    const receipt = this.#admit(envelope, now, "mailbox", cursor);
+    target.cursor += 1n;
+    target.mailbox.set(receipt.id, target.cursor);
+    target.mailboxBytes += receipt.payloadBytes;
+    this.#emit("accepted", now, receipt.id, envelope);
+    return { kind: "accepted", acceptanceId: receipt.acceptanceId! };
+  }
+
+  inbox(epoch: string, endpointId: string, cursor: string, now: number, limit = RELAY_LIMITS.INBOX_PAGE_ITEMS as number) {
+    this.checkEpoch(epoch); time(now);
+    if (!decimal(cursor) || !Number.isInteger(limit) || limit < 1 || limit > RELAY_LIMITS.INBOX_PAGE_ITEMS) fail("INVALID_CURSOR");
+    const entry = this.#activeRegistration(endpointId, now);
+    if (!entry) fail("REGISTRATION_EXPIRED");
+    const after = BigInt(cursor);
+    if (after > entry.cursor) fail("INVALID_CURSOR");
+    const deliveries: { cursor: string; envelope: RelayEnvelope }[] = [];
+    let pageBytes = 0, hasMore = false;
+    // Bounded by this mailbox's active-item ceiling, never by completed history.
+    for (const [id, sequence] of entry.mailbox) {
+      if (sequence <= after) continue;
+      const envelope = JSON.parse(this.#payloads.get(id)!) as RelayEnvelope;
+      const delivery = { cursor: sequence.toString(), envelope };
+      const size = bytes(delivery);
+      if (deliveries.length >= limit || pageBytes + size > RELAY_LIMITS.INBOX_PAGE_BYTES) { hasMore = true; break; }
+      deliveries.push(delivery); pageBytes += size;
+    }
+    return { deliveries, nextCursor: deliveries.at(-1)?.cursor ?? cursor, hasMore };
+  }
+
+  acknowledge(epoch: string, endpointId: string, envelopeId: string, now: number): "acknowledged" | "duplicate" | "missing" {
+    this.checkEpoch(epoch); time(now);
+    if (!this.#activeRegistration(endpointId, now)) fail("REGISTRATION_EXPIRED");
+    const receipt = this.#receipt(envelopeId, now);
+    if (!receipt || receipt.target.relay !== RELAY_ID || receipt.target.id !== endpointId) return "missing";
+    if (receipt.state === "acknowledged") return "duplicate";
+    if (receipt.state !== "mailbox") return "missing";
+    this.#terminal(receipt, "acknowledged", now);
+    this.#emit("acknowledged", now, receipt.id);
+    return "acknowledged";
+  }
+
+  /** Queuing/starting forwarding is NOT successful relay acceptance. */
+  beginForward(epoch: string, input: RelayEnvelope, now: number): ForwardAttempt {
+    this.checkEpoch(epoch); time(now);
+    const envelope = this.#envelope(input);
+    if (envelope.source.relay !== RELAY_ID || !isPeerRelayId(envelope.target.relay)) fail("CROSS_RELAY_ENDPOINT");
+    this.#source(envelope, now);
+    const route = this.#routes.get(envelope.target.relay);
+    if (!route) fail("CROSS_RELAY_ENDPOINT");
+    let receipt = this.#existing(envelope, now);
+    if (!receipt) {
+      receipt = this.#admit(envelope, now, "forwarding", undefined);
+      route.items++; route.payloadBytes += receipt.payloadBytes;
+      this.#emit("forward_queued", now, receipt.id, envelope);
+    }
+    if (receipt.state === "forwarded") return { kind: "forwarded", acceptanceId: receipt.acceptanceId! };
+    if (receipt.state === "unconfirmed") return { kind: "unconfirmed", mayHaveBeenDelivered: true };
+    if (receipt.state !== "forwarding") fail("ENVELOPE_CONFLICT");
+    if (receipt.token) return { kind: "pending", retryAt: receipt.nextAttemptAt };
+    if (now >= receipt.deadline) {
+      this.#terminal(receipt, "unconfirmed", now);
+      this.#emit("forward_unconfirmed", now, receipt.id);
+      return { kind: "unconfirmed", mayHaveBeenDelivered: true };
+    }
+    if (now < receipt.nextAttemptAt) return { kind: "pending", retryAt: receipt.nextAttemptAt };
+    receipt.attempts++;
+    receipt.nextAttemptAt = now + MEMORY_RELAY_TIMING.retryMs;
+    receipt.token = randomUUID();
+    // Gateway owns a bounded network deadline. Never reap an in-flight attempt
+    // underneath its completion; worker loss instead loses the whole epoch.
+    this.#expiry.delete(`r:${receipt.id}`);
+    this.#emit("forward_attempt", now, receipt.id);
+    return { kind: "attempt", token: receipt.token, envelope: JSON.parse(this.#payloads.get(receipt.id)!) as RelayEnvelope, origin: route.origin };
+  }
+
+  finishForward(epoch: string, envelopeId: string, token: string,
+    outcome: { readonly kind: "confirmed"; readonly acceptanceId: string } | { readonly kind: "retryable" | "rejected" }, now: number): boolean {
+    this.checkEpoch(epoch); time(now);
+    const value = captured(outcome, 256);
+    if (!value || !keys(value, ["kind", "acceptanceId"]) || !["confirmed", "retryable", "rejected"].includes(value.kind)
+      || (value.kind === "confirmed" && !isOpaqueRelayId(value.acceptanceId))) fail("INVALID_REQUEST");
+    const receipt = this.#receipts.get(envelopeId);
+    if (!receipt || receipt.state !== "forwarding" || !receipt.token || receipt.token !== token) return false;
+    receipt.token = undefined;
+    if (value.kind === "confirmed") {
+      receipt.acceptanceId = value.acceptanceId;
+      this.#terminal(receipt, "forwarded", now);
+      this.#emit("forward_confirmed", now, envelopeId);
+    } else if (value.kind === "rejected" || receipt.attempts >= RELAY_LIMITS.MAX_FORWARD_ATTEMPTS || now >= receipt.deadline) {
+      this.#terminal(receipt, "unconfirmed", now);
+      this.#emit("forward_unconfirmed", now, envelopeId);
+    } else {
+      this.#expiry.set(`r:${receipt.id}`, receipt.deadline);
+      this.#emit("forward_retry", now, envelopeId);
+    }
+    return true;
+  }
+
+  /** Timer/caller drives bounded expiry work. Never expires accepted mailboxes. */
+  maintenance(epoch: string, now: number, limit = 64): number {
+    this.checkEpoch(epoch); time(now);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 1024) fail("INVALID_REQUEST");
+    let processed = 0;
+    while (processed < limit) {
+      const key = this.#expiry.takeDue(now);
+      if (key === undefined) break;
+      processed++;
+      const id = key.slice(2);
+      if (key.startsWith("g:")) {
+        const entry = this.#registrations.get(id);
+        if (!entry || entry.references) continue;
+        this.#registrations.delete(id); this.#metadataBytes -= entry.bytes;
+        if (this.#sessions.get(entry.value.sessionId) === id) this.#sessions.delete(entry.value.sessionId);
+      } else {
+        const receipt = this.#receipts.get(id);
+        if (!receipt) continue;
+        if (receipt.state === "forwarding") {
+          this.#terminal(receipt, "unconfirmed", now);
+          this.#emit("forward_unconfirmed", now, id);
+        } else this.#forget(receipt);
+      }
+    }
+    return processed;
+  }
+
+  #activeRegistration(id: string, now: number): RegistrationEntry | undefined {
+    const entry = this.#registrations.get(id);
+    return entry && this.#sessions.get(entry.value.sessionId) === id && Date.parse(entry.value.leaseExpiresAt) > now ? entry : undefined;
+  }
+
+  #source(envelope: RelayEnvelope, now: number): void {
+    if (envelope.source.relay === RELAY_ID) {
+      if (!this.#activeRegistration(envelope.source.id, now)) fail("REGISTRATION_EXPIRED");
+    } else if (!this.#routes.has(envelope.source.relay)) fail("CROSS_RELAY_ENDPOINT");
+  }
+
+  #envelope(input: RelayEnvelope): RelayEnvelope {
+    const envelope = captured(input, RELAY_LIMITS.HTTP_BODY_BYTES);
+    if (!isRelayEnvelope(envelope) || !isRelayTimestamp(envelope.createdAt) || envelope.protocolVersion !== RELAY_PROTOCOL_VERSION
+      || !keys(envelope, ["envelopeId", "protocolVersion", "source", "target", "payload", "createdAt"])
+      || !keys(envelope.source, ["relay", "id"]) || !keys(envelope.target, ["relay", "id"])
+      || bytes(envelope.payload) > RELAY_LIMITS.PAYLOAD_BYTES) fail("INVALID_REQUEST");
+    return envelope;
+  }
+
+  #existing(envelope: RelayEnvelope, now: number): Receipt | undefined {
+    const receipt = this.#receipt(envelope.envelopeId, now);
+    if (receipt && receipt.digest !== createHash("sha256").update(canonicalJson(envelope)).digest("hex")) {
+      this.#emit("rejected", now, envelope.envelopeId, undefined, "conflict");
+      fail("ENVELOPE_CONFLICT");
+    }
+    return receipt;
+  }
+
+  #receipt(id: string, now: number): Receipt | undefined {
+    const receipt = this.#receipts.get(id);
+    if (receipt?.expiresAt !== undefined && receipt.expiresAt <= now) { this.#forget(receipt); return undefined; }
+    return receipt;
+  }
+
+  #admit(envelope: RelayEnvelope, now: number, state: "mailbox" | "forwarding", cursor: string | undefined): Receipt {
+    const created = Date.parse(envelope.createdAt);
+    if (created > now + MEMORY_RELAY_TIMING.clockSkewMs || now >= created + MEMORY_RELAY_TIMING.deadlineMs + MEMORY_RELAY_TIMING.clockSkewMs) {
+      this.#emit("rejected", now, envelope.envelopeId, undefined, "expired");
+      fail("ENVELOPE_EXPIRED");
+    }
+    const encoded = canonicalJson(envelope), size = Buffer.byteLength(encoded);
+    // Reserve a conservative encoded upper bound for fixed receipt fields,
+    // including 32-digit cursor, digest, UUIDs, timestamps, counters and status.
+    const reservation = bytes({ id: envelope.envelopeId, source: envelope.source, target: envelope.target }) + 1024;
+    const target = state === "mailbox" ? this.#registrations.get(envelope.target.id)! : undefined;
+    const peer = state === "forwarding" ? this.#routes.get(envelope.target.relay)! : undefined;
+    if (this.#payloads.size >= this.#limits.activeItems || this.#activeBytes + size > this.#limits.activeBytes
+      || this.#receipts.size >= this.#limits.receipts || this.#receiptBytes + reservation > this.#limits.receiptBytes
+      || (target && (target.mailbox.size >= this.#limits.mailboxItems || target.mailboxBytes + size > this.#limits.mailboxBytes))
+      || (peer && (peer.items >= this.#limits.peerItems || peer.payloadBytes + size > this.#limits.peerBytes))) {
+      this.#emit("rejected", now, envelope.envelopeId, undefined, "capacity");
+      fail("RELAY_CAPACITY");
+    }
+    const receipt: Receipt = { id: envelope.envelopeId, digest: createHash("sha256").update(encoded).digest("hex"),
+      source: { ...envelope.source }, target: { ...envelope.target }, bytes: reservation, payloadBytes: size, cursor,
+      acceptanceId: state === "mailbox" ? randomUUID() : undefined, state, attempts: 0, nextAttemptAt: now, token: undefined,
+      deadline: Math.min(now + MEMORY_RELAY_TIMING.deadlineMs, created + MEMORY_RELAY_TIMING.deadlineMs + MEMORY_RELAY_TIMING.clockSkewMs), expiresAt: undefined };
+    this.#receipts.set(receipt.id, receipt); this.#payloads.set(receipt.id, encoded);
+    this.#activeBytes += size; this.#receiptBytes += reservation;
+    for (const endpoint of [receipt.source, receipt.target]) {
+      if (endpoint.relay !== RELAY_ID) continue;
+      this.#registrations.get(endpoint.id)!.references++;
+      this.#expiry.delete(`g:${endpoint.id}`);
+    }
+    if (state === "forwarding") this.#expiry.set(`r:${receipt.id}`, receipt.deadline);
+    return receipt;
+  }
+
+  #terminal(receipt: Receipt, state: "acknowledged" | "forwarded" | "unconfirmed", now: number): void {
+    if (this.#payloads.delete(receipt.id)) {
+      this.#activeBytes -= receipt.payloadBytes;
+      if (receipt.state === "mailbox") {
+        const target = this.#registrations.get(receipt.target.id)!;
+        target.mailbox.delete(receipt.id); target.mailboxBytes -= receipt.payloadBytes;
+      } else {
+        const route = this.#routes.get(receipt.target.relay)!;
+        route.items--; route.payloadBytes -= receipt.payloadBytes;
+      }
+    }
+    receipt.state = state; receipt.token = undefined;
+    receipt.expiresAt = now + MEMORY_RELAY_TIMING.receiptMs;
+    this.#expiry.set(`r:${receipt.id}`, receipt.expiresAt);
+  }
+
+  #forget(receipt: Receipt): void {
+    this.#receipts.delete(receipt.id); this.#receiptBytes -= receipt.bytes;
+    this.#expiry.delete(`r:${receipt.id}`);
+    for (const endpoint of [receipt.source, receipt.target]) {
+      if (endpoint.relay !== RELAY_ID) continue;
+      const entry = this.#registrations.get(endpoint.id)!;
+      entry.references--;
+      if (!entry.references) this.#expiry.set(`g:${endpoint.id}`, Date.parse(entry.value.leaseExpiresAt));
+    }
+  }
+
+  #emit(kind: RelayInvestigationEvent["kind"], now: number, envelopeId?: string, envelope?: RelayEnvelope, reason?: RelayInvestigationEvent["reason"]): void {
+    if (!this.#sink) return;
+    try {
+      if (this.#sink.offer({ epoch: this.#epoch, at: now, kind, envelopeId, envelope, reason })) return;
+    } catch { /* Investigation cannot roll back or turn acceptance into a failure. */ }
+    this.#logDrops = Math.min(Number.MAX_SAFE_INTEGER, this.#logDrops + 1);
+  }
+}

--- a/tests/integration/control-api-schema-temp-cleanup.test.ts
+++ b/tests/integration/control-api-schema-temp-cleanup.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { existsSync, mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,15 +12,26 @@ test("schema contract cleanup does not delete a planted temp-root target", async
   const sandbox = mkdtempSync(join(tmpdir(), "wolfpack-schema-cleanup-regression-"));
   const victim = join(sandbox, "victim");
   const sentinel = join(victim, "sentinel");
+  const bin = join(sandbox, "bin");
+  const shell = join(bin, "fixture-shell");
+  const providerMarker = join(sandbox, "provider-version-called");
   let child: Bun.Subprocess<"pipe", "ignore", "inherit"> | undefined;
   let exited: Promise<number> | undefined;
 
   try {
     mkdirSync(victim);
     writeFileSync(sentinel, "keep me");
+    mkdirSync(bin, { mode: 0o700 });
+    // Server import reads a login-shell PATH, and /api/providers executes --version.
+    // Neither the operator's shell startup nor installed agent CLIs belong in
+    // this cleanup regression's deadline. Keep real HTTP/probing, but use owned
+    // fixtures (including the shell's executable probe) with no external commands.
+    writeFileSync(join(bin, "test"), '#!/bin/sh\n[ "$1" = "-x" ] && [ -x "$2" ]\n', { mode: 0o700 });
+    writeFileSync(shell, '#!/bin/sh\n[ "$1" = "-lic" ] && [ "$2" = \'echo $PATH\' ] || exit 64\nprintf \'%s\\n\' "$PATH"\n', { mode: 0o700 });
+    writeFileSync(join(bin, "pi"), '#!/bin/sh\n[ "$#" = "1" ] && [ "$1" = "--version" ] || exit 64\nprintf \'%s\\n\' "$1" >> "$WOLFPACK_SCHEMA_PROVIDER_MARKER"\nprintf \'fixture-pi 0.0.0\\n\'\n', { mode: 0o700 });
     child = Bun.spawn([process.execPath, "test", "--preload", PRELOAD, TARGET_TEST], {
       cwd: ROOT,
-      env: { ...process.env, TMPDIR: sandbox },
+      env: { ...process.env, TMPDIR: sandbox, PATH: bin, SHELL: shell, WOLFPACK_SCHEMA_PROVIDER_MARKER: providerMarker },
       stdin: "pipe",
       stdout: "ignore",
       stderr: "inherit",
@@ -34,6 +45,8 @@ test("schema contract cleanup does not delete a planted temp-root target", async
 
     expect(await exited).toBe(0);
     expect(existsSync(sentinel)).toBe(true);
+    expect(readFileSync(sentinel, "utf8")).toBe("keep me");
+    expect(readFileSync(providerMarker, "utf8")).toBe("--version\n");
   } finally {
     if (child?.exitCode === null) child.kill("SIGKILL");
     if (exited) await exited;

--- a/tests/unit/task-relay-investigation.test.ts
+++ b/tests/unit/task-relay-investigation.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { chmodSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BoundedRelayInvestigation, RotatingRelayInvestigationWriter } from "../../src/task-relay/investigation.ts";
+import type { RelayInvestigationEvent } from "../../src/task-relay/investigation.ts";
+import { MemoryRelayStore } from "../../src/task-relay/memory-store.ts";
+
+const event = (envelopeId = "record"): RelayInvestigationEvent => ({ epoch: randomUUID(), at: Date.now(), kind: "acknowledged", envelopeId });
+const root = () => mkdtempSync(join(tmpdir(), "wolfpack-relay-investigation-"));
+const gate = () => { let resolve!: () => void; const promise = new Promise<void>(done => { resolve = done; }); return { promise, resolve }; };
+
+describe("bounded best-effort relay investigation", () => {
+  test("queue cap includes blocked in-flight write, then releases exact credits", async () => {
+    const blocked = gate(), entered = gate(); const lines: string[] = [];
+    const logger = new BoundedRelayInvestigation({ async append(line) { entered.resolve(); await blocked.promise; lines.push(line); } }, { items: 1 });
+    try {
+      const input = event("first");
+      expect(logger.offer(input)).toBe(true);
+      await entered.promise;
+      const charged = logger.health().queuedBytes;
+      expect(charged).toBeGreaterThan(0);
+      expect(logger.offer(event("overflow"))).toBe(false);
+      expect(logger.health()).toMatchObject({ queuedItems: 1, queuedBytes: charged, droppedRecords: 1, degraded: true });
+      (input as { envelopeId: string }).envelopeId = "caller-mutation";
+      blocked.resolve(); await logger.drain();
+      expect(JSON.parse(lines[0]!).envelopeId).toBe("first");
+      expect(logger.health()).toMatchObject({ queuedItems: 0, queuedBytes: 0, written: 1 });
+      expect(logger.offer(event("after-release"))).toBe(true);
+      await logger.close();
+      expect(logger.offer(event("closed"))).toBe(false);
+      expect(logger.health()).toMatchObject({ written: 2, droppedRecords: 2, lastFailure: "closed", closed: true });
+    } finally { blocked.resolve(); await logger.close(); }
+  });
+
+  test("byte cap, exotics and getters fail without calling code or filling the queue", async () => {
+    const logger = new BoundedRelayInvestigation({ async append() { throw new Error("must not write"); } }, { bytes: 1 });
+    let calls = 0;
+    expect(logger.offer({ ...event(), get envelopeId() { calls++; return "getter"; } })).toBe(false);
+    expect(logger.offer({ ...event(), envelope: new ArrayBuffer(1024) } as any)).toBe(false);
+    expect(logger.offer(new Proxy(event(), { ownKeys() { calls++; return []; } }))).toBe(false);
+    expect(logger.offer(event())).toBe(false);
+    expect(calls).toBe(0);
+    expect(logger.health()).toMatchObject({ queuedBytes: 0, queuedItems: 0, invalidRecords: 3, droppedRecords: 4 });
+    await logger.close();
+  });
+
+  test("write failure is counted and sanitized, later writes recover without replaying failed records", async () => {
+    let attempts = 0;
+    const logger = new BoundedRelayInvestigation({ async append() { if (++attempts === 1) throw new Error("secret disk error details"); } });
+    expect(logger.offer(event("failed"))).toBe(true);
+    expect(logger.offer(event("written"))).toBe(true);
+    await logger.close();
+    expect(logger.health()).toMatchObject({ queuedItems: 0, queuedBytes: 0, written: 1, writeFailures: 1, droppedRecords: 1, lastFailure: "write_failed" });
+    expect(JSON.stringify(logger.health())).not.toContain("secret");
+    expect(attempts).toBe(2);
+  });
+
+  test("offers in the pump completion microtask cannot be stranded", async () => {
+    // Exercise both sides of each completion/assimilation microtask, without timers.
+    for (let gap = 0; gap < 16; gap++) {
+      const lines: string[] = [];
+      const logger = new BoundedRelayInvestigation({ async append(line) { lines.push(line); } });
+      logger.offer(event("first"));
+      for (let i = 0; i < gap; i++) await Promise.resolve();
+      logger.offer(event("second"));
+      await logger.close();
+      expect(lines.length).toBe(2);
+      expect(logger.health()).toMatchObject({ queuedItems: 0, queuedBytes: 0, written: 2 });
+    }
+  });
+
+  test("store ACK frees active payload while an independent, bounded log queue still owns its copy", async () => {
+    const blocked = gate();
+    const logger = new BoundedRelayInvestigation({ async append() { await blocked.promise; } });
+    const store = new MemoryRelayStore({ investigation: logger });
+    const now = Date.now();
+    const connect = (sessionId: string) => store.register({ sessionId, generation: "g", leaseMs: 60_000, protocolVersions: [2] }, now).endpoint;
+    try {
+      const source = connect("source"), target = connect("target");
+      store.accept(store.epoch, { envelopeId: "payload", protocolVersion: 2, source, target, createdAt: new Date(now).toISOString(), payload: "x".repeat(40_000) }, now);
+      store.acknowledge(store.epoch, target.id, "payload", now);
+      expect(store.stats()).toMatchObject({ activeItems: 0, activeBytes: 0, receipts: 1 });
+      expect(logger.health().queuedBytes).toBeGreaterThan(40_000);
+      blocked.resolve(); await logger.close();
+      expect(logger.health()).toMatchObject({ queuedBytes: 0, queuedItems: 0, written: 4 });
+    } finally { blocked.resolve(); await logger.close(); }
+  });
+});
+
+describe("private fixed-slot investigation rotation", () => {
+  test("rotation bounds disk without touching legacy files; files and directory remain private", async () => {
+    const home = root(), logs = join(home, "investigation-volatile-v1");
+    const legacy = join(home, "relay-state.json");
+    writeFileSync(legacy, "legacy investigation, not recovery");
+    let now = Date.now();
+    const writer = new RotatingRelayInvestigationWriter(logs, { slots: 2, segmentBytes: 100, clock: () => now++ });
+    try {
+      for (let i = 0; i < 10; i++) {
+        await writer.append(JSON.stringify({ i, body: "x".repeat(50) }) + "\n");
+        const files = readdirSync(logs);
+        expect(files.length).toBeLessThanOrEqual(2);
+        expect(files.reduce((sum, name) => sum + lstatSync(join(logs, name)).size, 0)).toBeLessThanOrEqual(200);
+        for (const name of files) expect(lstatSync(join(logs, name)).mode & 0o077).toBe(0);
+      }
+      expect(lstatSync(logs).mode & 0o077).toBe(0);
+      expect(readFileSync(legacy, "utf8")).toBe("legacy investigation, not recovery");
+      const content = readdirSync(logs).flatMap(name => readFileSync(join(logs, name), "utf8").trim().split("\n").map(line => JSON.parse(line).i)).sort((a, b) => a - b);
+      expect(content).toEqual([8, 9]);
+    } finally { rmSync(home, { recursive: true, force: true }); }
+  });
+
+  test("retention is from creation, not refreshed by continuous writes", async () => {
+    const home = root(), logs = join(home, "logs"); let now = Date.now();
+    const start = now;
+    const writer = new RotatingRelayInvestigationWriter(logs, { slots: 2, segmentBytes: 1000, retentionMs: 100, clock: () => now });
+    try {
+      await writer.append('{"old":true}\n');
+      now = start + 99; await writer.append('{"recent":true}\n');
+      now = start + 100; await writer.append('{"new":true}\n');
+      expect(readdirSync(logs).map(name => readFileSync(join(logs, name), "utf8"))).toEqual(['{"new":true}\n']);
+    } finally { rmSync(home, { recursive: true, force: true }); }
+  });
+
+  test("idle cleanup coalesces through the bounded queue and removes expired output without another delivery", async () => {
+    const home = root(), logs = join(home, "logs"); let now = Date.now();
+    const writer = new RotatingRelayInvestigationWriter(logs, { retentionMs: 100, clock: () => now });
+    const logger = new BoundedRelayInvestigation(writer);
+    try {
+      logger.offer(event()); await logger.drain();
+      expect(readdirSync(logs).length).toBe(1);
+      now += 100;
+      expect(logger.requestCleanup()).toBe(true);
+      expect(logger.requestCleanup()).toBe(false);
+      await logger.close();
+      expect(readdirSync(logs)).toEqual([]);
+      expect(logger.health()).toMatchObject({ written: 1, queuedItems: 0, maintenanceFailures: 0, droppedRecords: 0 });
+    } finally { await logger.close(); rmSync(home, { recursive: true, force: true }); }
+  });
+
+  test("a restarted writer starts another slot, never replays or appends into partial historical JSON", async () => {
+    const home = root(), logs = join(home, "logs");
+    const options = { slots: 2, segmentBytes: 1000 };
+    try {
+      await new RotatingRelayInvestigationWriter(logs, options).append('{"partial":');
+      await new RotatingRelayInvestigationWriter(logs, options).append('{"next":true}\n');
+      const contents = readdirSync(logs).map(name => readFileSync(join(logs, name), "utf8"));
+      expect(contents).toContain('{"partial":'); expect(contents).toContain('{"next":true}\n');
+    } finally { rmSync(home, { recursive: true, force: true }); }
+  });
+
+  test("symlinks and world-readable outputs fail closed in logging, not in relay delivery", async () => {
+    const home = root(), logs = join(home, "logs"), outside = join(home, "outside");
+    mkdirSync(logs, { mode: 0o700 }); writeFileSync(outside, "untouched", { mode: 0o600 });
+    const slot = join(logs, "relay-investigation-00.jsonl");
+    symlinkSync(outside, slot);
+    try {
+      const writer = new RotatingRelayInvestigationWriter(logs, { slots: 1 });
+      await expect(writer.append("{}\n")).rejects.toThrow();
+      expect(readFileSync(outside, "utf8")).toBe("untouched");
+      rmSync(slot); writeFileSync(slot, "private", { mode: 0o600 }); chmodSync(slot, 0o644);
+      await expect(writer.append("{}\n")).rejects.toThrow();
+      expect(readFileSync(slot, "utf8")).toBe("private");
+      chmodSync(slot, 0o600); chmodSync(logs, 0o755);
+      await expect(writer.append("{}\n")).rejects.toThrow();
+    } finally { rmSync(home, { recursive: true, force: true }); }
+  });
+});

--- a/tests/unit/task-relay-investigation.test.ts
+++ b/tests/unit/task-relay-investigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { chmodSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, linkSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { BoundedRelayInvestigation, RotatingRelayInvestigationWriter } from "../../src/task-relay/investigation.ts";
@@ -150,13 +150,16 @@ describe("private fixed-slot investigation rotation", () => {
     } finally { rmSync(home, { recursive: true, force: true }); }
   });
 
-  test("symlinks and world-readable outputs fail closed in logging, not in relay delivery", async () => {
+  test("symlinks, hardlinks and world-readable outputs fail closed in logging, not in relay delivery", async () => {
     const home = root(), logs = join(home, "logs"), outside = join(home, "outside");
     mkdirSync(logs, { mode: 0o700 }); writeFileSync(outside, "untouched", { mode: 0o600 });
     const slot = join(logs, "relay-investigation-00.jsonl");
     symlinkSync(outside, slot);
     try {
       const writer = new RotatingRelayInvestigationWriter(logs, { slots: 1 });
+      await expect(writer.append("{}\n")).rejects.toThrow();
+      expect(readFileSync(outside, "utf8")).toBe("untouched");
+      rmSync(slot); linkSync(outside, slot);
       await expect(writer.append("{}\n")).rejects.toThrow();
       expect(readFileSync(outside, "utf8")).toBe("untouched");
       rmSync(slot); writeFileSync(slot, "private", { mode: 0o600 }); chmodSync(slot, 0o644);

--- a/tests/unit/task-relay-memory.test.ts
+++ b/tests/unit/task-relay-memory.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { MemoryRelayStore, MEMORY_RELAY_TIMING, MemoryRelayError } from "../../src/task-relay/memory-store.ts";
+import { RelayExpiryIndex } from "../../src/task-relay/expiry-index.ts";
+import { RELAY_ID, RELAY_PROTOCOL_VERSION, RELAY_LIMITS } from "../../src/task-relay/domain.ts";
+import type { RelayEnvelope } from "../../src/task-relay/domain.ts";
+
+const NOW = Date.parse("2026-09-08T00:00:00Z");
+function fixture(options: ConstructorParameters<typeof MemoryRelayStore>[0] = {}) {
+  const store = new MemoryRelayStore(options), epoch = store.epoch;
+  const registration = (sessionId: string, generation = "g", now = NOW) => store.register({ sessionId, generation, leaseMs: RELAY_LIMITS.MAX_LEASE_MS, protocolVersions: [RELAY_PROTOCOL_VERSION] }, now);
+  const source = registration("source").endpoint, target = registration("target").endpoint;
+  const envelope = (id: string = randomUUID(), payload: unknown = { text: "opaque" }, now = NOW): RelayEnvelope => ({
+    envelopeId: id, protocolVersion: RELAY_PROTOCOL_VERSION, source, target, createdAt: new Date(now).toISOString(), payload,
+  });
+  return { store, epoch, source, target, envelope, registration };
+}
+function code(operation: () => unknown, expected: MemoryRelayError["code"]) {
+  try { operation(); throw new Error("operation unexpectedly succeeded"); }
+  catch (error) { expect(error).toBeInstanceOf(MemoryRelayError); expect((error as MemoryRelayError).code).toBe(expected); }
+}
+
+describe("bounded volatile relay engine (not legacy gateway cutover)", () => {
+  test("ACK releases payload, preserves exact receipt, and sparse pages use real cursors", () => {
+    const f = fixture();
+    const first = f.envelope("1"), second = f.envelope("2"), third = f.envelope("3");
+    const accepted = f.store.accept(f.epoch, first, NOW);
+    f.store.accept(f.epoch, second, NOW); f.store.accept(f.epoch, third, NOW);
+    expect(f.store.acknowledge(f.epoch, f.target.id, "2", NOW)).toBe("acknowledged");
+    const page = f.store.inbox(f.epoch, f.target.id, "0", NOW);
+    expect(page.deliveries.map(x => x.cursor)).toEqual(["1", "3"]);
+    expect(page.nextCursor).toBe("3");
+    const limited = f.store.inbox(f.epoch, f.target.id, "0", NOW, 1);
+    expect(limited.nextCursor).toBe("1"); expect(limited.hasMore).toBe(true);
+    expect(f.store.inbox(f.epoch, f.target.id, limited.nextCursor, NOW).deliveries.map(x => x.cursor)).toEqual(["3"]);
+    expect(f.store.acknowledge(f.epoch, f.target.id, "1", NOW)).toBe("acknowledged");
+    expect(f.store.acknowledge(f.epoch, f.target.id, "3", NOW)).toBe("acknowledged");
+    expect(f.store.stats()).toMatchObject({ activeItems: 0, activeBytes: 0, receipts: 3 });
+    expect(f.store.accept(f.epoch, first, NOW)).toEqual({ ...accepted, kind: "duplicate" });
+    expect(f.store.acknowledge(f.epoch, f.target.id, "1", NOW)).toBe("duplicate");
+    expect(f.store.inbox(f.epoch, f.target.id, "0", NOW)).toEqual({ deliveries: [], nextCursor: "0", hasMore: false });
+    f.store.accept(f.epoch, f.envelope("4"), NOW);
+    expect(f.store.inbox(f.epoch, f.target.id, "0", NOW).nextCursor).toBe("4");
+  });
+
+  test("genuine changed payload/timestamp conflict even after ACK; receipts are not refreshed", () => {
+    const f = fixture(), original = f.envelope("stable");
+    f.store.accept(f.epoch, original, NOW);
+    f.store.acknowledge(f.epoch, f.target.id, "stable", NOW);
+    code(() => f.store.accept(f.epoch, { ...original, payload: "changed" }, NOW), "ENVELOPE_CONFLICT");
+    code(() => f.store.accept(f.epoch, { ...original, createdAt: new Date(NOW + 1).toISOString() }, NOW), "ENVELOPE_CONFLICT");
+    const expiry = NOW + MEMORY_RELAY_TIMING.receiptMs;
+    f.registration("source", "g", expiry - 1); f.registration("target", "g", expiry - 1);
+    expect(f.store.accept(f.epoch, original, expiry - 1).kind).toBe("duplicate");
+    f.store.maintenance(f.epoch, expiry);
+    expect(f.store.stats().receipts).toBe(0);
+    code(() => f.store.accept(f.epoch, original, expiry), "ENVELOPE_EXPIRED");
+  });
+
+  test("payload ownership and prototype-looking keys are detached in both directions", () => {
+    const f = fixture();
+    const payload = JSON.parse('{"__proto__":{"n":1},"constructor":[2]}');
+    const envelope = f.envelope("owned", payload);
+    f.store.accept(f.epoch, envelope, NOW);
+    payload.__proto__.n = 9;
+    const page = f.store.inbox(f.epoch, f.target.id, "0", NOW);
+    expect(page.deliveries[0]!.envelope.payload).toEqual(JSON.parse('{"__proto__":{"n":1},"constructor":[2]}'));
+    (page.deliveries[0]!.envelope.payload as any).__proto__.n = 100;
+    expect((f.store.inbox(f.epoch, f.target.id, "0", NOW).deliveries[0]!.envelope.payload as any).__proto__.n).toBe(1);
+  });
+
+  test("rejects accessors/proxies/exotics without executing code or charging state", () => {
+    const f = fixture(); let calls = 0;
+    const accessor = { ...f.envelope(), get payload() { calls++; return {}; } };
+    const proxy = new Proxy(f.envelope(), { ownKeys() { calls++; throw new Error("trap"); } });
+    const before = f.store.stats();
+    for (const envelope of [accessor, proxy, f.envelope("array-buffer", new ArrayBuffer(1024)), { ...f.envelope(), extra: "ignored?" }, f.envelope("date", new Date())]) {
+      code(() => f.store.accept(f.epoch, envelope, NOW), "INVALID_REQUEST");
+    }
+    expect(calls).toBe(0); expect(f.store.stats()).toEqual(before);
+  });
+
+  test("global and endpoint count budgets reject BEFORE acceptance, duplicates need no credits", () => {
+    for (const limits of [{ activeItems: 1 }, { mailboxItems: 1 }]) {
+      const f = fixture({ limits }), first = f.envelope("first");
+      const accepted = f.store.accept(f.epoch, first, NOW), before = f.store.stats();
+      code(() => f.store.accept(f.epoch, f.envelope("second"), NOW), "RELAY_CAPACITY");
+      expect(f.store.stats()).toEqual(before);
+      expect(f.store.accept(f.epoch, first, NOW)).toEqual({ ...accepted, kind: "duplicate" });
+      f.store.acknowledge(f.epoch, f.target.id, "first", NOW);
+      expect(f.store.accept(f.epoch, f.envelope("second"), NOW).kind).toBe("accepted");
+    }
+  });
+
+  test("byte, receipt reservation, registration and route bounds cannot be bypassed", () => {
+    for (const limits of [{ activeBytes: 1 }, { mailboxBytes: 1 }, { receiptBytes: 1 }]) {
+      const f = fixture({ limits }), before = f.store.stats();
+      code(() => f.store.accept(f.epoch, f.envelope(), NOW), "RELAY_CAPACITY");
+      expect(f.store.stats()).toEqual(before);
+    }
+    const f = fixture({ limits: { receipts: 1, registrations: 2, routes: 1 } });
+    f.store.accept(f.epoch, f.envelope("first"), NOW);
+    f.store.acknowledge(f.epoch, f.target.id, "first", NOW);
+    code(() => f.store.accept(f.epoch, f.envelope("second"), NOW), "RELAY_CAPACITY");
+    code(() => f.registration("third"), "RELAY_CAPACITY");
+    const route = f.store.peerRoute(f.epoch, "https://one.example.ts.net");
+    expect(f.store.peerRoute(f.epoch, route.origin)).toEqual(route);
+    code(() => f.store.peerRoute(f.epoch, "https://two.example.ts.net"), "RELAY_CAPACITY");
+    code(() => f.store.peerRoute(f.epoch, "https://untrusted.example.com"), "INVALID_REQUEST");
+    const tiny = new MemoryRelayStore({ limits: { metadataBytes: 1 } });
+    code(() => tiny.register({ sessionId: "s", generation: "g", leaseMs: 10, protocolVersions: [2] }, NOW), "RELAY_CAPACITY");
+    expect(tiny.stats().registrations).toBe(0);
+  });
+
+  test("leases are strict; accepted obligations pin old generations, not their authority", () => {
+    const f = fixture();
+    f.store.accept(f.epoch, f.envelope("pending"), NOW);
+    f.store.maintenance(f.epoch, NOW + 10_000_000);
+    expect(f.store.stats()).toMatchObject({ activeItems: 1, registrations: 2 });
+    code(() => f.store.inbox(f.epoch, f.target.id, "0", NOW + RELAY_LIMITS.MAX_LEASE_MS), "REGISTRATION_EXPIRED");
+    expect(f.registration("target", "g", NOW + 10_000_000).endpoint).toEqual(f.target);
+    const replacement = f.registration("target", "new", NOW + 10_000_000).endpoint;
+    expect(replacement.id).not.toBe(f.target.id);
+    code(() => f.store.acknowledge(f.epoch, f.target.id, "pending", NOW + 10_000_000), "REGISTRATION_EXPIRED");
+    expect(f.store.acknowledge(f.epoch, replacement.id, "pending", NOW + 10_000_000)).toBe("missing");
+    expect(f.store.stats().activeItems).toBe(1);
+  });
+
+  test("renewals update one expiry node and preserve owned registration values", () => {
+    const f = fixture();
+    for (let i = 0; i < 10_000; i++) f.registration("source", "g", NOW + i);
+    expect(f.store.stats()).toMatchObject({ registrations: 2, expiryEntries: 2 });
+    const registered = f.store.registrationForSession(f.epoch, "source", NOW)!;
+    (registered.protocolVersions as number[]).push(99);
+    expect(f.store.registration(f.epoch, f.source.id, NOW)!.protocolVersions).toEqual([2]);
+    expect(f.store.maintenance(f.epoch, NOW + 1_000_000)).toBe(2);
+    expect(f.store.stats()).toMatchObject({ registrations: 0, sessions: 0, metadataBytes: 0, expiryEntries: 0 });
+  });
+
+  test("new instances lose everything and reject old epochs, not silently reset cursors", () => {
+    const f = fixture(); f.store.accept(f.epoch, f.envelope(), NOW);
+    const restarted = new MemoryRelayStore();
+    expect(restarted.epoch).not.toBe(f.epoch);
+    expect(restarted.stats().activeItems).toBe(0);
+    code(() => restarted.inbox(f.epoch, f.target.id, "0", NOW), "RELAY_RESET");
+    for (const cursor of ["-1", "01", "1.1", "9007199254740993", "9".repeat(33)]) {
+      code(() => f.store.inbox(f.epoch, f.target.id, cursor, NOW), "INVALID_CURSOR");
+    }
+  });
+
+  test("page byte budget includes explicit cursor framing and never skips a truncated suffix", () => {
+    const f = fixture();
+    for (let i = 0; i < 8; i++) f.store.accept(f.epoch, f.envelope(String(i), "x".repeat(47 * 1024)), NOW);
+    const first = f.store.inbox(f.epoch, f.target.id, "0", NOW);
+    expect(first.deliveries.length).toBe(5); expect(first.hasMore).toBe(true); expect(first.nextCursor).toBe("5");
+    expect(first.deliveries.reduce((sum, item) => sum + Buffer.byteLength(JSON.stringify(item)), 0)).toBeLessThanOrEqual(RELAY_LIMITS.INBOX_PAGE_BYTES);
+    expect(f.store.inbox(f.epoch, f.target.id, first.nextCursor, NOW).deliveries.map(x => x.cursor)).toEqual(["6", "7", "8"]);
+  });
+
+  test("forwarding does not accept pending work; one token owns an attempt and confirmation releases bytes", () => {
+    const f = fixture(); const route = f.store.peerRoute(f.epoch, "https://peer.example.ts.net");
+    const envelope = { ...f.envelope("forward"), target: { relay: route.id, id: randomUUID() } };
+    const first = f.store.beginForward(f.epoch, envelope, NOW);
+    expect(first.kind).toBe("attempt"); if (first.kind !== "attempt") throw new Error("no attempt");
+    expect(f.store.beginForward(f.epoch, envelope, NOW)).toMatchObject({ kind: "pending" });
+    expect(f.store.finishForward(f.epoch, envelope.envelopeId, "wrong", { kind: "confirmed", acceptanceId: randomUUID() }, NOW)).toBe(false);
+    const acceptanceId = randomUUID();
+    expect(f.store.finishForward(f.epoch, envelope.envelopeId, first.token, { kind: "confirmed", acceptanceId }, NOW)).toBe(true);
+    expect(f.store.finishForward(f.epoch, envelope.envelopeId, first.token, { kind: "retryable" }, NOW)).toBe(false);
+    expect(f.store.beginForward(f.epoch, envelope, NOW)).toEqual({ kind: "forwarded", acceptanceId });
+    expect(f.store.stats()).toMatchObject({ activeItems: 0, activeBytes: 0, receipts: 1 });
+  });
+
+  test("four failures exhaust visibly, cooldown calls do not spend attempts and duplicates never rearm", () => {
+    const f = fixture(); const route = f.store.peerRoute(f.epoch, "https://peer.example.ts.net");
+    const envelope = { ...f.envelope("exhaust"), target: { relay: route.id, id: randomUUID() } };
+    for (let i = 0; i < 4; i++) {
+      const at = NOW + i * 1000;
+      const attempt = f.store.beginForward(f.epoch, envelope, at);
+      if (attempt.kind !== "attempt") throw new Error(`no attempt ${i}`);
+      f.store.finishForward(f.epoch, envelope.envelopeId, attempt.token, { kind: "retryable" }, at);
+      expect(f.store.beginForward(f.epoch, envelope, at + 1).kind).toBe(i < 3 ? "pending" : "unconfirmed");
+    }
+    expect(f.store.beginForward(f.epoch, envelope, NOW + 60_000)).toEqual({ kind: "unconfirmed", mayHaveBeenDelivered: true });
+    expect(f.store.stats()).toMatchObject({ activeItems: 0, activeBytes: 0, receipts: 1 });
+    code(() => f.store.beginForward(f.epoch, { ...envelope, payload: "new" }, NOW + 60_000), "ENVELOPE_CONFLICT");
+  });
+
+  test("deadline expires idle forwarding but cannot invalidate a still-owned network completion", () => {
+    const f = fixture(); const route = f.store.peerRoute(f.epoch, "https://peer.example.ts.net");
+    const envelope = { ...f.envelope("deadline"), target: { relay: route.id, id: randomUUID() } };
+    const attempt = f.store.beginForward(f.epoch, envelope, NOW);
+    if (attempt.kind !== "attempt") throw new Error("no attempt");
+    f.store.maintenance(f.epoch, NOW + MEMORY_RELAY_TIMING.deadlineMs);
+    expect(f.store.stats().activeItems).toBe(1);
+    const confirmedAt = NOW + MEMORY_RELAY_TIMING.deadlineMs + 1;
+    const acceptanceId = randomUUID();
+    f.store.finishForward(f.epoch, envelope.envelopeId, attempt.token, { kind: "confirmed", acceptanceId }, confirmedAt);
+    expect(f.store.beginForward(f.epoch, envelope, confirmedAt)).toEqual({ kind: "forwarded", acceptanceId });
+    expect(f.store.stats().activeItems).toBe(0);
+
+    const idle = fixture(); const idleRoute = idle.store.peerRoute(idle.epoch, "https://peer.example.ts.net");
+    const queued = { ...idle.envelope("idle"), target: { relay: idleRoute.id, id: randomUUID() } };
+    const started = idle.store.beginForward(idle.epoch, queued, NOW);
+    if (started.kind !== "attempt") throw new Error("no idle attempt");
+    idle.store.finishForward(idle.epoch, queued.envelopeId, started.token, { kind: "retryable" }, NOW + 1);
+    idle.store.maintenance(idle.epoch, NOW + MEMORY_RELAY_TIMING.deadlineMs);
+    expect(idle.store.stats().activeItems).toBe(0);
+    expect(idle.store.beginForward(idle.epoch, queued, NOW + MEMORY_RELAY_TIMING.deadlineMs)).toMatchObject({ kind: "unconfirmed" });
+  });
+
+  test("per-peer credit recovers after terminal outcome; no credit is granted by a forged completion", () => {
+    for (const limits of [{ peerItems: 1 }, { peerBytes: 1 }]) {
+      const f = fixture({ limits }); const route = f.store.peerRoute(f.epoch, "https://peer.example.ts.net");
+      const envelope = { ...f.envelope("a"), target: { relay: route.id, id: randomUUID() } };
+      if ("peerBytes" in limits) {
+        const before = f.store.stats(); code(() => f.store.beginForward(f.epoch, envelope, NOW), "RELAY_CAPACITY"); expect(f.store.stats()).toEqual(before);
+        continue;
+      }
+      const attempt = f.store.beginForward(f.epoch, envelope, NOW);
+      if (attempt.kind !== "attempt") throw new Error("no attempt");
+      code(() => f.store.beginForward(f.epoch, { ...envelope, envelopeId: "b" }, NOW), "RELAY_CAPACITY");
+      f.store.finishForward(f.epoch, "a", attempt.token, { kind: "rejected" }, NOW);
+      expect(f.store.beginForward(f.epoch, { ...envelope, envelopeId: "b" }, NOW).kind).toBe("attempt");
+    }
+  });
+
+  test("two engine instances deduplicate a lost peer response before source acceptance", () => {
+    const a = fixture(), b = fixture();
+    const routeB = a.store.peerRoute(a.epoch, "https://b.example.ts.net");
+    const routeA = b.store.peerRoute(b.epoch, "https://a.example.ts.net");
+    const outgoing = { ...a.envelope("lost-peer-response"), target: { relay: routeB.id, id: b.target.id } };
+    const deliver = (attempt: ReturnType<MemoryRelayStore["beginForward"]>) => {
+      if (attempt.kind !== "attempt") throw new Error("no attempt");
+      // Same normalization as the trusted peer gateway: source is scoped to the
+      // receiving relay's origin alias, target becomes its local endpoint.
+      return b.store.accept(b.epoch, { ...attempt.envelope,
+        source: { relay: routeA.id, id: attempt.envelope.source.id }, target: b.target }, NOW);
+    };
+    const first = a.store.beginForward(a.epoch, outgoing, NOW);
+    if (first.kind !== "attempt") throw new Error("no first attempt");
+    const accepted = deliver(first);
+    a.store.finishForward(a.epoch, outgoing.envelopeId, first.token, { kind: "retryable" }, NOW); // response lost
+    expect(a.store.beginForward(a.epoch, outgoing, NOW).kind).toBe("pending");
+    const second = a.store.beginForward(a.epoch, outgoing, NOW + 1000);
+    if (second.kind !== "attempt") throw new Error("no retry");
+    const duplicate = deliver(second);
+    expect(duplicate).toEqual({ ...accepted, kind: "duplicate" });
+    a.store.finishForward(a.epoch, outgoing.envelopeId, second.token, { kind: "confirmed", acceptanceId: duplicate.acceptanceId }, NOW + 1000);
+    expect(a.store.beginForward(a.epoch, outgoing, NOW + 1000)).toEqual({ kind: "forwarded", acceptanceId: accepted.acceptanceId });
+    expect(b.store.inbox(b.epoch, b.target.id, "0", NOW).deliveries.length).toBe(1);
+    b.store.acknowledge(b.epoch, b.target.id, outgoing.envelopeId, NOW);
+    expect(a.store.stats().activeBytes).toBe(0); expect(b.store.stats().activeBytes).toBe(0);
+  });
+
+  test("completed payload volume is absent from active state while compact receipts remain bounded", () => {
+    const f = fixture();
+    for (let i = 0; i < 5000; i++) {
+      const id = String(i);
+      f.store.accept(f.epoch, f.envelope(id, "x".repeat(1024)), NOW);
+      f.store.acknowledge(f.epoch, f.target.id, id, NOW);
+    }
+    expect(f.store.stats()).toMatchObject({ activeItems: 0, activeBytes: 0, receipts: 5000, expiryEntries: 5000 });
+    expect(f.store.inbox(f.epoch, f.target.id, "0", NOW).deliveries).toEqual([]);
+    f.store.accept(f.epoch, f.envelope("live"), NOW);
+    expect(f.store.inbox(f.epoch, f.target.id, "0", NOW).deliveries.map(x => x.cursor)).toEqual(["5001"]);
+    expect(f.store.stats().activeBytes).toBeLessThan(1024);
+    expect(f.store.maintenance(f.epoch, NOW + MEMORY_RELAY_TIMING.receiptMs, 64)).toBe(64);
+    expect(f.store.stats()).toMatchObject({ receipts: 4937, activeItems: 1 });
+  });
+
+  test("investigation failure never rolls back accepted state or retains completed payload", () => {
+    const f = fixture({ investigation: { offer() { throw new Error("ENOSPC"); } } });
+    f.store.accept(f.epoch, f.envelope("log-failure"), NOW);
+    f.store.acknowledge(f.epoch, f.target.id, "log-failure", NOW);
+    expect(f.store.stats()).toMatchObject({ activeItems: 0, activeBytes: 0, receipts: 1, logDrops: 4 });
+  });
+});
+
+describe("indexed expiry heap", () => {
+  test("updates, deletes and pops agree with a map oracle without stale nodes", () => {
+    const heap = new RelayExpiryIndex(), oracle = new Map<string, number>();
+    let seed = 123;
+    const random = () => { seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0; return seed; };
+    for (let i = 0; i < 10_000; i++) {
+      const key = String(random() % 64), at = random() % 1000;
+      if (i % 3) { heap.set(key, at); oracle.set(key, at); }
+      else { expect(heap.delete(key)).toBe(oracle.delete(key)); }
+      expect(heap.size).toBe(oracle.size);
+    }
+    while (oracle.size) {
+      const minimum = Math.min(...oracle.values());
+      expect(heap.takeDue(minimum - 1)).toBeUndefined();
+      const key = heap.takeDue(minimum)!;
+      expect(oracle.get(key)).toBe(minimum); oracle.delete(key);
+      expect(heap.size).toBe(oracle.size);
+    }
+    expect(heap.takeDue(Infinity)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Preparatory implementation slice for #351 — **not the production store cutover and not completion of the issue**.

- Add an instance-owned in-memory relay engine with bounded payload/receipt/registration/route state, incremental indexes, explicit epochs, real sparse decimal cursors, atomic pre-admission budgets, ACK payload release and token-owned bounded forwarding. Pending forwarding is not successful acceptance; exhaustion is explicitly unconfirmed.
- Add an indexed expiry heap without accumulating stale renewal nodes.
- Add separate best-effort investigation logging: bounded queue including in-flight writes, private fixed-slot rotation, coalesced idle cleanup, health counters, and symlink/hardlink/nonprivate-file rejection.
- Add 28 focused engine/logger tests and a documented adapter compatibility audit.
- Fix the existing schema-cleanup regression's host dependence: its child now uses private shell/provider fixtures while still exercising real HTTP/schema responses and the provider version probe. Keep the original 3-second child / 4.5-second outer deadlines and strengthen sentinel/provider assertions.

## Scope and remaining work

The existing `TaskRelayGateway`, worker entry, HTTP contract and installed pi-tasks adapter **remain unchanged**. The new engine is not selected by production. There is no `tasks/v1` or endpoint-owned task lifecycle/store redesign, historical-file deletion, deployment or restart.

Follow-up must coordinate the negotiated volatile profile, broker-authorized gateway/worker/schema integration, live-process epoch reset, actual per-delivery cursors, immutable adapter retry timestamps/deadlines, terminal retry handling and exported logging health. The installed pi-tasks 0.1.7 compatibility audit still reproduces timestamp conflicts after lost responses and incompatibility with simulated cursor gaps; this PR does not claim those adapter bugs are fixed.

Encoded byte/count ceilings are not native heap or total-RSS guarantees. Receipt retention limits sustained admission; logging may drop records during overflow/failure. No new production latency/CPU/RSS benchmark or live two-host claim is made. See `docs/memory-owned-relay-design.md` for contracts, tradeoffs and historical evidence.

## Validation

Exact head: `d16048be4cb378e571662dbdcb7a61211fff53e5`.
Latest fetched `main`: `175861b49045e5c5e7859261f081aa8d912d0a4c`, already an ancestor (rechecked before push).

- `bun run typecheck` and `git diff --check origin/main..HEAD`: pass.
- `bun test tests/unit`: **1,698 pass, 1 Linux-only skip, 0 fail**.
- Full integration suite with a non-live broker socket and no selected broker binary: **428 pass, 22 broker-dependent skips, 0 fail**, plus **8 passing nested schema-child tests** (436 aggregate). Includes existing cross-process task-gateway and compiled-worker integration; not new-profile packaging validation.
- Fixed cleanup test repeated five times: **5/5 outer regressions and 40/40 nested schema tests pass**.
- Unsafe-cleanup mutant: all 8 child schema tests complete, then the parent fails because the planted sentinel was deleted. Deadline unchanged; regression is non-vacuous.
- Three earlier engine/logger mutants fail their intended assertions: retained ACKed rows, exhaustion hidden as pending, and stranded logger completion wake.

Earlier failures remain documented/private: the cleanup child timeout reproduced on unchanged merged base; instrumentation showed the stdin gate completed and execution stalled during real provider probing after login-shell startup. Setting inherited PATH alone did not isolate it because server import restores login-shell PATH. No timing tolerance was increased. Initial development typecheck failures and private probe logs are retained.

Independent review of this slice is pending. CI will provide additional platform validation; local native broker cases were skipped, not passed.
